### PR TITLE
Prevent crashes from steering.

### DIFF
--- a/Binding/FlightControlManager.cs
+++ b/Binding/FlightControlManager.cs
@@ -127,28 +127,34 @@ namespace kOS.Binding
 
             public void OnFlyByWire(ref FlightCtrlState c)
             {
-                if (_value != null)
-                {
-                    switch (name)
+                try {
+                    if (_value != null)
                     {
-                        case "throttle":
-                            UpdateThrottle(c);
-                            break;
-                        case "wheelthrottle":
-                            UpdateWheelThrottle(c);
-                            break;
-                        case "steering":
-                            SteerByWire(c);
-                            break;
-                        case "wheelsteering":
-                            WheelSteer(c);
-                            break;
-                        default:
-                            break;
+                        switch (name)
+                        {
+                            case "throttle":
+                                UpdateThrottle(c);
+                                break;
+                            case "wheelthrottle":
+                                UpdateWheelThrottle(c);
+                                break;
+                            case "steering":
+                                SteerByWire(c);
+                                break;
+                            case "wheelsteering":
+                                WheelSteer(c);
+                                break;
+                            default:
+                                break;
+                        }
                     }
                 }
+                catch (Exception e) 
+                {
+                    if (_shared.Logger != null) _shared.Logger.Log(e);
+                }
             }
-
+            
             private void UpdateThrottle(FlightCtrlState c)
             {
                 c.mainThrottle = (float)Convert.ToDouble(_value);


### PR DESCRIPTION
Fixes #23. Will prevent unhandled exceptions from steering from crashing the game.
