### PR TITLE
added list indexing and expressions as a separate branch.

### DIFF
--- a/Compilation/KS/Compiler.cs
+++ b/Compilation/KS/Compiler.cs
@@ -685,6 +685,11 @@ namespace kOS.Compilation.KS
             int nodeIndex = 2;
             while (nodeIndex < node.Nodes.Count)
             {
+            	// Skip two tokens instead of one bewteen dimensions if using the "[]" syntax:
+            	if( node.Nodes[nodeIndex].Token.Type == TokenType.SQUAREOPEN ){
+            		++nodeIndex;
+            	}
+            	
                 VisitNode(node.Nodes[nodeIndex]);
                 
                 // when we are setting a member value we need to leave
@@ -780,7 +785,8 @@ namespace kOS.Compilation.KS
                 ParseNode arrayIdentifier = node.Nodes[0];
                 foreach (ParseNode child in arrayIdentifier.Nodes)
                 {
-                    if (child.Token.Type == TokenType.ARRAYINDEX)
+                    if (child.Token.Type == TokenType.SQUAREOPEN ||
+                	    child.Token.Type == TokenType.ARRAYINDEX )
                     {
                         return true;
                     }

--- a/Compilation/KS/ParseTree.cs
+++ b/Compilation/KS/ParseTree.cs
@@ -316,11 +316,11 @@ namespace kOS.Compilation.KS
                 case TokenType.number:
                     Value = Evalnumber(tree, paramlist);
                     break;
-                case TokenType.varidentifier:
-                    Value = Evalvaridentifier(tree, paramlist);
-                    break;
                 case TokenType.array_identifier:
                     Value = Evalarray_identifier(tree, paramlist);
+                    break;
+                case TokenType.varidentifier:
+                    Value = Evalvaridentifier(tree, paramlist);
                     break;
                 case TokenType.function_identifier:
                     Value = Evalfunction_identifier(tree, paramlist);
@@ -653,14 +653,14 @@ namespace kOS.Compilation.KS
             return null;
         }
 
-        protected virtual object Evalvaridentifier(ParseTree tree, params object[] paramlist)
+        protected virtual object Evalarray_identifier(ParseTree tree, params object[] paramlist)
         {
             foreach (var node in Nodes)
                 node.Eval(tree, paramlist);
             return null;
         }
 
-        protected virtual object Evalarray_identifier(ParseTree tree, params object[] paramlist)
+        protected virtual object Evalvaridentifier(ParseTree tree, params object[] paramlist)
         {
             foreach (var node in Nodes)
                 node.Eval(tree, paramlist);

--- a/Compilation/KS/Parser.cs
+++ b/Compilation/KS/Parser.cs
@@ -2413,6 +2413,88 @@ namespace kOS.Compilation.KS
             parent.Token.UpdateRange(node.Token);
         }
 
+        private void Parsearray_identifier(ParseNode parent)
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.array_identifier), "array_identifier");
+            parent.Nodes.Add(node);
+
+
+            
+            Parsefunction_identifier(node);
+
+            
+            tok = scanner.LookAhead(TokenType.ARRAYINDEX, TokenType.SQUAREOPEN);
+            while (tok.Type == TokenType.ARRAYINDEX
+                || tok.Type == TokenType.SQUAREOPEN)
+            {
+                tok = scanner.LookAhead(TokenType.ARRAYINDEX, TokenType.SQUAREOPEN);
+                switch (tok.Type)
+                {
+                    case TokenType.ARRAYINDEX:
+
+                        
+                        tok = scanner.Scan(TokenType.ARRAYINDEX);
+                        n = node.CreateNode(tok, tok.ToString() );
+                        node.Token.UpdateRange(tok);
+                        node.Nodes.Add(n);
+                        if (tok.Type != TokenType.ARRAYINDEX) {
+                            tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.ARRAYINDEX.ToString(), 0x1001, tok));
+                            return;
+                        }
+
+                        
+                        tok = scanner.LookAhead(TokenType.IDENTIFIER, TokenType.INTEGER, TokenType.DOUBLE);
+                        switch (tok.Type)
+                        {
+                            case TokenType.IDENTIFIER:
+                                Parsefunction_identifier(node);
+                                break;
+                            case TokenType.INTEGER:
+                            case TokenType.DOUBLE:
+                                Parsenumber(node);
+                                break;
+                            default:
+                                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found.", 0x0002, tok));
+                                break;
+                        }
+                        break;
+                    case TokenType.SQUAREOPEN:
+
+                        
+                        tok = scanner.Scan(TokenType.SQUAREOPEN);
+                        n = node.CreateNode(tok, tok.ToString() );
+                        node.Token.UpdateRange(tok);
+                        node.Nodes.Add(n);
+                        if (tok.Type != TokenType.SQUAREOPEN) {
+                            tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.SQUAREOPEN.ToString(), 0x1001, tok));
+                            return;
+                        }
+
+                        
+                        Parseexpr(node);
+
+                        
+                        tok = scanner.Scan(TokenType.SQUARECLOSE);
+                        n = node.CreateNode(tok, tok.ToString() );
+                        node.Token.UpdateRange(tok);
+                        node.Nodes.Add(n);
+                        if (tok.Type != TokenType.SQUARECLOSE) {
+                            tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.SQUARECLOSE.ToString(), 0x1001, tok));
+                            return;
+                        }
+                        break;
+                    default:
+                        tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found.", 0x0002, tok));
+                        break;
+                }
+            tok = scanner.LookAhead(TokenType.ARRAYINDEX, TokenType.SQUAREOPEN);
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        }
+
         private void Parsevaridentifier(ParseNode parent)
         {
             Token tok;
@@ -2449,66 +2531,6 @@ namespace kOS.Compilation.KS
                     return;
                 }
             tok = scanner.LookAhead(TokenType.COLON);
-            }
-
-            parent.Token.UpdateRange(node.Token);
-        }
-
-        private void Parsearray_identifier(ParseNode parent)
-        {
-            Token tok;
-            ParseNode n;
-            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.array_identifier), "array_identifier");
-            parent.Nodes.Add(node);
-
-
-            
-            Parsefunction_identifier(node);
-
-            
-            tok = scanner.LookAhead(TokenType.ARRAYINDEX);
-            while (tok.Type == TokenType.ARRAYINDEX)
-            {
-
-                
-                tok = scanner.Scan(TokenType.ARRAYINDEX);
-                n = node.CreateNode(tok, tok.ToString() );
-                node.Token.UpdateRange(tok);
-                node.Nodes.Add(n);
-                if (tok.Type != TokenType.ARRAYINDEX) {
-                    tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.ARRAYINDEX.ToString(), 0x1001, tok));
-                    return;
-                }
-
-                
-                tok = scanner.LookAhead(TokenType.INTEGER, TokenType.IDENTIFIER);
-                switch (tok.Type)
-                {
-                    case TokenType.INTEGER:
-                        tok = scanner.Scan(TokenType.INTEGER);
-                        n = node.CreateNode(tok, tok.ToString() );
-                        node.Token.UpdateRange(tok);
-                        node.Nodes.Add(n);
-                        if (tok.Type != TokenType.INTEGER) {
-                            tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.INTEGER.ToString(), 0x1001, tok));
-                            return;
-                        }
-                        break;
-                    case TokenType.IDENTIFIER:
-                        tok = scanner.Scan(TokenType.IDENTIFIER);
-                        n = node.CreateNode(tok, tok.ToString() );
-                        node.Token.UpdateRange(tok);
-                        node.Nodes.Add(n);
-                        if (tok.Type != TokenType.IDENTIFIER) {
-                            tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.IDENTIFIER.ToString(), 0x1001, tok));
-                            return;
-                        }
-                        break;
-                    default:
-                        tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found.", 0x0002, tok));
-                        break;
-                }
-            tok = scanner.LookAhead(TokenType.ARRAYINDEX);
             }
 
             parent.Token.UpdateRange(node.Token);

--- a/Compilation/KS/Scanner.cs
+++ b/Compilation/KS/Scanner.cs
@@ -246,6 +246,14 @@ namespace kOS.Compilation.KS
             Patterns.Add(TokenType.CURLYCLOSE, regex);
             Tokens.Add(TokenType.CURLYCLOSE);
 
+            regex = new Regex(@"\[");
+            Patterns.Add(TokenType.SQUAREOPEN, regex);
+            Tokens.Add(TokenType.SQUAREOPEN);
+
+            regex = new Regex(@"\]");
+            Patterns.Add(TokenType.SQUARECLOSE, regex);
+            Tokens.Add(TokenType.SQUARECLOSE);
+
             regex = new Regex(@",");
             Patterns.Add(TokenType.COMMA, regex);
             Tokens.Add(TokenType.COMMA);
@@ -504,8 +512,8 @@ namespace kOS.Compilation.KS
             atom    = 45,
             sci_number= 46,
             number  = 47,
-            varidentifier= 48,
-            array_identifier= 49,
+            array_identifier= 48,
+            varidentifier= 49,
             function_identifier= 50,
 
             //Terminal tokens:
@@ -561,19 +569,21 @@ namespace kOS.Compilation.KS
             BRACKETCLOSE= 100,
             CURLYOPEN= 101,
             CURLYCLOSE= 102,
-            COMMA   = 103,
-            COLON   = 104,
-            IN      = 105,
-            ARRAYINDEX= 106,
-            ALL     = 107,
-            IDENTIFIER= 108,
-            INTEGER = 109,
-            DOUBLE  = 110,
-            STRING  = 111,
-            EOI     = 112,
-            EOF     = 113,
-            WHITESPACE= 114,
-            COMMENTLINE= 115
+            SQUAREOPEN= 103,
+            SQUARECLOSE= 104,
+            COMMA   = 105,
+            COLON   = 106,
+            IN      = 107,
+            ARRAYINDEX= 108,
+            ALL     = 109,
+            IDENTIFIER= 110,
+            INTEGER = 111,
+            DOUBLE  = 112,
+            STRING  = 113,
+            EOI     = 114,
+            EOF     = 115,
+            WHITESPACE= 116,
+            COMMENTLINE= 117
     }
 
     public class Token

--- a/Compilation/KS/kRISC.tpg
+++ b/Compilation/KS/kRISC.tpg
@@ -58,6 +58,8 @@ BRACKETOPEN -> @"\(";
 BRACKETCLOSE -> @"\)";
 CURLYOPEN -> @"\{";
 CURLYCLOSE -> @"\}";
+SQUAREOPEN -> @"\[";
+SQUARECLOSE -> @"\]";
 COMMA -> @",";
 COLON -> @":";
 IN -> @"in";
@@ -134,6 +136,6 @@ atom -> PLUSMINUS? ( sci_number |
         STRING;
 sci_number -> number (E PLUSMINUS? INTEGER)?;
 number -> (INTEGER | DOUBLE);
+array_identifier -> function_identifier ( (ARRAYINDEX (function_identifier|number)) | (SQUAREOPEN expr SQUARECLOSE) )*;
 varidentifier -> array_identifier (COLON IDENTIFIER)*;
-array_identifier -> function_identifier (ARRAYINDEX (INTEGER | IDENTIFIER))*;
 function_identifier -> IDENTIFIER (BRACKETOPEN arglist? BRACKETCLOSE)?;

--- a/Compilation/Opcode.cs
+++ b/Compilation/Opcode.cs
@@ -172,6 +172,10 @@ namespace kOS.Compilation
         public override void Execute(CPU cpu)
         {
             object index = cpu.PopValue();
+            if( index is double || index is float )
+            {
+            	index = Convert.ToInt32(index);  // allow expressions like (1.0) to be indeces
+            }
             object list = cpu.PopValue();
 
             if (!(list is IIndexable)) throw new Exception(string.Format("Can't iterate on an object of type {0}", list.GetType()));
@@ -191,7 +195,10 @@ namespace kOS.Compilation
             object value = cpu.PopValue();
             object index = cpu.PopValue();
             object list = cpu.PopValue();
-
+            if( index is double || index is float )
+            {
+            	index = Convert.ToInt32(index);  // allow expressions like (1.0) to be indeces
+            }
             if (!(list is IIndexable)) throw new Exception(string.Format("Can't iterate on an object of type {0}", list.GetType()));
             if (!(index is int)) throw new Exception("The index must be an integer number");
 

--- a/kOS.csproj
+++ b/kOS.csproj
@@ -148,7 +148,9 @@
     <Compile Include="Persistence\Volume.cs" />
     <Compile Include="Persistence\VolumeManager.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="Compilation\KS\kRISC.tpg" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>


### PR DESCRIPTION
Contains the list indexing as a separate pull request without the not/negate/until change.

Old syntax, and the syntax used in commit #22 is supported backward compatibly:  You can do this:
- ARR#0
- ARR#1
- ARR#2

and this:
- ARR#i
- ARR#i#j

But new syntax with square brackets allows any arbitrary complex expression as the index, not just numbers or variables:
- ARR[0]
- ARR[i]
- ARR[ i ] [j]
- ARR [ mod(X,10) ] [ y - 3 ]

It was not possible to support any arbitrary complex expression as the index without changing the syntax to one in which an open/close pairing (like [..]) was used to demark the index, for reasons explained elsewhere in comments to #38.
