### PR TITLE
Vector division fix

### DIFF
--- a/Suffixed/Vector.cs
+++ b/Suffixed/Vector.cs
@@ -63,6 +63,7 @@ namespace kOS.Suffixed
                         if (other is Vector) return (Vector) other - this;
                     }
                     break;
+                    
                 default:
                     throw new NotImplementedException(string.Format(
                         "Cannot perform operation: {0} {1} {2}", ToString(), op, other.ToString() ) );


### PR DESCRIPTION
This should address issue #65 and #76 related to vector division problems.
New behavior:
(vector/scalar) works.. Now turns into vector \* (1/scalar) behind the scenes.
(scalar/vector) issues exception and error message: cannot divide by vector
(vector/vector) issues exception and error message: cannot divide by vector
