### PR TITLE
Resolves #66 and improves terminal scrolling buffer issues.

### DIFF
--- a/Screen/ScreenBuffer.cs
+++ b/Screen/ScreenBuffer.cs
@@ -41,24 +41,22 @@ namespace kOS.Screen
 
         private void InitializeBuffer()
         {
-            for (int row = 0; row < RowCount; row++)
-            {
-                AddNewBufferLine();
-            }
+            AddNewBufferLines(RowCount);
 
             _topRow = 0;
             CursorRow = 0;
             CursorColumn = 0;
         }
 
-        private void AddNewBufferLine()
+        protected void AddNewBufferLines( int howMany = 1)
         {
-            _buffer.Add(new char[ColumnCount]);
+            while (howMany-- > 0)
+                _buffer.Add(new char[ColumnCount]);
         }
 
         public void SetSize(int rowCount, int columnCount)
         {
-            if (rowCount <= 36 && columnCount <= 50)
+            if (rowCount <= MAX_ROWS && columnCount <= MAX_COLUMNS)
             {
                 RowCount = rowCount;
                 ColumnCount = columnCount;
@@ -69,7 +67,7 @@ namespace kOS.Screen
 
         private int ScrollVerticalInternal(int deltaRows)
         {
-            int maxTopRow = _buffer.Count - RowCount;
+            int maxTopRow = _buffer.Count - 1;
 
             // boundary checks
             if (_topRow + deltaRows < 0) deltaRows = -_topRow;
@@ -106,7 +104,7 @@ namespace kOS.Screen
             if ((CursorRow + 1) >= RowCount)
             {
                 // scrolling up
-                AddNewBufferLine();
+                AddNewBufferLines(1);
                 ScrollVerticalInternal(1);
             }
             else
@@ -207,9 +205,17 @@ namespace kOS.Screen
         }
 
         public List<char[]> GetBuffer()
-        { 
+        {
+            
             // base buffer
             List<char[]> mergedBuffer = new List<char[]>(_buffer.GetRange(_topRow, RowCount));
+
+            // The screen may be scrolled such that the bottom of the text content doesn't
+            // go all the way to the bottom of the screen.  If so, pad it for display:
+            while (mergedBuffer.Count < RowCount)
+            {
+                mergedBuffer.Add(new char[ColumnCount]);
+            }
 
             // merge sub buffers
             UpdateSubBuffers();

--- a/Screen/TextEditor.cs
+++ b/Screen/TextEditor.cs
@@ -156,12 +156,34 @@ namespace kOS.Screen
 
             while (lineCursorIndex > lines[lineIndex].Length)
             {
-                lineCursorIndex -= (lines[lineIndex].Length + 1);
+                //lineCursorIndex -= (lines[lineIndex].Length + 1);
+                lineCursorIndex -= lines[lineIndex].Length;
                 lineIndex++;
             }
 
             _cursorRowBuffer = lineIndex;
             _cursorColumnBuffer = lineCursorIndex;
+
+            KeepCursorInBounds();
+        }
+        
+        protected void KeepCursorInBounds()
+        {
+            // Check to see if wrapping or scrolling needs to be done
+            // because the cursor went off the screen, and if so, do it:
+            if (CursorColumnShow >= MAX_COLUMNS)
+            {
+                int tooBigColumn = CursorColumnShow;
+                _cursorColumnBuffer = (tooBigColumn % MAX_COLUMNS);
+                _cursorRowBuffer += (tooBigColumn / MAX_COLUMNS); // truncating integer division.
+            }
+            if (CursorRowShow >= MAX_ROWS)
+            {
+                int rowsToScroll = (CursorRowShow-MAX_ROWS) + 1;
+                CursorRow -= rowsToScroll;
+                ScrollVertical(rowsToScroll);
+                AddNewBufferLines(rowsToScroll);
+            }
         }
 
         protected virtual void NewLine()


### PR DESCRIPTION
1. Allowed the logic to allow having lines in the TextEditor subbuffer
   causing the scrolling of the underlying ScreenBuffer when the text
   overuns the bottom of the screen.
2. Now puts the cursor in the right place and aligns the screen
   correctly when using up-arrow to obtain a previously entered long
   line that wrapped past the edge of the screen.
3. Fixed the off-by-one error where typing a line that wrapped around
   past the right edge of the screen used to put the cursor in the
   wrong place.  The more times the line wrapped the more off the cursor
   became.
