### PR TITLE
Adds the ability to query or set whether the game is in Map View.

### DIFF
--- a/Binding/BindingsUniverse.cs
+++ b/Binding/BindingsUniverse.cs
@@ -30,7 +30,18 @@ namespace kOS.Binding
                         TimeWarp.SetRate(newRate, false);
                     }
                 });
-
+            _shared.BindingMgr.AddGetter("MAPVIEW", delegate(CPU cpu) { return MapView.MapIsEnabled; } );
+            _shared.BindingMgr.AddSetter("MAPVIEW", delegate(CPU cpu, object val)
+                {
+                    if( Convert.ToBoolean( val ) )
+                    {
+                        MapView.EnterMapView();
+                    }
+                    else
+                    {
+                        MapView.ExitMapView();
+                    }
+                });
             foreach (var body in FlightGlobals.fetch.bodies)
             {
                 var cBody = body;


### PR DESCRIPTION
Rationale: Though not necessary, it's analogous to allowing the script to set the WARP mode.

Syntax:

```
  // Querying:
  if MAPVIEW { print "I am on map view". } else { print "I am in flight view". }.

  // Setting:
  set MAPVIEW to true.
  print "Now looking at the map".
  wait 5.
  set MAPVIEW to false.
  print "Now looking at flight view".
```
