### PR TITLE
Allow empty curly brace blocks. Resolves #138

### DIFF
--- a/src/Compilation/KS/kRISC.tpg
+++ b/src/Compilation/KS/kRISC.tpg
@@ -82,7 +82,7 @@ COMMENTLINE -> @"//[^\n]*\n?";
 // Rules
 // ===================================================
 Start -> (instruction)* EOF;
-instruction_block -> instruction | CURLYOPEN instruction+ CURLYCLOSE EOI?;
+instruction_block -> instruction | CURLYOPEN instruction* CURLYCLOSE EOI?;
 instruction -> set_stmt | if_stmt | until_stmt | lock_stmt | unlock_stmt | print_stmt |
                on_stmt | toggle_stmt | wait_stmt | when_stmt | onoff_stmt | stage_stmt |
                clear_stmt | add_stmt | remove_stmt | log_stmt | break_stmt | preserve_stmt | declare_stmt |


### PR DESCRIPTION
For issue #138:

This is literally the easiest change I've ever made to kOS.  It's exactly 1 character of source code changed.  I expected some problems when I tested it - perhaps having branch opcodes trying to jump to nonexistant instructions - but when I tested it seemed to work everywhere from just this one change - if's, else's, until's, when's, on's.  nested complex cases, long if-else ladders with null blocks in the middle, etc.  It seems to work just fine with only changing the syntax config.

(To pull this pull request, don't forget to re-run tinyPG, as I've left the files it autogenerates out of the commit.).
