### PR TITLE
Resolves #154 - Now :VECTOR suffix will work on all types of Direction.

### DIFF
--- a/src/Suffixed/Direction.cs
+++ b/src/Suffixed/Direction.cs
@@ -38,7 +38,7 @@ namespace kOS.Suffixed
             get { return vector; }
             set
             {
-                vector = value;
+                vector = value.normalized;
                 rotation = Quaternion.LookRotation(value);
                 euler = rotation.eulerAngles;
             }


### PR DESCRIPTION
The Direction class maintained all of the following members:
euler
rotation
vector

When constructing a Direction from a vector, it would calculate the euler and rotation from the vector, but it didn't reciprocate and do the reverse when constructing a Direction from a Euler or a Rotation.  Now it does, and this means expressions like SHIP:FACING:VECTOR will now work correctly.
