### PR TITLE
Added function anglediff( a1, a2 ).

### DIFF
--- a/src/Function/Trigonometry.cs
+++ b/src/Function/Trigonometry.cs
@@ -82,4 +82,16 @@ namespace kOS.Function
             shared.Cpu.PushStack(result);
         }
     }
+
+    [FunctionAttribute("anglediff")]
+    public class FunctionAngleDiff : FunctionBase
+    {
+        public override void Execute(SharedObjects shared)
+        {
+            double ang2 = GetDouble(shared.Cpu.PopValue());
+            double ang1 = GetDouble(shared.Cpu.PopValue());
+            double result = kOS.Utilities.Utils.DegreeFix( ang2 - ang1, -180 );
+            shared.Cpu.PushStack(result);
+        }
+    }
 }


### PR DESCRIPTION
returns the difference in angle between a1 and a2, quashed into the
range [-180,180).  With positve numbers meaning a2 is a bigger angle than a1.

example: anglediff( 5, 355 ) returns -10.  anglediff(355,5) returns +10.

Also squashes the result into meaningful ranges.  i.e. anglediff(365,355) handles the fact that 365 is > 360 just fine.

Important because users can't write functions yet, and KSP tends to return things like
longitude or Rotational components in stupid ways like "540 degrees".

TODO: wheelsteering should call the same thing this code does to fix the 'can't steer north' bug, but that isn't part of this commit.
