### PR TITLE
Resolves #168 : Direction*Vector now returns the rotated Vector,and vec...

### DIFF
--- a/src/Suffixed/Direction.cs
+++ b/src/Suffixed/Direction.cs
@@ -102,7 +102,8 @@ namespace kOS.Suffixed
         {
             if (other is Vector)
             {
-                other = ((Vector) other).ToDirection();
+                Vector3d vec = ((Vector)other).ToVector3D();
+                return new Vector(Rotation*vec);
             }
 
             if (op == "*" && other is Direction)

--- a/src/Suffixed/Vector.cs
+++ b/src/Suffixed/Vector.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace kOS.Suffixed
 {
@@ -105,6 +106,8 @@ namespace kOS.Suffixed
                     return Normalized();
                 case "SQRMAGNITUDE":
                     return new Vector3d(X, Y, Z).sqrMagnitude;
+                case "DIRECTION":
+                    return ToDirection();
             }
 
             return base.GetSuffix(suffixName);
@@ -113,20 +116,52 @@ namespace kOS.Suffixed
         public override bool SetSuffix(string suffixName, object value)
         {
             double dblValue;
+            Direction dirValue = null;
+            bool isDouble = false;
+            bool isDirection = false;
+
             if (value is double)
             {
                 dblValue = (double)value;
+                isDouble = true;
             }
-            else if (!double.TryParse(value.ToString(), out dblValue))
+            else if (double.TryParse(value.ToString(), out dblValue))
             {
-                return false;
+                isDouble = true;                
+            }
+            else if (value is Direction)
+            {
+                dirValue = (Direction)value;
+                isDirection = true;
+            }
+
+            // Type check (this is the sort of thing that it would be good
+            // to do automatically with a standard suffix handling system):
+            bool typeMismatch = false;
+            switch (suffixName)
+            {
+                case "X":
+                case "Y":
+                case "Z":
+                case "MAG":
+                    if (!isDouble)
+                        typeMismatch = true;
+                    break;
+                case "DIRECTION":
+                    if (!isDirection)
+                        typeMismatch = true;
+                    break;
+            }
+            if (typeMismatch)
+            {
+                throw new InvalidCastException("Can't set a vector's :" + suffixName + " to a " + value.GetType().Name);
             }
 
             switch (suffixName)
             {
                 case "X":
                     X = dblValue;
-                    return true;
+                    return true;                        
                 case "Y":
                     Y = dblValue;
                     return true;
@@ -141,7 +176,12 @@ namespace kOS.Suffixed
                     X = X/oldMag*dblValue;
                     Y = Y/oldMag*dblValue;
                     Z = Z/oldMag*dblValue;
-
+                    return true;
+                case "DIRECTION":
+                    Vector3d newVal = dirValue.Rotation * Vector3d.forward;
+                    X = newVal.x;
+                    Y = newVal.y;
+                    Z = newVal.z;
                     return true;
             }
 


### PR DESCRIPTION
...tors can be rotated with DIRECTION suffix.

For Example:

```
// Gets the world coords vector corresponding to
// the geo-coords vector: north=20,west=10,up=50
SET MyVec to V(20,10,50).
SET MyRotatedVec TO UP * MyVec.

// The new Vector :DIRECTION suffix would allow you to get the old "*" result if you want it:
SET oldStyleMultResult TO MyRotatedVec:DIRECTION.

// Gets the world coords vector corresponding to a position in
// space that is 30 meters in front of the target ship's CoM in
// the direction the target ship is pointing:
SET PosAheadOfTarget TO TARGET:POSITION + ( TARGET:FACING * V(0,0,30) ).

// You can now get the Direction of a Vector with the :DIRECTION suffix,
// as the analogous inverse to Direction's :VECTOR suffix:
SET surfDir to SHIP:VELOCITY:SURFACE:DIRECTION. // an alternate way to get surface prograde dir.

// The Vector's new :DIRECTION suffix is also settable.
// Much like setting a vector's :MAG will keep its orientation but give a new length,
// setting a the Vector's :DIRECTION will keep its length but give it a new orientation.
SET MyVec to V(3,4,0).  // vector's magnitude is sqrt(3^2 + 4^2) = 5
SET MyVec:DIRECTION TO UP. // magnitude is still 5 but now points at navball UP.
```
