### PR TITLE
Added binding for ACTIVEVESSEL Resolves #187

### DIFF
--- a/src/Binding/FlightStats.cs
+++ b/src/Binding/FlightStats.cs
@@ -28,6 +28,7 @@ namespace kOS.Binding
             Shared.BindingMgr.AddGetter("OBT", cpu => new OrbitInfo(Shared.Vessel.orbit,Shared));
             Shared.BindingMgr.AddGetter("TIME", cpu => new TimeSpan(Planetarium.GetUniversalTime()));
             Shared.BindingMgr.AddGetter("SHIP", cpu => new VesselTarget(Shared));
+            Shared.BindingMgr.AddGetter("ACTIVEVESSEL", cpu => new VesselTarget(FlightGlobals.ActiveVessel, Shared));
             Shared.BindingMgr.AddGetter("STATUS", cpu => Shared.Vessel.situation.ToString());
             Shared.BindingMgr.AddGetter("STAGE", cpu => new StageValues(Shared.Vessel));
             Shared.BindingMgr.AddSetter("VESSELNAME", delegate(CPU cpu, object value) { Shared.Vessel.vesselName = value.ToString(); });


### PR DESCRIPTION
ACTIVEVESSEL is like SHIP, but always refers to the active vessel even when the current CPU Vessel is not the active vessel.
