### PR TITLE
Resolves #104 - upper limit on trigger duration.

### DIFF
--- a/src/Execution/CPU.cs
+++ b/src/Execution/CPU.cs
@@ -28,12 +28,16 @@ namespace kOS.Execution
         private readonly List<ProgramContext> contexts;
         private ProgramContext currentContext;
         private Dictionary<string, Variable> savedPointers;
+        private int instructionsSoFarInUpdate;
+        private int instructionsPerUpdate;
         
         // statistics
         public double TotalCompileTime = 0D;
         private double totalUpdateTime;
         private double totalTriggersTime;
         private double totalExecutionTime;
+        private int mostMainlineInstSoFar = 0;
+        private int mostTriggerInstSoFar = 0;
 
         public int InstructionPointer
         {
@@ -443,6 +447,12 @@ namespace kOS.Execution
             Stopwatch updateWatch = null;
             Stopwatch triggerWatch = null;
             Stopwatch executionWatch = null;
+            
+            // If the script changes config value, it doesn't take effect until next update:
+            instructionsPerUpdate = Config.Instance.InstructionsPerUpdate;
+            instructionsSoFarInUpdate = 0;
+            int numTriggerInstructions = 0;
+            int numMainlineInstructions = 0;
 
             if (showStatistics) updateWatch = Stopwatch.StartNew();
 
@@ -456,6 +466,7 @@ namespace kOS.Execution
                 {
                     if (showStatistics) triggerWatch = Stopwatch.StartNew();
                     ProcessTriggers();
+                    numTriggerInstructions = instructionsSoFarInUpdate;
                     if (showStatistics)
                     {
                         triggerWatch.Stop();
@@ -468,6 +479,7 @@ namespace kOS.Execution
                     {
                         if (showStatistics) executionWatch = Stopwatch.StartNew();
                         ContinueExecution();
+                        numMainlineInstructions = instructionsSoFarInUpdate - numTriggerInstructions;
                         if (showStatistics)
                         {
                             executionWatch.Stop();
@@ -502,6 +514,10 @@ namespace kOS.Execution
             {
                 updateWatch.Stop();
                 totalUpdateTime += updateWatch.ElapsedMilliseconds;
+                if (mostTriggerInstSoFar < numTriggerInstructions)
+                    mostTriggerInstSoFar = numTriggerInstructions;
+                if (mostMainlineInstSoFar < numMainlineInstructions)
+                    mostMainlineInstSoFar = numMainlineInstructions;
             }
         }
 
@@ -546,15 +562,32 @@ namespace kOS.Execution
                         currentContext.InstructionPointer = triggerPointer;
 
                         bool executeNext = true;
-                        while (executeNext)
+                        while (executeNext && instructionsSoFarInUpdate < instructionsPerUpdate)
                         {
                             executeNext = ExecuteInstruction(currentContext);
+                            instructionsSoFarInUpdate++;
                         }
                     }
                     catch (Exception e)
                     {
                         RemoveTrigger(triggerPointer);
                         shared.Logger.Log(e);
+                    }
+                    if (instructionsSoFarInUpdate >= instructionsPerUpdate)
+                    {
+                        // This is a verbose error message, but it's important, as without knowing
+                        // the internals, a user has no idea why it's happening.  The verbose
+                        // error message helps direct the user to areas of the documentation
+                        // where longer explanations can be found.
+                        throw new Exception("__________________________________________________\n" +
+                                            "Triggers (*) exceeded max Instructions-Per-Update.\n" +
+                                            "TO FIX THIS PROBLEM, TRY ONE OR MORE OF THESE:\n" +
+                                            " - Redesign your triggers to use less code.\n" +
+                                            " - Make CONFIG:IPU value bigger.\n" +
+                                            " - If your trigger body was meant to be a loop, \n" +
+                                            "     consider using the PRESERVE keyword instead\n" +
+                                            "     to make it run one iteration per Update.\n" +
+                                            "* (\"Trigger\" means a WHEN or ON or LOCK command.)\n");
                     }
                 }
 
@@ -564,17 +597,15 @@ namespace kOS.Execution
 
         private void ContinueExecution()
         {
-            int instructionCounter = 0;
             bool executeNext = true;
-            int instructionsPerUpdate = Config.Instance.InstructionsPerUpdate;
             
             while (currentStatus == Status.Running && 
-                   instructionCounter < instructionsPerUpdate &&
+                   instructionsSoFarInUpdate < instructionsPerUpdate &&
                    executeNext &&
                    currentContext != null)
             {
                 executeNext = ExecuteInstruction(currentContext);
-                instructionCounter++;
+                instructionsSoFarInUpdate++;
             }
         }
 
@@ -644,12 +675,16 @@ namespace kOS.Execution
             shared.Screen.Print(string.Format("Total update time: {0:F3}ms", totalUpdateTime));
             shared.Screen.Print(string.Format("Total triggers time: {0:F3}ms", totalTriggersTime));
             shared.Screen.Print(string.Format("Total execution time: {0:F3}ms", totalExecutionTime));
+            shared.Screen.Print(string.Format("Most Trigger instructions in one update: {0}", mostTriggerInstSoFar));
+            shared.Screen.Print(string.Format("Most Mainline instructions in one update: {0}", mostMainlineInstSoFar));
             shared.Screen.Print(" ");
 
             TotalCompileTime = 0D;
             totalUpdateTime = 0D;
             totalTriggersTime = 0D;
             totalExecutionTime = 0D;
+            mostMainlineInstSoFar = 0;
+            mostTriggerInstSoFar = 0;
         }
 
         public void OnSave(ConfigNode node)

--- a/src/Suffixed/Config.cs
+++ b/src/Suffixed/Config.cs
@@ -30,7 +30,7 @@ namespace kOS.Suffixed
 
         private void BuildValuesDictionary()
         {
-            AddConfigKey(PropId.InstructionsPerUpdate, new ConfigKey("InstructionsPerUpdate", "IPU", "Instructions per update", 100, typeof(int)));
+            AddConfigKey(PropId.InstructionsPerUpdate, new ConfigKey("InstructionsPerUpdate", "IPU", "Instructions per update", 150, typeof(int)));
             AddConfigKey(PropId.UseCompressedPersistence, new ConfigKey("UseCompressedPersistence", "UCP", "Use compressed persistence", false, typeof(bool)));
             AddConfigKey(PropId.ShowStatistics, new ConfigKey("ShowStatistics", "STAT", "Show execution statistics", false, typeof(bool)));
             AddConfigKey(PropId.EnableRT2Integration, new ConfigKey("EnableRT2Integration", "RT2", "Enable RT2 integration", false, typeof(bool)));


### PR DESCRIPTION
The change simply involved taking the logic that had existed only in continueExecution() (which handles the mainline code update) and moving it a bit farther out so it's wrapped around the whole update, including both the trigger and mainline code executions.

I also changed the default CONFIG:IPU from 100 to 150, since it's now counting things it had been ignoring before.  **HOWEVER THIS CHANGE WILL BE IGNORED** for most users who've used kOS before, because kOS writes out a config file to the mod folder with current settings, and whatever is in the config file will override the defaults in this code. - so the 100 that's in people's configs will still be the setting.  **This needs to be mentioned in the release notes!** - _When people use this new version, they need to change their CONFIG:IPU setting manually once the first time after they install the version, or else they'll suddenly notice their programs are much slower than they used to be (if they use a lot of triggers, that is)._

I also added stats on max number of instructions that happened in a single update to the CONFIG:STAT printout - to help warn if the code is getting close to a problem point.
