### PR TITLE
Resolves #219.  Changed the way it counts "am I at the end" to handle

### DIFF
--- a/src/Compilation/KS/Compiler.cs
+++ b/src/Compilation/KS/Compiler.cs
@@ -858,11 +858,23 @@ namespace kOS.Compilation.KS
                 
                 VisitNode(node.Nodes[nodeIndex]);
                 
+                // Two ways to check if this is the last index (i.e. the 'k' in arr[i][j][k]'),
+                // depeding on whehter using the "#" syntax or the "[..]" syntax:
+                bool isLastIndex = false;
+                if (node.Nodes[nodeIndex-1].Token.Type == TokenType.ARRAYINDEX)
+                {
+                    isLastIndex = (nodeIndex == node.Nodes.Count-1);
+                }
+                else if (node.Nodes[nodeIndex-1].Token.Type == TokenType.SQUAREOPEN)
+                {
+                    isLastIndex = (nodeIndex == node.Nodes.Count-2);
+                }
+
                 // when we are setting a member value we need to leave
                 // the last object and the last index in the stack
                 // the only exception is when we are setting a suffix of the indexed value
                 if (!(_compilingSetDestination &&
-                      nodeIndex == (node.Nodes.Count - 1)) ||
+                      isLastIndex) ||
                     VarIdentifierHasSuffix(node.Parent))
                 {
                     AddOpcode(new OpcodeGetIndex());


### PR DESCRIPTION
the square-bracket list index style (where there's a "]" token node after
the last index, unlike with the "#" syntax where the index is the last
node there is.).
