### PR TITLE
Bigger code fragment dump on runtime errors.

### DIFF
--- a/src/KSPLogger.cs
+++ b/src/KSPLogger.cs
@@ -22,7 +22,7 @@ namespace kOS
             // print the call stack
             UnityEngine.Debug.Log(e);
             // print a fragment of the code where the exception ocurred
-            List<string> codeFragment = Shared.Cpu.GetCodeFragment(4);
+            List<string> codeFragment = Shared.Cpu.GetCodeFragment(16);
             var messageBuilder = new StringBuilder();
             messageBuilder.AppendLine("Code Fragment");
             foreach (string instruction in codeFragment)


### PR DESCRIPTION
I was noticing that each and every time I was trying to use the
code fragment dump that comes from runtime errors, it was never
long enough to tell me anything and I always had to increase this number.
Then I'd set it back to 4 again before checking in because it was never
part of the actual change the pull request was for.

Finally I got tired of this and made it a seperate pull request to dump
more of the program opcodes around the error.  Clearly in practice, 4 was
never enough to diagnose anything.
