### PR TITLE
Addresses: #239 Ship with kOS part won't load with Quickload.

### DIFF
--- a/src/Execution/CPU.cs
+++ b/src/Execution/CPU.cs
@@ -755,9 +755,16 @@ namespace kOS.Execution
                     // (Possibly all of OnLoad needs work because it never seemed to bring
                     // back the context fully right anyway, which is why this hasn't been
                     // addressed yet).
-                    programBuilder.AddRange(shared.ScriptHandler.Compile("reloaded file", 1, scriptBuilder.ToString()));
-                    List<Opcode> program = programBuilder.BuildProgram();
-                    RunProgram(program, true);
+                    try
+                    {
+                        programBuilder.AddRange(shared.ScriptHandler.Compile("reloaded file", 1, scriptBuilder.ToString()));
+                        List<Opcode> program = programBuilder.BuildProgram();
+                        RunProgram(program, true);
+                    }
+                    catch
+                    {
+                        UnityEngine.Debug.LogError("kOS: program builder failed on load.");
+                    }
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
Using Quickload will cause a "Object referenced is not an instance of an
object" error which will cause the ship to not load completely.  Adding
this try..catch loop into the OnLoad event in CPU.cs will catch an
unhandled exception from Compile which happens when Quickload is used.
