### PR TITLE
Fixes #239: Ship with kOS part won't load with Quickload (better).

### DIFF
--- a/src/kOS.Safe/Execution/Variable.cs
+++ b/src/kOS.Safe/Execution/Variable.cs
@@ -43,12 +43,6 @@ namespace kOS.Safe.Execution
             return Name;
         }
 
-        public System.Type GetType()
-        {
-            return _value.GetType();
-        }
-
-
         ~Variable()
         {
             // There is no guarantee of timeliness for calling a finalizer,

--- a/src/kOS/Execution/CPU.cs
+++ b/src/kOS/Execution/CPU.cs
@@ -133,8 +133,8 @@ namespace kOS.Execution
 
                 var programContext = shared.Cpu.GetProgramContext();
                 programContext.Silent = true;
-                var options = new CompilerOptions {LoadProgramsInSameAddressSpace = true};
-                string filePath = shared.VolumeMgr.GetVolumeRawIdentifier(shared.VolumeMgr.CurrentVolume) + "/" + "boot" ;
+                var options = new CompilerOptions { LoadProgramsInSameAddressSpace = true };
+                string filePath = shared.VolumeMgr.GetVolumeRawIdentifier(shared.VolumeMgr.CurrentVolume) + "/" + "boot";
                 List<CodePart> parts = shared.ScriptHandler.Compile(filePath, 1, "run boot.", "program", options);
                 programContext.AddParts(parts);
             }
@@ -277,7 +277,7 @@ namespace kOS.Execution
         {
             if (!program.Any()) return;
 
-            var newContext = new ProgramContext(false, program) {Silent = silent};
+            var newContext = new ProgramContext(false, program) { Silent = silent };
             PushContext(newContext);
         }
 
@@ -746,7 +746,7 @@ namespace kOS.Execution
                         if (!(kvp.Value is Binding.BoundVariable) &&
                             (kvp.Value.Name.IndexOfAny(new[] { '*', '-' }) == -1))  // variables that have this characters are internal and shouldn't be persisted
                         {
-                            if (kvp.Value.GetType().ToString() == "System.String")  // if the variable is a string, enclose the value in ""
+                            if (kvp.Value.Value.GetType().ToString() == "System.String")  // if the variable is a string, enclose the value in ""
                             {
                                 varNode.AddValue(kvp.Key.TrimStart('$'), (char)34 + Persistence.ProgramFile.EncodeLine(kvp.Value.Value.ToString()) + (char)34);
                             }


### PR DESCRIPTION
The problem turns out to be with how the Context Node is written into
the save files: string values are written without enclosing
double-quotes.  This causes the parse error, which throws an exception,
etc.

So, in Variable.cs I added this function to get the type of information
stored in the variable:

```
public Type GetType()
{
return _value.GetType();
}
```

Then in CPU.cs, in the OnSave, I added a check for if the type is
"System.String", and have it write the double quotes:

```
if (kvp.Value.GetType().ToString() == "System.String")  // if the
variable is a string, enclose the value in ""
{
varNode.AddValue(kvp.Key.TrimStart('$'), (char)34 +
Persistence.ProgramFile.EncodeLine(kvp.Value.Value.ToString()) +
(char)34);
}
else
{
varNode.AddValue(kvp.Key.TrimStart('$'),
Persistence.ProgramFile.EncodeLine(kvp.Value.Value.ToString()));
}
```

I also added logging in the OnLoad where it tries to run the Context
information so that it will log the whole text that's going to be run.
This would be helpful in figuring out just what has gone wrong here in
the future if something else like this comes up.
