### PR TITLE
Resolves #231 by always using center of mass as the meaning of vessel position.

### DIFF
--- a/src/kOS/Function/PrintList.cs
+++ b/src/kOS/Function/PrintList.cs
@@ -115,7 +115,7 @@ namespace kOS.Function
             
             foreach (var body in FlightGlobals.fetch.bodies)
             {
-                list.AddItem(body.bodyName, Vector3d.Distance(body.position, shared.Vessel.GetWorldPos3D()));
+                list.AddItem(body.bodyName, Vector3d.Distance(body.position, shared.Vessel.findWorldCenterOfMass()));
             }
 
             return list;

--- a/src/kOS/Suffixed/BodyTarget.cs
+++ b/src/kOS/Suffixed/BodyTarget.cs
@@ -17,7 +17,7 @@ namespace kOS.Suffixed
 
         override public Vector GetPosition()
         {
-            return new Vector( Body.position - Shared.Vessel.GetWorldPos3D() );
+            return new Vector( Body.position - Shared.Vessel.findWorldCenterOfMass() );
         }
         
         override public OrbitableVelocity GetVelocities()
@@ -27,7 +27,7 @@ namespace kOS.Suffixed
         
         override public Vector GetPositionAtUT( TimeSpan timeStamp )
         {
-            return new Vector( Body.getPositionAtUT( timeStamp.ToUnixStyleTime() ) - Shared.Vessel.GetWorldPos3D() );
+            return new Vector( Body.getPositionAtUT( timeStamp.ToUnixStyleTime() ) - Shared.Vessel.findWorldCenterOfMass() );
         }
 
         override public OrbitableVelocity GetVelocitiesAtUT( TimeSpan timeStamp )
@@ -73,7 +73,7 @@ namespace kOS.Suffixed
         
         public double GetDistance()
         {
-            return Vector3d.Distance(Shared.Vessel.GetWorldPos3D(), Body.position) - Body.Radius;
+            return Vector3d.Distance(Shared.Vessel.findWorldCenterOfMass(), Body.position) - Body.Radius;
         }
 
         public override object GetSuffix(string suffixName)

--- a/src/kOS/Suffixed/GeoCoordinates.cs
+++ b/src/kOS/Suffixed/GeoCoordinates.cs
@@ -139,7 +139,7 @@ namespace kOS.Suffixed
 
             var targetWorldCoords = Body.GetWorldSurfacePosition(Lat, Lng, GetTerrainAltitude() );
 
-            var vector = Vector3d.Exclude(up, targetWorldCoords - Shared.Vessel.GetWorldPos3D()).normalized;
+            var vector = Vector3d.Exclude(up, targetWorldCoords - Shared.Vessel.findWorldCenterOfMass()).normalized;
             var headingQ =
                 Quaternion.Inverse(Quaternion.Euler(90, 0, 0)*Quaternion.Inverse(Quaternion.LookRotation(vector, up))*
                                    Quaternion.LookRotation(north, up));
@@ -155,7 +155,7 @@ namespace kOS.Suffixed
         private double DistanceFrom()
         {
             Vector3d latLongCoords = Body.GetWorldSurfacePosition( Lat, Lng, GetTerrainAltitude() );
-            Vector3d hereCoords = Shared.Vessel.GetWorldPos3D();
+            Vector3d hereCoords = Shared.Vessel.findWorldCenterOfMass();
             return Vector3d.Distance( latLongCoords, hereCoords );
         }
 

--- a/src/kOS/Suffixed/OrbitInfo.cs
+++ b/src/kOS/Suffixed/OrbitInfo.cs
@@ -32,7 +32,7 @@ namespace kOS.Suffixed
         /// <returns></returns>
         public Vector GetPositionAtUT( TimeSpan timeStamp )
         {
-            return new Vector( orbit.getPositionAtUT( timeStamp.ToUnixStyleTime() ) - shared.Vessel.GetWorldPos3D() );
+            return new Vector( orbit.getPositionAtUT( timeStamp.ToUnixStyleTime() ) - shared.Vessel.findWorldCenterOfMass() );
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace kOS.Suffixed
             if (parent != null)
             {
                 Vector3d pos = GetPositionAtUT( timeStamp ).ToVector3D();
-                surfVel = new Vector( orbVel - parent.getRFrmVel( pos + shared.Vessel.GetWorldPos3D()) );
+                surfVel = new Vector( orbVel - parent.getRFrmVel( pos + shared.Vessel.findWorldCenterOfMass()) );
             }
             else
                 surfVel = new Vector( orbVel.X, orbVel.Y, orbVel.Z );

--- a/src/kOS/Suffixed/Orbitable.cs
+++ b/src/kOS/Suffixed/Orbitable.cs
@@ -178,13 +178,12 @@ namespace kOS.Suffixed
             return d;
         }
 
-
         public double PositionToLatitude( Vector pos )
         {
             CelestialBody parent = Orbit.referenceBody;
             if (parent == null) //happens when this Orbitable is the Sun
                 return 0.0;
-            Vector3d unityWorldPos = GetPosition() + Shared.Vessel.GetWorldPos3D();
+            Vector3d unityWorldPos = GetPosition() + Utils.Vector3ToVector3d(Shared.Vessel.findWorldCenterOfMass());
             return parent.GetLatitude(unityWorldPos);
         }
         public double PositionToLongitude( Vector pos )
@@ -192,7 +191,7 @@ namespace kOS.Suffixed
             CelestialBody parent = Orbit.referenceBody;
             if (parent == null) //happens when this Orbitable is the Sun
                 return 0.0;
-            Vector3d unityWorldPos = GetPosition() + Shared.Vessel.GetWorldPos3D();
+            Vector3d unityWorldPos = GetPosition() + Utils.Vector3ToVector3d(Shared.Vessel.findWorldCenterOfMass());
             return Utils.DegreeFix( parent.GetLongitude(unityWorldPos), -180.0 );
         }
         public double PositionToAltitude( Vector pos )
@@ -200,7 +199,7 @@ namespace kOS.Suffixed
             CelestialBody parent = Orbit.referenceBody;
             if (parent == null) //happens when this Orbitable is the Sun
                 return 0.0;
-            Vector3d unityWorldPos = GetPosition() + Shared.Vessel.GetWorldPos3D();
+            Vector3d unityWorldPos = GetPosition() + Utils.Vector3ToVector3d(Shared.Vessel.findWorldCenterOfMass());
             return parent.GetAltitude(unityWorldPos);
         }
         

--- a/src/kOS/Suffixed/Vector.cs
+++ b/src/kOS/Suffixed/Vector.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using kOS.Safe.Encapsulation;
+using UnityEngine;
 
 namespace kOS.Suffixed
 {
@@ -10,6 +11,13 @@ namespace kOS.Suffixed
         public double Z { get; set; }
 
         public Vector(Vector3d init)
+        {
+            X = init.x;
+            Y = init.y;
+            Z = init.z;
+        }
+
+        public Vector(Vector3 init) // Vector3 is the single-precision version of Vector3d.
         {
             X = init.x;
             Y = init.y;
@@ -191,6 +199,11 @@ namespace kOS.Suffixed
         public Vector3d ToVector3D()
         {
             return new Vector3d(X, Y, Z);
+        }
+
+        public Vector3 ToVector3() // Vector3 is the single-precision version of Vector3D.
+        {
+            return new Vector3((float)X, (float)Y, (float)Z);
         }
 
         public override string ToString()

--- a/src/kOS/Suffixed/VectorRenderer.cs
+++ b/src/kOS/Suffixed/VectorRenderer.cs
@@ -110,7 +110,7 @@ namespace kOS.Suffixed
         {
             if (isOnMap)
                 shipCenterCoords = ScaledSpace.LocalToScaledSpace(
-                     shared.Vessel.GetWorldPos3D() );
+                     shared.Vessel.findWorldCenterOfMass() );
             else
                 shipCenterCoords = shared.Vessel.findWorldCenterOfMass();
         }

--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -16,7 +16,7 @@ namespace kOS.Suffixed
 
         override public Vector GetPosition()
         {
-            return new Vector( Vessel.GetWorldPos3D() - CurrentVessel.GetWorldPos3D() );
+            return new Vector( Vessel.findWorldCenterOfMass() - CurrentVessel.findWorldCenterOfMass() );
         }
 
         override public OrbitableVelocity GetVelocities()
@@ -55,7 +55,7 @@ namespace kOS.Suffixed
                 pos = pos + offset;
             }
 
-            return new Vector( pos - Shared.Vessel.GetWorldPos3D() ); // Convert to ship-centered frame.
+            return new Vector( pos - Shared.Vessel.findWorldCenterOfMass() ); // Convert to ship-centered frame.
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace kOS.Suffixed
             if (parent != null)
             {
                 Vector3d pos = GetPositionAtUT( timeStamp ).ToVector3D();
-                surfVel = new Vector( orbVel - parent.getRFrmVel( pos + Shared.Vessel.GetWorldPos3D()) );
+                surfVel = new Vector( orbVel - parent.getRFrmVel( pos + Shared.Vessel.findWorldCenterOfMass()) );
             }
             else
                 surfVel = new Vector( orbVel.x, orbVel.y, orbVel.z );
@@ -199,7 +199,7 @@ namespace kOS.Suffixed
         // in order to implement the orbit solver later.
         public double GetDistance()
         {
-            return Vector3d.Distance(CurrentVessel.GetWorldPos3D(), Vessel.GetWorldPos3D());
+            return Vector3d.Distance(CurrentVessel.findWorldCenterOfMass(), Vessel.findWorldCenterOfMass());
         }
 
         public override string ToString()
@@ -254,7 +254,7 @@ namespace kOS.Suffixed
                     return Vessel.horizontalSrfSpeed;
                 case "AIRSPEED":
                     return
-                        (Vessel.orbit.GetVel() - FlightGlobals.currentMainBody.getRFrmVel(Vessel.GetWorldPos3D()))
+                        (Vessel.orbit.GetVel() - FlightGlobals.currentMainBody.getRFrmVel(Vessel.findWorldCenterOfMass()))
                             .magnitude; //the velocity of the vessel relative to the air);
                 //DEPRICATED VESSELNAME
                 case "VESSELNAME":

--- a/src/kOS/Utilities/Utils.cs
+++ b/src/kOS/Utilities/Utils.cs
@@ -249,6 +249,17 @@ namespace kOS.Utilities
         }
 
         /// <summary>
+        /// Given a Vector3, construct a new Vector3D out of it.
+        /// By all rights SQUAD should have had this as a constructor in their Vector3d class.  I don't know why they didn't.
+        /// </summary>
+        /// <param name="convertFrom">The Vector3 to convert</param>
+        /// <returns>A Vector3d that has the same values as the Vector3 passed in.</returns>
+        public static Vector3d Vector3ToVector3d(Vector3 convertFrom)
+        {
+            return new Vector3d( (double)convertFrom.x, (double)convertFrom.y, (double)convertFrom.z);
+        }
+
+        /// <summary>
         ///   Returns true if body a orbits body b, either directly or through
         ///   a grandparent chain.
         /// </summary>

--- a/src/kOS/Utilities/VesselUtils.cs
+++ b/src/kOS/Utilities/VesselUtils.cs
@@ -204,7 +204,7 @@ namespace kOS.Utilities
                 body => body.name.ToUpper() == "KERBIN" || 
                 body.name.ToUpper() == "EARTH"))
             {
-                return Vector3d.Distance(body.position, vessel.GetWorldPos3D()) - body.Radius;
+                return Vector3d.Distance(body.position, vessel.findWorldCenterOfMass()) - body.Radius;
                 // Kerbin radius = 600,000
             }
 
@@ -250,7 +250,7 @@ namespace kOS.Utilities
             var up = vessel.upAxis;
             var north = GetNorthVector(vessel);
             var vector =
-                Vector3d.Exclude(vessel.upAxis, target.GetWorldPos3D() - vessel.GetWorldPos3D()).normalized;
+                Vector3d.Exclude(vessel.upAxis, target.findWorldCenterOfMass() - vessel.findWorldCenterOfMass()).normalized;
             var headingQ =
                 Quaternion.Inverse(Quaternion.Euler(90, 0, 0)*Quaternion.Inverse(Quaternion.LookRotation(vector, up))*
                                    Quaternion.LookRotation(north, up));


### PR DESCRIPTION
The root cause of the problem was an inconsistency in how different places in
the code defined "the" position of a vessel.  It was sometimes using the
vessel's root part and sometimes using the vessel's center of mass.  Now it
uses the vessel's center of mass for everything it does.
