### PR TITLE
fix RemoteTech and AVC file

### DIFF
--- a/Resources/GameData/kOS/kOS.version
+++ b/Resources/GameData/kOS/kOS.version
@@ -8,7 +8,7 @@
   },
   "KSP_VERSION": {
     "MAJOR": 0,
-    "MINOR": 24,
-    "PATCH": 2
+    "MINOR": 25,
+    "PATCH": 0
   }
 }

--- a/src/AddOns/RemoteTech2/RemoteTechHook.cs
+++ b/src/AddOns/RemoteTech2/RemoteTechHook.cs
@@ -6,7 +6,7 @@ namespace kOS.AddOns.RemoteTech2
 {
     public static class RemoteTechHook
     {
-        private const String REMOTE_TECH_ASSEMBLY = "RemoteTech2";
+        private const String REMOTE_TECH_ASSEMBLY = "RemoteTech"; // RemoteTech recently renamed the assembly from RemoteTech2 to RemoteTech
         private const String REMOTE_TECH_API = "RemoteTech.API";
 
         private static bool hookFail;


### PR DESCRIPTION
Update RemoteTechHook.cs to match the new assembly name.
Update kos.version to reflect support for version .25
