### PR TITLE
Added tree-walk suffixes to PartValue.

### DIFF
--- a/src/kOS/Suffixed/Part/PartValue.cs
+++ b/src/kOS/Suffixed/Part/PartValue.cs
@@ -32,6 +32,18 @@ namespace kOS.Suffixed.Part
             AddSuffix("MODULES", new Suffix<ListValue>(() => GatherModules(Part)));
             AddSuffix("TARGETABLE", new Suffix<bool>(() => Part.Modules.OfType<ITargetable>().Any()));
             AddSuffix("SHIP", new Suffix<VesselTarget>(() => new VesselTarget(Part.vessel, shared)));
+            AddSuffix("PARENT", new Suffix<PartValue>(() => new PartValue(Part.parent,shared), "The parent part of this part"));
+            AddSuffix("CHILDREN", new Suffix<ListValue>(() => GetChildren(), "A LIST() of the children parts of this part"));
+        }
+
+        private ListValue GatherModules(global::Part part)
+        {
+            var modules = new ListValue();
+            foreach (var module in part.Modules)
+            {
+                modules.Add(module.GetType());
+            }
+            return modules;
         }
 
         public override string ToString()
@@ -95,14 +107,14 @@ namespace kOS.Suffixed.Part
             return resources;
         }
 
-        private ListValue GatherModules(global::Part part)
+        private ListValue GetChildren()
         {
-            var modules = new ListValue();
-            foreach (var module in part.Modules)
+            ListValue kids = new ListValue();
+            foreach (global::Part part in Part.children)
             {
-                modules.Add(module.GetType());
+                kids.Add(new PartValue(part,shared));
             }
-            return modules;
+            return kids;
         }
     }
 }

--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -279,6 +279,8 @@ namespace kOS.Suffixed
                     return VesselUtils.GetTerminalVelocity(Vessel);
                 case "LOADED":
                     return Vessel.loaded;
+                case "ROOTPART":
+                    return new Part.PartValue(Vessel.rootPart,Shared);
             }
 
             // Is this a resource?


### PR DESCRIPTION
With these new suffixes you can walk the parts of a vessel with
tree thinking:

Note: Because there's still no "null" in KOS this is not quite entirely usable yet because walking up the tree you can't tell what happens when PARENT is null.  But you can deal with children that are "null" because that returns an empty ListValue of zero items.

New suffixes:

VesselTarget :ROOTPART
PartValue :PARENT
PartValue :CHILDREN
