### PR TITLE
Revert rename of PseudoNull to PseudoVoid.

### DIFF
--- a/src/kOS.Safe/Compilation/CompiledObject.cs
+++ b/src/kOS.Safe/Compilation/CompiledObject.cs
@@ -49,7 +49,7 @@ namespace kOS.Safe.Compilation
             // TODO: Make some sort of Assertion to run during OnAwake that will
             // verify this is the case and give a Nag Message if it's not.
             //
-            AddTypeData(0, typeof(PseudoVoid));
+            AddTypeData(0, typeof(PseudoNull));
             AddTypeData(1, typeof(bool));
             AddTypeData(2, typeof(byte));
             AddTypeData(3, typeof(Int16));
@@ -337,7 +337,7 @@ namespace kOS.Safe.Compilation
         {
             const int LABEL_OFFSET = 3; // Account for the %An at the front of the argument pack.
             
-            object arg = argument ?? new PseudoVoid();
+            object arg = argument ?? new PseudoNull();
             
             int returnValue; // bogus starting value before it's calculated.
             bool existsAlready = argumentPackFinder.TryGetValue(arg, out returnValue);
@@ -376,7 +376,7 @@ namespace kOS.Safe.Compilation
         /// <param name="obj">the thing to write</param>
         private static void WriteSomeBinaryPrimitive(BinaryWriter writer, object obj)
         {
-            if      (obj is PseudoVoid) { /* do nothing.  for a null the type byte code is enough - no further data. */ }
+            if      (obj is PseudoNull) { /* do nothing.  for a null the type byte code is enough - no further data. */ }
             else if (obj is Boolean)    writer.Write((bool)obj);
             else if (obj is Int32)      writer.Write((Int32)obj);
             else if (obj is String)     writer.Write((String)obj);
@@ -404,7 +404,7 @@ namespace kOS.Safe.Compilation
         {
             object returnValue = null;
             
-            if      (cSharpType == typeof(PseudoVoid)) { /* do nothing.  for a null the type byte code is enough - no further data. */ }
+            if      (cSharpType == typeof(PseudoNull)) { /* do nothing.  for a null the type byte code is enough - no further data. */ }
             else if (cSharpType == typeof(Boolean))    returnValue = reader.ReadBoolean();
             else if (cSharpType == typeof(Int32))      returnValue = reader.ReadInt32();
             else if (cSharpType == typeof(String))     returnValue = reader.ReadString();
@@ -664,7 +664,7 @@ namespace kOS.Safe.Compilation
                 byte opCodeTypeId = reader.ReadByte();
                 Type opCodeCSharpType = Opcode.TypeFromCode((ByteCode)opCodeTypeId);
                 
-                if (opCodeCSharpType == typeof(PseudoVoid))
+                if (opCodeCSharpType == typeof(PseudoNull))
                 {
                     // As soon as there's an opcode encountered that isn't a known opcode type, the section is done:
                     sectionEnded = true;

--- a/src/kOS.Safe/Compilation/OpCode.cs
+++ b/src/kOS.Safe/Compilation/OpCode.cs
@@ -364,7 +364,7 @@ namespace kOS.Safe.Compilation
             Type returnValue;
             if (! mapCodeToType.TryGetValue(code, out returnValue))
             {
-                returnValue = typeof(PseudoVoid); // flag telling the caller "not found".
+                returnValue = typeof(PseudoNull); // flag telling the caller "not found".
             }        
             return returnValue;
         }
@@ -379,7 +379,7 @@ namespace kOS.Safe.Compilation
             Type returnValue;
             if (! mapNameToType.TryGetValue(name, out returnValue))
             {
-                returnValue = typeof(PseudoVoid); // flag telling the caller "not found".
+                returnValue = typeof(PseudoNull); // flag telling the caller "not found".
             }
             return returnValue;
         }

--- a/src/kOS.Safe/Compilation/PseudoNull.cs
+++ b/src/kOS.Safe/Compilation/PseudoNull.cs
@@ -4,12 +4,12 @@ namespace kOS.Safe.Compilation
 {
     // Because nulls don't have real Types,
     // use this for a fake "type" to reperesent null:
-    public class PseudoVoid : IEquatable<object>
+    public class PseudoNull : IEquatable<object>
     {
         // all instances of PseudoNull should be considered identical:
         public override bool Equals(object o)
         {
-            return o is PseudoVoid;
+            return o is PseudoNull;
         }
 
         public override int GetHashCode() { return 0; }

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -53,7 +53,7 @@
     <Compile Include="Compilation\Opcode.cs" />
     <Compile Include="Compilation\ProgramBuilder.cs" />
     <Compile Include="Compilation\ProgramBuilderInterpreter.cs" />
-    <Compile Include="Compilation\PseudoVoid.cs" />
+    <Compile Include="Compilation\PseudoNull.cs" />
     <Compile Include="Compilation\Script.cs" />
     <Compile Include="Encapsulation\ConstantValue.cs" />
     <Compile Include="Encapsulation\FileInfo.cs" />


### PR DESCRIPTION
The original name was correct - they should be called PseudoNull.
The rename was an accidental misuse of the IDE's "helpful" features.
