### PR TITLE
Fixed PANELS ON and GEAR ON And AG1 ON.

### DIFF
--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -1686,7 +1686,7 @@ namespace kOS.Safe.Compilation.KS
         private void VisitOnOffStatement(ParseNode node)
         {
             SetLineNum(node);
-            VisitVarIdentifier(node.Nodes[0]);
+            VisitVariableNode(node.Nodes[0]);
             
             // node.Nodes[1].Token.Type == TokenType.onoff_trailer at this point
                 

--- a/src/kOS.Safe/Execution/ICpu.cs
+++ b/src/kOS.Safe/Execution/ICpu.cs
@@ -13,6 +13,7 @@ namespace kOS.Safe.Execution
         object PeekValue(int digDepth);        
         int GetStackSize();
         void SetValue(string identifier, object value);
+        void DumpVariables();
         void RemoveVariable(string identifier);
         void RemoveAllVariables();
         int InstructionPointer { get; set; }

--- a/src/kOS/Execution/CPU.cs
+++ b/src/kOS/Execution/CPU.cs
@@ -359,6 +359,18 @@ namespace kOS.Execution
             return variable;
         }
 
+        public void DumpVariables()
+        {
+            foreach (string ident in variables.Keys)
+            {
+                Variable v = variables[ident];
+                string line = ident + "=" + (v.Value.ToString() ?? "<null>");
+                shared.Screen.Print(line);
+                UnityEngine.Debug.Log(line);
+            }
+            shared.Screen.Print("YOU CAN SEE THIS LOG IN THE DEBUG OUTPUT.");
+        }
+
         private Variable GetVariable(string identifier)
         {
             identifier = identifier.ToLower();

--- a/src/kOS/Function/Misc.cs
+++ b/src/kOS/Function/Misc.cs
@@ -233,4 +233,14 @@ namespace kOS.Function
             if (shared.Processor != null) shared.Processor.SetMode(ProcessorModes.OFF);
         }
     }
+
+    [FunctionAttribute("debugglobalvars")]
+    public class DebugGlobalVars : FunctionBase
+    {
+        public override void Execute(SharedObjects shared)
+        {
+            shared.Cpu.DumpVariables();
+        }
+    }
+
 }


### PR DESCRIPTION
The problem was that the ON and OFF commands didn't treat the
identifier like a varible and therefore produced code like this:

push panels
push true
store

when it is supposed to do this:

push $panels
push true
store

NOTE this also includes the debugging function 

DEBUGGLOBALVARS().

Which I added to help find the problem, but it's useful to leave around.
