### PR TITLE
Added the suffix :PARTS to Vessel.

### DIFF
--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -206,6 +206,11 @@ namespace kOS.Suffixed
         {
             return "SHIP(\"" + Vessel.vesselName + "\")";
         }
+        
+        public ListValue GetAllParts()
+        {
+            return PartValue.PartsToList(Vessel.Parts, Shared);
+        }
 
         private ListValue GetPartsNamed(string partName)
         {
@@ -338,7 +343,8 @@ namespace kOS.Suffixed
             AddSuffix("MODULESNAMED", new OneArgsSuffix<ListValue,string>(GetModulesNamed));
             AddSuffix("PARTSINGROUP", new OneArgsSuffix<ListValue,string>(GetPartsInGroup));
             AddSuffix("MODULESINGROUP", new OneArgsSuffix<ListValue,string>(GetModulesInGroup));
-        }
+            AddSuffix("PARTS", new NoArgsSuffix<ListValue>(GetAllParts));
+       }
 
         public override object GetSuffix(string suffixName)
         {


### PR DESCRIPTION
// These will produce the same result now:

```
SET foo TO SHIP:PARTS.
```

```
LIST PARTS IN foo.
```

I'd previously been against doing this because people might try to use the expensive SHIP:PARTS[0] over and over instead of stuffing it in a variable first.  But now that we allow SHIP:PARTSNAMED("foo") which is just as expensive, we may as well put it in and if someone wants to do something the inefficient way and bog down their frame rate that's their problem.
