### PR TITLE
structure suffixes should be case insensitive

### DIFF
--- a/src/kOS.Safe.Test/StructureTest.cs
+++ b/src/kOS.Safe.Test/StructureTest.cs
@@ -151,6 +151,30 @@ namespace kOS.Safe.Test
         }
 
         [Test]
+        public void InstanceSuffixesAreCaseInsensitive()
+        {
+            var testStructure = new TestStructure();
+
+            var testObject1 = new object();
+            var testSuffix1 = Substitute.For<ISuffix>();
+            testSuffix1.Get().Returns(testObject1);
+
+            var testObject2 = new object();
+            var testSuffix2 = Substitute.For<ISuffix>();
+            testSuffix2.Get().Returns(testObject2);
+
+            var suffixNameLower = Guid.NewGuid().ToString().ToLower();
+            var suffixNameUpper = suffixNameLower.ToUpper();
+
+            testStructure.TestAddInstanceSuffix(suffixNameUpper, testSuffix1);
+            Assert.AreEqual(testObject1, testStructure.GetSuffix(suffixNameUpper));
+            Assert.AreEqual(testObject1, testStructure.GetSuffix(suffixNameLower));
+            testStructure.TestAddInstanceSuffix(suffixNameLower, testSuffix2);
+            Assert.AreEqual(testObject2, testStructure.GetSuffix(suffixNameUpper));
+            Assert.AreEqual(testObject2, testStructure.GetSuffix(suffixNameLower));
+        }
+
+        [Test]
         public void CanSetInstanceSuffix()
         {
             var testObject = new object();

--- a/src/kOS.Safe/Encapsulation/Structure.cs
+++ b/src/kOS.Safe/Encapsulation/Structure.cs
@@ -17,7 +17,7 @@ namespace kOS.Safe.Encapsulation
 
         protected Structure()
         {
-            instanceSuffixes = new Dictionary<string, ISuffix>();
+            instanceSuffixes = new Dictionary<string, ISuffix>(StringComparer.OrdinalIgnoreCase);
         }
 
         protected void AddSuffix(string suffixName, ISuffix suffixToAdd)
@@ -73,7 +73,7 @@ namespace kOS.Safe.Encapsulation
                 {
                     return typeSuffixes;
                 }
-                return new Dictionary<string, ISuffix>();
+                return new Dictionary<string, ISuffix>(StringComparer.OrdinalIgnoreCase);
             }
         }
 


### PR DESCRIPTION
i realized they were not and that didnt quite jive with the design. should make them easier to use
