### PR TITLE
bugs in logging an exception caused a new exception that masked the original.

### DIFF
--- a/src/kOS/KSPLogger.cs
+++ b/src/kOS/KSPLogger.cs
@@ -108,8 +108,6 @@ namespace kOS
         
         private string BuildLocationString(string source, int line)
         {
-            string[] splitParts = source.Split('/');
-            
             if (line < 0)
             {
                 // Special exception - if line number is negative then this isn't from any
@@ -117,6 +115,12 @@ namespace kOS
                 // to recalculate LOCK THROTTLE and LOCK STEERING each time there's an Update).
                 return "(kOS built-in Update)";
             }
+            if (source==null || source==string.Empty)
+            {
+                return "<<probably internal kOS C# error>>";
+            }
+
+            string[] splitParts = source.Split('/');
 
             if (splitParts.Length <= 1)
                 return string.Format("{0}, line {1}", source, line);
@@ -128,9 +132,6 @@ namespace kOS
         private string GetSourceLine(string filePath, int line)
         {
             string returnVal = "(Can't show source line)";
-            string[] pathParts = filePath.Split('/');
-            string fileName = pathParts.Last();
-            Volume vol;
             if (line < 0 && (filePath==null || filePath == String.Empty))
             {
                 // Special exception - if line number is negative then this isn't from any
@@ -138,6 +139,13 @@ namespace kOS
                 // to recalculate LOCK THROTTLE and LOCK STEERING each time there's an Update).
                 return "<<System Built-In Flight Control Updater>>";
             }
+            else if (filePath==null || filePath == String.Empty)
+            {
+                return "<<Probably internal error within kOS C# code>>";
+            }
+            string[] pathParts = filePath.Split('/');
+            string fileName = pathParts.Last();
+            Volume vol;
             if (pathParts!=null && pathParts.Length > 1)
             {
                 string volName = pathParts.First();


### PR DESCRIPTION
When a C# System exception is thrown due to a bug in our own C# code rather than something occurring in the kerboscript's code, the KSPlogger doesn't have a source filepath to work with (this is the path to the kerboscript where the error happened), and it didn't deal properly with the condition where that path is null.

This was masking part of the stack trace of the original C# exception in the output_log, because the trace ended up describing the new exception thrown by the KSPLogger itself instead of the original exception.

This was fixed by moving the use of the source filepath string to AFTER the check to see if it's null has occurred (previously the checks didn't happen until after the first attempt to make use of the string, making the checks rather pointless).

I had to do this to diagnose what was wrong with the develop platform.  This logging bug was masking the actual error so I wasted some time chasing through my own code changes trying to find it.  The actual error I found after making this fix to the logger was the one I just described in issue #324.
