### PR TITLE
Resolves issue #328 - smart partvalue constructor

### DIFF
--- a/src/kOS/Suffixed/Part/PartFactory.cs
+++ b/src/kOS/Suffixed/Part/PartFactory.cs
@@ -1,0 +1,42 @@
+﻿/*
+ * Created by SharpDevelop.
+ * User: Dunbaratu
+ * Date: 11/5/2014
+ * Time: 3:13 AM
+ * 
+ * To change this template use Tools | Options | Coding | Edit Standard Headers.
+ */
+using System;
+using System.Linq;
+
+namespace kOS.Suffixed.Part
+{
+    /// <summary>
+    /// Description of PartFactory.
+    /// </summary>
+    public class PartFactory 
+    {        
+        public static PartValue Construct(global::Part part, SharedObjects shared)
+        {
+            foreach (PartModule module in part.Modules)
+            {
+                ModuleEngines mEng = module as ModuleEngines;
+                if (mEng != null)
+                    return new EngineValue(part, new ModuleEngineAdapter(mEng), shared);
+                ModuleEnginesFX mEngFX = module as ModuleEnginesFX;
+                if (mEngFX != null)
+                    return new EngineValue(part, new ModuleEngineAdapter(mEngFX), shared);
+                ModuleDockingNode mDock = module as ModuleDockingNode;
+                if (mDock != null)
+                    return new DockingPortValue(mDock, shared);
+                ModuleEnviroSensor mSense = module as ModuleEnviroSensor;
+                if (mSense != null)
+                    return new SensorValue(part, mSense, shared);
+                
+            }
+            
+            // Fallback if none of the above: then just a normal part:
+            return new PartValue(part, shared);
+        }
+    }
+}

--- a/src/kOS/Suffixed/Part/PartModuleFields.cs
+++ b/src/kOS/Suffixed/Part/PartModuleFields.cs
@@ -336,7 +336,7 @@ namespace kOS.Suffixed.Part
         private void InitializeSuffixesAfterConstruction()
         {
             AddSuffix("NAME",       new Suffix<string>(() => partModule.moduleName));
-            AddSuffix("PART",       new Suffix<PartValue>(() => new PartValue(partModule.part,shared)));
+            AddSuffix("PART",       new Suffix<PartValue>(() => PartFactory.Construct(partModule.part,shared)));
             AddSuffix("ALLFIELDS",  new Suffix<ListValue>(() => AllFields("({0}) {1}, is {2}")));
             AddSuffix("HASFIELD",   new OneArgsSuffix<bool, string>(HasField));
             AddSuffix("ALLEVENTS",  new Suffix<ListValue>(() => AllEvents("({0}) {1}, is {2}")));

--- a/src/kOS/Suffixed/Part/PartValue.cs
+++ b/src/kOS/Suffixed/Part/PartValue.cs
@@ -37,7 +37,7 @@ namespace kOS.Suffixed.Part
             AddSuffix("SHIP", new Suffix<VesselTarget>(() => new VesselTarget(Part.vessel, shared)));
             AddSuffix("GETMODULE", new OneArgsSuffix<PartModuleFields,string>(GetModule));
             AddSuffix("MODULES", new Suffix<ListValue>(GetAllModules, "A List of all the modules' names on this part"));            
-            AddSuffix("PARENT", new Suffix<PartValue>(() => new PartValue(Part.parent,shared), "The parent part of this part"));
+            AddSuffix("PARENT", new Suffix<PartValue>(() => PartFactory.Construct(Part.parent,shared), "The parent part of this part"));
             AddSuffix("HASPARENT", new Suffix<bool>(() => Part.parent != null, "Tells you if this part has a parent, is used to avoid null exception from PARENT"));
             AddSuffix("CHILDREN", new Suffix<ListValue>(GetChildren, "A LIST() of the children parts of this part"));
         }
@@ -65,7 +65,7 @@ namespace kOS.Suffixed.Part
             var toReturn = new ListValue();
             foreach (var part in parts)
             {
-                toReturn.Add(new PartValue(part, sharedObj));
+                toReturn.Add(PartFactory.Construct(part, sharedObj));
             }
             return toReturn;
         }
@@ -121,7 +121,7 @@ namespace kOS.Suffixed.Part
             var kids = new ListValue();
             foreach (global::Part part in Part.children)
             {
-                kids.Add(new PartValue(part,shared));
+                kids.Add(PartFactory.Construct(part,shared));
             }
             return kids;
         }

--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -223,7 +223,7 @@ namespace kOS.Suffixed
 
             ListValue kScriptParts = new ListValue();
             foreach (global::Part kspPart in kspParts)
-                kScriptParts.Add( new PartValue(kspPart,Shared));
+                kScriptParts.Add(PartFactory.Construct(kspPart,Shared));
             return kScriptParts;
         }
 
@@ -233,7 +233,11 @@ namespace kOS.Suffixed
                 .Where( p => p.Modules.OfType<KOSNameTag>()
                 .Any(tag => String.Equals(tag.nameTag, tagName, StringComparison.CurrentCultureIgnoreCase)));
 
-            return ListValue.CreateList(partsWithName);
+            // The KSP Parts need to become KOS PartValues before becoming a ListValue:
+            ListValue kScriptParts = new ListValue();
+            foreach (global::Part kspPart in partsWithName)
+                kScriptParts.Add(PartFactory.Construct(kspPart,Shared));
+            return kScriptParts;
         }
 
         private ListValue GetModulesNamed(string modName)
@@ -280,7 +284,7 @@ namespace kOS.Suffixed
                 bool hasPartAction = p.Actions.Any(a => a.actionGroup.Equals(matchGroup));
                 if (hasPartAction)
                 {
-                    kScriptParts.Add(new PartValue(p,Shared));
+                    kScriptParts.Add(PartFactory.Construct(p,Shared));
                     continue;
                 }
 
@@ -288,7 +292,7 @@ namespace kOS.Suffixed
                 bool hasModuleAction = modules.Any(pm => pm.Actions.Any(a=>a.actionGroup.Equals(matchGroup)));
                 if (hasModuleAction)
                 {
-                        kScriptParts.Add(new PartValue(p,Shared));
+                        kScriptParts.Add(PartFactory.Construct(p,Shared));
                 }
             }
             return kScriptParts;
@@ -417,7 +421,7 @@ namespace kOS.Suffixed
                 case "LOADED":
                     return Vessel.loaded;
                 case "ROOTPART":
-                    return new PartValue(Vessel.rootPart,Shared);
+                    return PartFactory.Construct(Vessel.rootPart,Shared);
             }
 
             // Is this a resource?

--- a/src/kOS/kOS.csproj
+++ b/src/kOS/kOS.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Suffixed\BodyTarget.cs" />
     <Compile Include="Suffixed\Orbitable.cs" />
     <Compile Include="Suffixed\Part\ModuleEngineAdapter.cs" />
+    <Compile Include="Suffixed\Part\PartFactory.cs" />
     <Compile Include="Suffixed\Part\PartModuleFields.cs" />
     <Compile Include="Suffixed\RgbaColor.cs" />
     <Compile Include="Suffixed\Config.cs" />


### PR DESCRIPTION
This should fix that small issue.

I also noticed in my testing that the list being created by the suffix :PARTSTAGGED("name") was a list of KSP Parts, not a list of KOS PartValues, and fixed that.
