### PR TITLE
Resolves #318 and adds a few related fixes.

### DIFF
--- a/src/kOS.Safe/Exceptions/KOSLookupFailException.cs
+++ b/src/kOS.Safe/Exceptions/KOSLookupFailException.cs
@@ -9,7 +9,8 @@ namespace kOS.Safe.Exceptions
     /// </summary>
     public class KOSLookupFailException: KOSException
     {
-        private const string TERSE_MSG_FMT = "No {0} called {1} was found on {2}";
+        private const string TERSE_NOT_EXIST_MSG_FMT = "No {0} called {1} was found on {2}";
+        private const string TERSE_DOES_EXIST_MSG_FMT = "The {0} called {1} on {2} is not accessable right now";
 
         public override string VerboseMessage { get{ return BuildVerboseMessage(); } }
 
@@ -18,6 +19,7 @@ namespace kOS.Safe.Exceptions
         private string category;
         private string lookupName;
         private object obj;
+        private bool exist;
         
         /// <summary>
         /// Make an exception describing improper suffix usage.
@@ -25,12 +27,15 @@ namespace kOS.Safe.Exceptions
         /// <param name="category">category of thing being looked up, i.e "field" or "module"</param>
         /// <param name="lookupName">thing being looked up</param>
         /// <param name="obj">ref to the object on the left of the suffix colon.</param>
-        public KOSLookupFailException(string category, string lookupName, object obj) :
-            base(String.Format(TERSE_MSG_FMT, category, lookupName.ToUpper(), obj.ToString()))
+        /// <param name="exist">True if the reason for the message is that the thing exists at
+        ///   other times, but is just not available at the moment.</param>
+        public KOSLookupFailException(string category, string lookupName, object obj, bool exist = false) :
+            base(String.Format( (exist ? TERSE_NOT_EXIST_MSG_FMT : TERSE_NOT_EXIST_MSG_FMT), category, lookupName.ToUpper(), obj.ToString()) )
         {
             this.category = category;
             this.lookupName = lookupName;
-            this.obj = obj;            
+            this.obj = obj;           
+            this.exist = exist;
         }
         
         private string BuildVerboseMessage()
@@ -41,13 +46,13 @@ namespace kOS.Safe.Exceptions
                 "    {2}\n" +
                 "from an object of type:\n" +
                 "    {3}\n" +
-                "when that object does not have that\n" +
-                "{1} on it.\n" +
+                "but it {4}.\n" +
                 "\n" +
                 "A full list of all {1}S on the object can be\n" +
                 "found by using its :ALL{1}s suffix.\n";
 
-            return String.Format(VERBOSE_TEXT, Message, category.ToUpper(), lookupName, obj.GetType().Name);
+            return String.Format(VERBOSE_TEXT, Message, category.ToUpper(), lookupName, obj.GetType().Name,
+                                 (exist ? "isn't avaiable at the moment" : "doesn't exist"));
 
         }
     }

--- a/src/kOS/Screen/KOSTextEditPopup.cs
+++ b/src/kOS/Screen/KOSTextEditPopup.cs
@@ -120,6 +120,7 @@ namespace kOS.Screen
         {
             if (IsOpen())
             {
+                
                 CalcOuterCoords(); // force windowRect to lock to bottom edge of the parents
                 CalcInnerCoords();
 

--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -163,6 +163,7 @@ namespace kOS.Screen
             }
             
             GUI.skin = HighLogic.Skin;
+            
             GUI.color = isLocked ? color : colorAlpha;
             
             windowRect = GUI.Window(uniqueId, windowRect, TerminalGui, "");

--- a/src/kOS/Suffixed/Part/PartModuleFields.cs
+++ b/src/kOS/Suffixed/Part/PartModuleFields.cs
@@ -83,12 +83,18 @@ namespace kOS.Suffixed.Part
         /// increments of 2, then a value of 17 is not something you could achieve in the GUI, being only able
         /// to go from 16 to 18 skipping over 17, and therefore this routine would return false for trying to
         /// set it to 17).
+        /// <br/><br/>
+        /// Note that the value passed in may be altered (which is why it's ref) when it's not
+        /// exactly legal, but it's CLOSE ENOUGH to be coerced into a legal value.  For example,
+        /// you set a slider to 10.45 and the slider only allows values on the 0.5 marks like 10, 10.5, 11. etc.
+        /// Rather than deny the attempt, the value will be nudged to the nearest legal value.
         /// </summary>
         /// <param name="field">Which KSPField is being checked?</param>
-        /// <param name="newVal">What is the value it's being set to?</param>
+        /// <param name="newVal">What is the value it's being set to?  It is possible to
+        ///    alter the value to an acceptable replacement which is why it passes by ref</param>
         /// <param name="except">An exception you can choose to throw if you want, or null if the value is legal.</param>
         /// <returns>Is it legal?</returns>
-        private bool IsLegalValue(BaseField field, object newVal, out KOSException except)
+        private bool IsLegalValue(BaseField field, ref object newVal, out KOSException except)
         {
             except = null;
             bool isLegal = true;
@@ -98,7 +104,7 @@ namespace kOS.Suffixed.Part
             
             if (!IsEditable(field))
             {
-                except = new KOSInvalidFieldValueException("Field is not editable");
+                except = new KOSInvalidFieldValueException("Field is read-only");
                 return false;
             }
             if (! newVal.GetType().IsSubclassOf(fType))
@@ -121,9 +127,7 @@ namespace kOS.Suffixed.Part
             // it's technically possible to have more than one according to the structure of
             // the API, this loop is here to check all of "them":
             foreach (UI_Control control in controls)
-            {
-                const float FLOAT_EPSILON = 0.0001f; // because using exact equality with floats is a bad idea.
-                
+            {                
                 // Some of these are subclasses of each other, so don't change this to an if/else.
                 // It's a series of if's on purpose so it checks all classes the control is derived from.
                 if (control is UI_Toggle)
@@ -155,35 +159,59 @@ namespace kOS.Suffixed.Part
                 if (range != null)
                 {
                     float val = Convert.ToSingle(convertedVal);
-                    float min = range.minValue;
-                    float max = range.maxValue;
-                    float inc = range.stepIncrement;
-                    if (val < min || val > max)
-                    {
-                        except = new KOSInvalidFieldValueException("Value is outside the allowed range ["+min+","+max+"]");
-                        isLegal = false;
-                    }
-                    else if (Math.Abs((val - min) % inc) > FLOAT_EPSILON)
-                    {
-                        except = new KOSInvalidFieldValueException("Value is not an exact integer multiple of allowed step increment "+inc);
-                        isLegal = false;
-                    }
+                    val = SliderClampRound(val, range.minValue, range.maxValue, range.stepIncrement);
+                    convertedVal = Convert.ToDouble(val);
                 }
                 if (! isLegal)
                     break;
             }
+            newVal = convertedVal;
             return isLegal;
+        }
+        
+        /// <summary>
+        /// Round the value to the nearest value the slider will allow if the slider starts
+        /// at min, ends at max, and has detents every inc.
+        /// </summary>
+        /// <param name="val">value to round</param>
+        /// <param name="min">minimun the slider allows</param>
+        /// <param name="max">maximum the slider allows</param>
+        /// <param name="inc">increment of the detents</param>
+        /// <returns></returns>
+        private float SliderClampRound(float val, float min, float max, float inc)
+        {
+            // First clamp the value to within min/max:
+            float outVal = Math.Max(min, Math.Min(val, max));
+            
+            // How many discrete increments up the slider gets us to the nearest detent less than or equal to the value:
+            int numIncs = Mathf.FloorToInt((outVal-min)/inc);
+
+            // get detent values just below and above the value:
+            float nearUnder = min + (numIncs*inc);
+            float nearOver = min + ((numIncs+1)*inc);
+            
+            // pick which one to round to:
+            float remainder = outVal - nearUnder;
+            if (remainder >= (inc/2f) && nearOver <= max)
+                outVal = nearOver;
+            else
+                outVal = nearUnder;
+
+            return outVal;
         }
 
         /// <summary>
-        /// Return a list of all the strings of all KSPfields registered to this PartModule.
+        /// Return a list of all the strings of all KSPfields registered to this PartModule
+        /// which are currently showing on the part's RMB menu.
         /// </summary>
         /// <returns>List of all the strings field names.</returns>
         private ListValue AllFields(string formatter)
         {            
             var returnValue = new ListValue();
             
-            foreach (BaseField field in partModule.Fields)
+            IEnumerable<BaseField> visibleFields = partModule.Fields.Cast<BaseField>().Where((field) => FieldIsVisible(field));
+
+            foreach (BaseField field in visibleFields)
             {
                 returnValue.Add(String.Format(formatter,
                                               (IsEditable(field)?"settable":"get-only"),
@@ -195,36 +223,38 @@ namespace kOS.Suffixed.Part
         
         /// <summary>
         /// Determine if the Partmodule has this KSPField on it, which is publicly
-        /// usable by a kOS script:
+        /// usable by a kOS script at the moment:
         /// </summary>
         /// <param name="fieldName">The field to search for</param>
         /// <returns>true if it is on the PartModule, false if it is not</returns>
         public bool HasField(string fieldName)
         {
-            return partModule.Fields.Cast<BaseField>().
-                Any(field => String.Equals(field.guiName, fieldName, StringComparison.CurrentCultureIgnoreCase));
+            return FieldIsVisible(GetField(fieldName));
         }
 
         /// <summary>
-        /// Return whatever the field's current value is in the PartModule.
+        /// Return the field itself that goes with the name (the BaseField, not the value).
         /// </summary>
         /// <param name="cookedGuiName">The case-insensitive guiName of the field.</param>
         /// <returns>a BaseField - a KSP type that can be used to get the value, or its GUI name or its reflection info.</returns>
         private BaseField GetField(string cookedGuiName)
-        {            
+        {
             return partModule.Fields.Cast<BaseField>().
                 FirstOrDefault(field => String.Equals(field.guiName, cookedGuiName, StringComparison.CurrentCultureIgnoreCase));
         }
 
         /// <summary>
-        /// Return a list of all the KSPEvents the module has in it.
+        /// Return a list of all the KSPEvents the module has in it which are currently
+        /// visible on the RMB menu.
         /// </summary>
         /// <returns></returns>
         private ListValue AllEvents(string formatter)
         {            
             var returnValue = new ListValue();
-            
-            foreach (BaseEvent kspEvent  in partModule.Events)
+
+            IEnumerable<BaseEvent> visibleEvents = partModule.Events.Cast<BaseEvent>().Where( (evt) => EventIsVisible(evt) );
+   
+            foreach (BaseEvent kspEvent in visibleEvents)
             {
                 returnValue.Add(String.Format(formatter,
                                               "callable",
@@ -242,8 +272,7 @@ namespace kOS.Suffixed.Part
         /// <returns>true if it is on the PartModule, false if it is not</returns>
         public bool HasEvent(string eventName)
         {
-            return partModule.Events.
-                Any(kspEvent => String.Equals(kspEvent.guiName, eventName, StringComparison.CurrentCultureIgnoreCase));
+            return EventIsVisible(GetEvent(eventName));
         }
 
         /// <summary>
@@ -349,6 +378,24 @@ namespace kOS.Suffixed.Part
             AddSuffix("DOACTION",   new TwoArgsSuffix<string, bool>(CallKSPAction));
         }
         
+        private static bool FieldIsVisible(BaseField field)
+        {
+            return (field==null) ?
+                false :
+                (HighLogic.LoadedSceneIsEditor ? field.guiActiveEditor : field.guiActive);
+        }
+
+        private static bool EventIsVisible(BaseEvent evt)
+        {
+            return (evt==null) ?
+                false :
+                (
+                    (HighLogic.LoadedSceneIsEditor ? evt.guiActiveEditor : evt.guiActive) &&
+                    /* evt.externalToEVAOnly) && */ // this flag seems bugged.  It always returns true no matter what.
+                    evt.active
+                );
+        }
+        
         /// <summary>
         /// Get a KSPField with the kOS suffix name given.
         /// </summary>
@@ -357,9 +404,10 @@ namespace kOS.Suffixed.Part
         private object GetKSPFieldValue(string suffixName)
         {
             BaseField field = GetField(suffixName);
-            if (field==null) {
+            if (field==null)
                 throw new KOSLookupFailException( "FIELD", suffixName, this);
-            }
+            if (! FieldIsVisible(field))
+                throw new KOSLookupFailException( "FIELD", suffixName, this, true);
             object obj = field.GetValue(partModule);
             return obj;
         }
@@ -374,9 +422,11 @@ namespace kOS.Suffixed.Part
             BaseField field = GetField(suffixName);
             if (field==null)
                 throw new KOSLookupFailException( "FIELD", suffixName, this);
+            if (! FieldIsVisible(field))
+                throw new KOSLookupFailException( "FIELD", suffixName, this, true);
 
             KOSException except;                
-            if (IsLegalValue(field, newValue, out except))
+            if (IsLegalValue(field, ref newValue, out except))
             {
                 object convertedValue = Convert.ChangeType(newValue,field.FieldInfo.FieldType);
                 field.SetValue(convertedValue, partModule);
@@ -396,6 +446,8 @@ namespace kOS.Suffixed.Part
             BaseEvent evt = GetEvent(suffixName);
             if (evt==null)
                 throw new KOSLookupFailException( "EVENT", suffixName, this);
+            if (! EventIsVisible(evt))
+                throw new KOSLookupFailException( "EVENT", suffixName, this, true);
             evt.Invoke();
         }
 

--- a/src/kOS/Suffixed/Part/PartValue.cs
+++ b/src/kOS/Suffixed/Part/PartValue.cs
@@ -36,7 +36,7 @@ namespace kOS.Suffixed.Part
             AddSuffix("TARGETABLE", new Suffix<bool>(() => Part.Modules.OfType<ITargetable>().Any()));
             AddSuffix("SHIP", new Suffix<VesselTarget>(() => new VesselTarget(Part.vessel, shared)));
             AddSuffix("GETMODULE", new OneArgsSuffix<PartModuleFields,string>(GetModule));
-            AddSuffix("MODULES", new Suffix<ListValue>(GetAllModules, "A List of all the modules' names on this part"));            
+            AddSuffix(new [] {"MODULES","ALLMODULES"}, new Suffix<ListValue>(GetAllModules, "A List of all the modules' names on this part"));
             AddSuffix("PARENT", new Suffix<PartValue>(() => PartValueFactory.Construct(Part.parent,shared), "The parent part of this part"));
             AddSuffix("HASPARENT", new Suffix<bool>(() => Part.parent != null, "Tells you if this part has a parent, is used to avoid null exception from PARENT"));
             AddSuffix("CHILDREN", new Suffix<ListValue>(() => PartValueFactory.Construct(Part.children, shared), "A LIST() of the children parts of this part"));


### PR DESCRIPTION
Other things dealt with are:

:MODULES suffix now has an alias :ALLMODULES that does the same
thing.  (Reason: the exception message for :GETMODULE("some bogus name")
tells the user to try running the :ALLMODULEs suffix, because it
always inserts the word "ALL" in front of the argument passed into
it to form the message.  I figured it might be nice if the thing
the excpetion tells the users to do is in fact actually possible.)

Restructured the "is this thing visible" checks to collect them all
into one function.

Took into account whether the editor is running or the flight mode
is running, to change whether it uses guiActive or guiActiveEditor.
At the moment this doesn't matter much because you can't run programs
inside the editor... but some day.....
