### PR TITLE
Resolves #311. Partial fix for boot filename consistency issue with Linux filesystems.

### DIFF
--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using kOS.Execution;
@@ -29,7 +29,7 @@ namespace kOS.Module
         private const int PROCESSOR_HARD_CAP = 655360;
 
         [KSPField(isPersistant = true, guiName = "Boot File", guiActive = false, guiActiveEditor = false)]
-        public string bootFile = "Boot";
+        public string bootFile = "boot";
 
         [KSPField(isPersistant = false, guiName = "Boot File Choice", guiActive = false, guiActiveEditor = true), UI_FloatRange(minValue=0f,maxValue=1f,stepIncrement=1f)]
         public float bootFileChoice = 0f;


### PR DESCRIPTION
After compiling this very small correction, it now behaves correctly with lowercase boot filenames on Linux systems. Further patching and testing is required to properly insure filename consistency but a warning to Linux users regarding the need for scripts to be all in lowercase filenames should suffice at the moment.
