### PR TITLE
Resolves #356 title in part list

### DIFF
--- a/src/kOS/Suffixed/Part/PartValue.cs
+++ b/src/kOS/Suffixed/Part/PartValue.cs
@@ -28,6 +28,7 @@ namespace kOS.Suffixed.Part
         {
             AddSuffix("CONTROLFROM", new NoArgsSuffix(ControlFrom));
             AddSuffix("NAME", new Suffix<string>(() => Part.name));
+            AddSuffix("TITLE", new Suffix<string>(() => Part.partInfo.title));
             AddSuffix("STAGE", new Suffix<int>(() => Part.inverseStage));
             AddSuffix("UID", new Suffix<uint>(() => Part.uid));
             AddSuffix("ROTATION", new Suffix<Direction>(() => new Direction( Part.transform.rotation) ));


### PR DESCRIPTION
Performs the following new suffixes:
- Part:TITLE - the GUI name of the part.
- Vessel:PARTSTITLED(foo) - list of the parts with foo title.
- Vessel:PARTSCALLED(foo) - aggregate of all the lookups, returns the distinct union of PARTSTAGGED(foo), PARTSTITLED(foo), and PARTSNAMED(foo).
