### PR TITLE
review comments

### DIFF
--- a/src/kOS/Function/Math.cs
+++ b/src/kOS/Function/Math.cs
@@ -155,7 +155,7 @@ namespace kOS.Function
 
             if (vector1 != null && vector2 != null)
             {
-                object result = new Vector(Vector3d.Cross(vector1.ToVector3D(), vector2.ToVector3D()));
+                object result = new Vector(Vector3d.Cross(vector1, vector2));
                 shared.Cpu.PushStack(result);
             }
         }
@@ -171,7 +171,7 @@ namespace kOS.Function
 
             if (vector1 != null && vector2 != null)
             {
-                object result = Vector3d.Dot(vector1.ToVector3D(), vector2.ToVector3D());
+                object result = Vector3d.Dot(vector1, vector2);
                 shared.Cpu.PushStack(result);
             }
         }
@@ -187,7 +187,7 @@ namespace kOS.Function
 
             if (vector1 != null && vector2 != null)
             {
-                object result = new Vector(Vector3d.Exclude(vector1.ToVector3D(), vector2.ToVector3D()));
+                object result = new Vector(Vector3d.Exclude(vector1, vector2));
                 shared.Cpu.PushStack(result);
             }
         }
@@ -203,7 +203,7 @@ namespace kOS.Function
 
             if (vector1 != null && vector2 != null)
             {
-                object result = Vector3d.Angle(vector1.ToVector3D(), vector2.ToVector3D());
+                object result = Vector3d.Angle(vector1, vector2);
                 shared.Cpu.PushStack(result);
             }
         }

--- a/src/kOS/Suffixed/BodyTarget.cs
+++ b/src/kOS/Suffixed/BodyTarget.cs
@@ -60,7 +60,7 @@ namespace kOS.Suffixed
         override public Vector GetNorthVector()
         {
             CelestialBody parent = Body.referenceBody ?? Body;
-            return new Vector( Vector3d.Exclude(GetUpVector().ToVector3D(), parent.transform.up) );
+            return new Vector( Vector3d.Exclude(GetUpVector(), parent.transform.up) );
         }
 
         public BodyTarget(string name, SharedObjects shareObj) : this(VesselUtils.GetBodyByName(name),shareObj)

--- a/src/kOS/Suffixed/Direction.cs
+++ b/src/kOS/Suffixed/Direction.cs
@@ -103,7 +103,7 @@ namespace kOS.Suffixed
             var otherVector = other as Vector;
             if (otherVector != null)
             {
-                Vector3d vec = otherVector.ToVector3D();
+                Vector3d vec = otherVector;
                 return new Vector(Rotation*vec);
             }
 

--- a/src/kOS/Suffixed/OrbitInfo.cs
+++ b/src/kOS/Suffixed/OrbitInfo.cs
@@ -53,7 +53,7 @@ namespace kOS.Suffixed
             Vector surfVel;
             if (parent != null)
             {
-                Vector3d pos = GetPositionAtUT( timeStamp ).ToVector3D();
+                Vector3d pos = GetPositionAtUT( timeStamp );
                 surfVel = new Vector( orbVel - parent.getRFrmVel( pos + shared.Vessel.findWorldCenterOfMass()) );
             }
             else

--- a/src/kOS/Suffixed/Orbitable.cs
+++ b/src/kOS/Suffixed/Orbitable.cs
@@ -140,9 +140,9 @@ namespace kOS.Suffixed
         
         public Direction GetPrograde()
         {
-            Vector3d up = GetUpVector().ToVector3D();
+            Vector3d up = GetUpVector();
             OrbitableVelocity vels = GetVelocities();
-            Vector3d normOrbVec = vels.Orbital.Normalized().ToVector3D();
+            Vector3d normOrbVec = vels.Orbital.Normalized();
 
             var d = new Direction {Rotation = Quaternion.LookRotation(normOrbVec, up)};
             return d;
@@ -150,9 +150,9 @@ namespace kOS.Suffixed
 
         public Direction GetRetrograde()
         {
-            Vector3d up = GetUpVector().ToVector3D();
+            Vector3d up = GetUpVector();
             OrbitableVelocity vels = GetVelocities();
-            Vector3d normOrbVec = vels.Orbital.Normalized().ToVector3D();
+            Vector3d normOrbVec = vels.Orbital.Normalized();
 
             var d = new Direction {Rotation = Quaternion.LookRotation(normOrbVec*(-1), up)};
             return d;
@@ -160,9 +160,9 @@ namespace kOS.Suffixed
 
         public Direction GetSurfacePrograde()
         {
-            Vector3d up = GetUpVector().ToVector3D();
+            Vector3d up = GetUpVector();
             OrbitableVelocity vels = GetVelocities();
-            Vector3d normSrfVec = vels.Surface.Normalized().ToVector3D();
+            Vector3d normSrfVec = vels.Surface.Normalized();
 
             var d = new Direction {Rotation = Quaternion.LookRotation(normSrfVec, up)};
             return d;
@@ -170,9 +170,9 @@ namespace kOS.Suffixed
 
         public Direction GetSurfaceRetrograde()
         {
-            Vector3d up = GetUpVector().ToVector3D();
+            Vector3d up = GetUpVector();
             OrbitableVelocity vels = GetVelocities();
-            Vector3d normSrfVec = vels.Surface.Normalized().ToVector3D();
+            Vector3d normSrfVec = vels.Surface.Normalized();
 
             var d = new Direction {Rotation = Quaternion.LookRotation(normSrfVec*(-1), up)};
             return d;
@@ -183,7 +183,7 @@ namespace kOS.Suffixed
             CelestialBody parent = Orbit.referenceBody;
             if (parent == null) //happens when this Orbitable is the Sun
                 return 0.0;
-            Vector3d unityWorldPos = GetPosition() + Utils.Vector3ToVector3d(Shared.Vessel.findWorldCenterOfMass());
+            Vector3d unityWorldPos = GetPosition() + (Vector3d)Shared.Vessel.findWorldCenterOfMass();
             return parent.GetLatitude(unityWorldPos);
         }
         public double PositionToLongitude( Vector pos )
@@ -191,7 +191,7 @@ namespace kOS.Suffixed
             CelestialBody parent = Orbit.referenceBody;
             if (parent == null) //happens when this Orbitable is the Sun
                 return 0.0;
-            Vector3d unityWorldPos = GetPosition() + Utils.Vector3ToVector3d(Shared.Vessel.findWorldCenterOfMass());
+            Vector3d unityWorldPos = GetPosition() + (Vector3d)Shared.Vessel.findWorldCenterOfMass();
             return Utils.DegreeFix( parent.GetLongitude(unityWorldPos), -180.0 );
         }
         public double PositionToAltitude( Vector pos )
@@ -199,7 +199,7 @@ namespace kOS.Suffixed
             CelestialBody parent = Orbit.referenceBody;
             if (parent == null) //happens when this Orbitable is the Sun
                 return 0.0;
-            Vector3d unityWorldPos = GetPosition() + Utils.Vector3ToVector3d(Shared.Vessel.findWorldCenterOfMass());
+            Vector3d unityWorldPos = GetPosition() + (Vector3d)Shared.Vessel.findWorldCenterOfMass();
             return parent.GetAltitude(unityWorldPos);
         }
 
@@ -243,9 +243,9 @@ namespace kOS.Suffixed
                 case "BODY":
                     return new BodyTarget(Orbit.referenceBody, Shared); 
                 case "UP":
-                    return new Direction(GetUpVector().ToVector3D(), false);
+                    return new Direction(GetUpVector(), false);
                 case "NORTH":
-                    return new Direction(GetNorthVector().ToVector3D(), false);
+                    return new Direction(GetNorthVector(), false);
                 case "PROGRADE":
                     return GetPrograde();
                 case "RETROGRADE":

--- a/src/kOS/Suffixed/Part/DockingPortValue.cs
+++ b/src/kOS/Suffixed/Part/DockingPortValue.cs
@@ -21,12 +21,12 @@ namespace kOS.Suffixed.Part
             AddSuffix("AQUIREFORCE", new Suffix<float>(() => module.acquireForce));
             AddSuffix("AQUIRETORQUE", new Suffix<float>(() => module.acquireTorque));
             AddSuffix("REENGAGEDISTANCE", new Suffix<float>(() => module.minDistanceToReEngage));
-            AddSuffix("DOCKEDSHIPNAME", new Suffix<string>(() => module.vesselInfo != null ? (string) module.vesselInfo.name : string.Empty));
+            AddSuffix("DOCKEDSHIPNAME", new Suffix<string>(() => module.vesselInfo != null ? module.vesselInfo.name : string.Empty));
             AddSuffix("STATE", new Suffix<string>(() => module.state));
             AddSuffix("TARGETABLE", new Suffix<bool>(() => true));
             AddSuffix("UNDOCK", new NoArgsSuffix(() => module.Undock()));
             AddSuffix("TARGET", new NoArgsSuffix(() => module.SetAsTarget()));
-            AddSuffix("PORTFACING", new NoArgsSuffix<Direction>(() => GetPortFacing()));
+            AddSuffix("PORTFACING", new NoArgsSuffix<Direction>(GetPortFacing));
         }
 
         public override ITargetable Target
@@ -41,7 +41,7 @@ namespace kOS.Suffixed.Part
             {
                 foreach (PartModule module in part.Modules)
                 {
-                    UnityEngine.Debug.Log("Module Found: "+ module);
+                    Debug.Log("Module Found: "+ module);
                     var dockingNode = module as ModuleDockingNode;
                     if (dockingNode != null)
                     {
@@ -60,8 +60,7 @@ namespace kOS.Suffixed.Part
             // docking node for example) they can differ.
             //
             Vector3 unityVector = module.nodeTransform.rotation * Vector3.forward;
-            Vector3d kspVector = new Vector3d(unityVector.x, unityVector.y, unityVector.z); // grr why didn't squad make a constructor that does this?
-            return new Direction(kspVector, false);
+            return new Direction(unityVector, false);
         }
     }
 }

--- a/src/kOS/Suffixed/Part/PartValue.cs
+++ b/src/kOS/Suffixed/Part/PartValue.cs
@@ -84,8 +84,7 @@ namespace kOS.Suffixed.Part
         private Direction GetFacing(global::Part part)
         {
             Vector3 partUp = part.transform.rotation * Vector3.up;
-            Vector3d partUpDoubles = new Vector3d(partUp.x, partUp.y, partUp.z);
-            return new Direction(partUpDoubles,false);
+            return new Direction(partUp,false);
         }
 
         private void ControlFrom()

--- a/src/kOS/Suffixed/VectorRenderer.cs
+++ b/src/kOS/Suffixed/VectorRenderer.cs
@@ -306,7 +306,7 @@ namespace kOS.Suffixed
             {
                 case "VEC":
                 case "VECTOR":
-                    Vector = vectorValue.ToVector3D();
+                    Vector = vectorValue;
                     RenderPointCoords();
                     return true;
                 case "SHOW":
@@ -318,7 +318,7 @@ namespace kOS.Suffixed
                     RenderColor();
                     return true;
                 case "START":
-                    Start = vectorValue.ToVector3D();
+                    Start = vectorValue;
                     RenderPointCoords();
                     return true;
                 case "SCALE":

--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -103,7 +103,7 @@ namespace kOS.Suffixed
             Vector surfVel;
             if (parent != null)
             {
-                Vector3d pos = GetPositionAtUT( timeStamp ).ToVector3D();
+                Vector3d pos = GetPositionAtUT( timeStamp );
                 surfVel = new Vector( orbVel - parent.getRFrmVel( pos + Shared.Vessel.findWorldCenterOfMass()) );
             }
             else

--- a/src/kOS/Utilities/Utils.cs
+++ b/src/kOS/Utilities/Utils.cs
@@ -259,17 +259,6 @@ namespace kOS.Utilities
         }
 
         /// <summary>
-        /// Given a Vector3, construct a new Vector3D out of it.
-        /// By all rights SQUAD should have had this as a constructor in their Vector3d class.  I don't know why they didn't.
-        /// </summary>
-        /// <param name="convertFrom">The Vector3 to convert</param>
-        /// <returns>A Vector3d that has the same values as the Vector3 passed in.</returns>
-        public static Vector3d Vector3ToVector3d(Vector3 convertFrom)
-        {
-            return new Vector3d( convertFrom.x, convertFrom.y, convertFrom.z);
-        }
-
-        /// <summary>
         ///   Returns true if body a orbits body b, either directly or through
         ///   a grandparent chain.
         /// </summary>


### PR DESCRIPTION
there exists an implicit cast between ksp Vector3 and Vector3d and kos Vector and Vector3d. I have not run this in game but these should all be equivalent statements 

 This is the operator overloads in KSP's vector class 

```
public static implicit operator Vector3(Vector3d v)
{
  return new Vector3((float) v.x, (float) v.y, (float) v.z);
}

public static implicit operator Vector3d(Vector3 v)
{
  return new Vector3d((double) v.x, (double) v.y, (double) v.z);
}
```
