### PR TITLE
Fixes #393.

### DIFF
--- a/src/kOS.Safe/Exceptions/KOSPersistenceException.cs
+++ b/src/kOS.Safe/Exceptions/KOSPersistenceException.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace kOS.Safe.Exceptions
+{
+    public class KOSPersistenceException : Exception
+    {
+        public KOSPersistenceException(string message):base(message)
+        {
+        }
+
+        public string VerboseMessage
+        {
+            get { return base.Message + "\n" + "This error occurred while trying to load or save from a kOS Volume"; }
+        }
+
+        public string HelpURL
+        {
+            get { return string.Empty; }
+        }
+    }
+}

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Exceptions\KOSLookupFailException.cs" />
     <Compile Include="Exceptions\KOSParseException.cs" />
     <Compile Include="Exceptions\KOSPatchesDeprecationException.cs" />
+    <Compile Include="Exceptions\KOSPersistenceException.cs" />
     <Compile Include="Exceptions\KOSPreserveInvalidHereException.cs" />
     <Compile Include="Exceptions\KOSSuffixUseException.cs" />
     <Compile Include="Exceptions\KOSUndefinedIdentifierException.cs" />

--- a/src/kOS/Persistence/PersistenceExtensions.cs
+++ b/src/kOS/Persistence/PersistenceExtensions.cs
@@ -119,6 +119,7 @@ namespace kOS.Persistence
                 {
                     // standard encoding
                     decodedString = PersistenceUtilities.DecodeLine(input);
+                    programFile.StringContent = decodedString;
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
The real problem turned out to just one one missing line of code.  But while I was at it, I also refactored the ampersand-encoding of dangerous characters in the persistence file, which was a fix I made on the way to trying to discover the problem, because I was barking up the wrong tree at first.  But I'm reluctant to remove the change because I think the new way is superior to the old, even if it wasn't the cause of the problem.

The new ampersand-encoding system made the following change:

Old way: (a blacklist):  Assume all characters are safe to write out raw except for those which are explicitly mentioned.  Create an ad-hoc encoding that hardcodes the ampersand escape for each exception case.

New way: (a whitelist): Assume all characters are UNsafe to write out raw except for those which are explicitly mentioned.  For anything not white-listed, create a generic encoding system that works for any arbitrary character.  (It's always the HTML ampersand escape "&#____;" where the ____ is the decimal integer ordinal of the character in whatever character encoding (unicode in this case) is being used.)

Why the new way is better: With the blacklist, the consequence of forgetting to mention a character that belonged on the list is corrupted files, broken saves, etc.  But with the whitelist, the consequence of forgetting to mention a character that belonged on the list is that it still works, but there's merely a bit of unnecessary work converting into and out of the encoding.
