### PR TITLE
Fixes 417. Error now shows on nonexstent function.

### DIFF
--- a/src/kOS.Safe/Compilation/OpCode.cs
+++ b/src/kOS.Safe/Compilation/OpCode.cs
@@ -1362,7 +1362,15 @@ namespace kOS.Safe.Compilation
 
         public override void Execute(ICpu cpu)
         {
-            cpu.PopStack();
+            // Even though this value is being thrown away it's still important to attempt to
+            // process it (with cpu.PopValue()) rather than ignore it (with cpu.PopStack()).  This
+            // is just in case it's an unknown variable name in need of an error message
+            // to the user.  Detecting that a variable name is unknown occurs during the popping
+            // of the value, not the pushing of it.  (This is necessary because SET and DECLARE
+            // statements have to be allowed to push undefined variable references onto the stack
+            // for new variables that they are going to create.)
+
+            cpu.PopValue();
         }
     }
 

--- a/src/kOS/Execution/CPU.cs
+++ b/src/kOS/Execution/CPU.cs
@@ -429,6 +429,7 @@ namespace kOS.Execution
         ///   back.  If it's not a variable, return it as-is.  If it's a variable,
         ///   look it up and return that.
         /// </summary>
+        /// <param name="testvalue">the object which might be a variable name</param>
         /// <param name="barewordOkay">
         ///   Is this a case in which it's acceptable for the
         ///   variable not to exist, and if it doesn't exist then the variable name itself
@@ -479,6 +480,7 @@ namespace kOS.Execution
         /// Peek at a value atop the stack without popping it, and if it's a variable name then get its value,
         /// else just return it as it is.
         /// </summary>
+        /// <param name="digDepth">Peek at the element this far down the stack (0 means top, 1 means just under the top, etc)</param>
         /// <param name="barewordOkay">Is this a context in which it's acceptable for
         ///   a variable not existing error to occur (in which case the identifier itself
         ///   should therefore become a string object returned)?</param>


### PR DESCRIPTION
You now get the error
"Undefined Variable Name 'blarg'."
If you try to run a non-existant command or have a typo in a command, like so:

```
blarg.
```

It's not the best descriptive message, but it's better than what it did before.

Also, While I was trying to diagnose the situation, I noticed some of the xml auto-docs for the methods I was looking at were missing some param fields, so I added them.
