### PR TITLE
Fixes #421 - local corrupt files.

### DIFF
--- a/src/kOS.Safe/Persistence/PersistenceUtilities.cs
+++ b/src/kOS.Safe/Persistence/PersistenceUtilities.cs
@@ -104,7 +104,7 @@ namespace kOS.Safe.Persistence
                     if (semicolonPos < 0)
                         throw new KOSPersistenceException("Improperly encoded saved file contains '&' without closing ';'");
                     int charOrdinal;
-                    if ( ! int.TryParse(input.Substring(inputPos+2, (semicolonPos-(inputPos+3))),out charOrdinal) )
+                    if ( ! int.TryParse(input.Substring(inputPos+2, (semicolonPos-(inputPos+2))),out charOrdinal) )
                         throw new KOSPersistenceException("Improperly encoded saved file contains non-digits between the '&#' and the ';'");
                     output.Append((char)charOrdinal);
                     inputPos = semicolonPos; // skip to the end of the encoding section, as if everything between '&' and ';' was one char of input.


### PR DESCRIPTION
The final character of the encoding digits was being cut off.
i.e. space = code 32, so it is coded as:

```
&#32;
```

but it was being read with the digit 2 being dropped off, so it
got read it as if it was code 3, not 32

I have no idea why it didn't break when I tried it the first time.
This is one of those "this should never have worked, ever" sorts
of bugs.  I have no idea why it didn't break when I tried it before.
