### PR TITLE
Fix for filenames without extensions

### DIFF
--- a/src/kOS.Safe/Persistence/ProgramFile.cs
+++ b/src/kOS.Safe/Persistence/ProgramFile.cs
@@ -10,7 +10,7 @@ namespace kOS.Safe.Persistence
             get { return filename; }
             set
             {
-                filename = value;
+                filename = PersistenceUtilities.CookedFilename(value, "ks");
 
                 var fileParts = filename.Split('.');
                 Extension = fileParts.Count() > 1 ? fileParts.Last() : string.Empty;


### PR DESCRIPTION
Added a call to "CookedFilename" when initializing the FileName property
on the ProgramFile class.  This should prevent us from accidentally
creating any files without an extension, while still allowing users to
set their own extension when referring to files.  It appears to work
with all of my existing scripts on vessels, and fixes all of my boot
scripts.
