### PR TITLE
Fixes #431 by making the suffixes into vectors

### DIFF
--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -421,9 +421,9 @@ namespace kOS.Suffixed
                 case "FACING":
                     return VesselUtils.GetFacing(Vessel);
                 case "ANGULARMOMENTUM":
-                    return new Direction(Vessel.angularMomentum, true);
+                    return new Vector(Vessel.angularMomentum);
                 case "ANGULARVEL":
-                    return new Direction(Vessel.angularVelocity, true);
+                    return new Vector(Vessel.angularVelocity);
                 case "MASS":
                     return Vessel.GetTotalMass();
                 case "VERTICALSPEED":


### PR DESCRIPTION
instead of being directions.

Note, this also needs a documentation change once the
docs are done being rewritten.  There's no point in me
changing the current KOS-DOC given that it's already
obsoleted by the new version being made.

It also will need a BREAKING message in the release notes.
