### PR TITLE
Fixes #447

### DIFF
--- a/src/kOS/Screen/KOSToolBarWindow.cs
+++ b/src/kOS/Screen/KOSToolBarWindow.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using kOS.Safe.Utilities;
 using UnityEngine;
 using kOS.Utilities;
 using kOS.Suffixed;
@@ -23,7 +24,7 @@ namespace kOS.Screen
     /// does not seem to be an option.  Therefore this class has a lot of silly counters to
     /// track how many times its been instanced.
     /// </summary>
-    [KSPAddon(KSPAddon.Startup.EditorAny | KSPAddon.Startup.Flight, false)]
+    [KSPAddon(KSPAddon.Startup.EveryScene,false)]
     public class KOSToolBarWindow : MonoBehaviour
     {
         private ApplicationLauncherButton launcherButton;
@@ -94,6 +95,8 @@ namespace kOS.Screen
 
         public KOSToolBarWindow()
         {
+            // This really needs fixing - the name ambiguity between UnityEngine's Debug and ours forces this long fully qualified name:
+            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolbarWindow: PROOF that constructor was called.");
             launcherButtonTexture = new Texture2D(0, 0, TextureFormat.DXT1, false);
             terminalClosedIconTexture = new Texture2D(0, 0, TextureFormat.DXT1, false);
             terminalOpenIconTexture = new Texture2D(0, 0, TextureFormat.DXT1, false);
@@ -107,7 +110,7 @@ namespace kOS.Screen
         {
             ++countInstances;
             myInstanceNum = countInstances;
-            Debug.Log("KOSToolBarWindow: Now making instance number "+myInstanceNum+" of KOSToolBarWindow");
+            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: Now making instance number "+myInstanceNum+" of KOSToolBarWindow");
 
             const string LAUNCHER_BUTTON_PNG = "GameData/kOS/GFX/launcher-button.png";
             const string TERMINAL_OPEN_ICON_PNG = "GameData/kOS/GFX/terminal-icon-open.png";
@@ -129,11 +132,11 @@ namespace kOS.Screen
             GameEvents.onGUIApplicationLauncherReady.Add(RunWhenReady);
             GameEvents.onGUIApplicationLauncherDestroyed.Add(GoAway);
         }
-        
-        public void Awake()
+
+        public void Start()
         {
-            // Awake gets called a stupid number of times.  This
-            // ensures only one of them per instance actually happens:
+            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolbarWindow: PROOF that Start() was called.");
+            // Prevent multiple calls of this:
             if (alreadyAwake) return;
             alreadyAwake = true;
 
@@ -142,7 +145,7 @@ namespace kOS.Screen
         
         public void RunWhenReady()
         {
-            Debug.Log("KOSToolBarWindow: Instance number " + myInstanceNum + " is trying to ready the hooks");
+            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: Instance number " + myInstanceNum + " is trying to ready the hooks");
             // KSP claims the hook ApplicationLauncherReady.Add will not run until
             // the application is ready, even though this is emphatically false.  It actually
             // fires the event a few times before the one that "sticks" and works:
@@ -151,7 +154,7 @@ namespace kOS.Screen
             thisInstanceHasHooks = true;
             someInstanceHasHooks = true;
             
-            Debug.Log("KOSToolBarWindow: Instance number " + myInstanceNum + " will now actually make its hooks");
+            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: Instance number " + myInstanceNum + " will now actually make its hooks");
             ApplicationLauncher launcher = ApplicationLauncher.Instance;
             
             launcherButton = launcher.AddModApplication(
@@ -171,10 +174,10 @@ namespace kOS.Screen
         
         public void GoAway()
         {
-            Debug.Log("KOSToolBarWindow: PROOF: Instance " + myInstanceNum + " is in GoAway().");
+            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: Instance " + myInstanceNum + " is in GoAway().");
             if (thisInstanceHasHooks)
             {
-                Debug.Log("KOSToolBarWindow: PROOF: Instance " + myInstanceNum + " has hooks and is entering the guts of GoAway().");
+                kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: Instance " + myInstanceNum + " has hooks and is entering the guts of GoAway().");
                 if (isOpen) Close();
                 clickedOn = false;
                 thisInstanceHasHooks = false;
@@ -199,7 +202,7 @@ namespace kOS.Screen
         /// <summary>Callback for when the button is toggled on</summary>
         public void CallbackOnTrue()
         {
-            Debug.Log("KOSToolBarWindow: PROOF: CallbackOnTrue()");
+            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnTrue()");
             clickedOn = true;
             Open();
         }
@@ -207,7 +210,7 @@ namespace kOS.Screen
         /// <summary>Callback for when the button is toggled off</summary>
         public void CallbackOnFalse()
         {            
-            Debug.Log("KOSToolBarWindow: PROOF: CallbackOnFalse()");
+            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnFalse()");
             clickedOn = false;
             Close();
         }
@@ -215,7 +218,7 @@ namespace kOS.Screen
         /// <summary>Callback for when the mouse is hovering over the button</summary>
         public void CallbackOnHover()
         {            
-            Debug.Log("KOSToolBarWindow: PROOF: CallbackOnHover()");
+            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnHover()");
             if (!clickedOn)
                 Open();
         }
@@ -223,7 +226,7 @@ namespace kOS.Screen
         /// <summary>Callback for when the mouse is hover is off the button</summary>
         public void CallbackOnHoverOut()
         {            
-            Debug.Log("KOSToolBarWindow: PROOF: CallbackOnHoverOut()");
+            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnHoverOut()");
             if (!clickedOn)
                 Close();
         }
@@ -231,7 +234,7 @@ namespace kOS.Screen
         /// <summary>Callback for when the mouse is hovering over the button</summary>
         public void CallbackOnShow()
         {            
-            Debug.Log("KOSToolBarWindow: PROOF: CallbackOnShow()");
+            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnShow()");
             if (!clickedOn && !isOpen)
                 Open();
         }
@@ -239,7 +242,7 @@ namespace kOS.Screen
         /// <summary>Callback for when the mouse is hover is off the button</summary>
         public void CallbackOnHide()
         {            
-            Debug.Log("KOSToolBarWindow: PROOF: CallbackOnHide()");
+            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnHide()");
             if (!clickedOn && isOpen)
             {
                 Close();
@@ -249,7 +252,7 @@ namespace kOS.Screen
         
         public void Open()
         {
-            Debug.Log("KOSToolBarWindow: PROOF: Open()");
+            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: Open()");
             
             bool isTop = ApplicationLauncher.Instance.IsPositionedAtTop;
 
@@ -263,14 +266,14 @@ namespace kOS.Screen
             float topEdge = isTop ? (40f) : (UnityEngine.Screen.height - (height+40) );
             
             windowRect = new Rect(leftEdge, topEdge, 0, 0); // will resize upon first GUILayout-ing.
-            Debug.Log("KOSToolBarWindow: PROOF: Open(), windowRect = " + windowRect);
+            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: Open(), windowRect = " + windowRect);
             
             isOpen = true;
         }
 
         public void Close()
         {
-            Debug.Log("KOSToolBarWindow: PROOF: Close()");
+            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: Close()");
             if (! isOpen)
                 return;
 
@@ -280,14 +283,14 @@ namespace kOS.Screen
         /// <summary>Callback for when the button is shown or enabled by the application launcher</summary>
         public void CallbackOnEnable()
         {
-            Debug.Log("KOSToolBarWindow: PROOF: CallbackOnEnable()");
+            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnEnable()");
             // do nothing, but leaving the hook here as a way to document "this thing exists and might be used".
         }
         
         /// <summary>Callback for when the button is hidden or disabled by the application launcher</summary>
         public void CallbackOnDisable()
         {            
-            Debug.Log("KOSToolBarWindow: PROOF: CallbackOnDisable()");
+            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnDisable()");
             // do nothing, but leaving the hook here as a way to document "this thing exists and might be used".
         }
         
@@ -299,7 +302,7 @@ namespace kOS.Screen
 
             if (!onGUICalledThisInstance) // I want proof it was called, but without spamming the log:
             {
-                Debug.Log("KOSToolBarWindow: PROOF: OnGUI() was called at least once on instance number " + myInstanceNum);
+                kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: OnGUI() was called at least once on instance number " + myInstanceNum);
                 onGUICalledThisInstance = true;
             }
             
@@ -307,7 +310,7 @@ namespace kOS.Screen
 
             if (!onGUIWasOpenThisInstance) // I want proof it was called, but without spamming the log:
             {
-                Debug.Log("KOSToolBarWindow: PROOF: OnGUI() was called while the window was supposed to be open at least once on instance number " + myInstanceNum);
+                kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: OnGUI() was called while the window was supposed to be open at least once on instance number " + myInstanceNum);
                 onGUIWasOpenThisInstance = true;
             }
             
@@ -550,7 +553,7 @@ namespace kOS.Screen
         private void CountBeginVertical(string debugHelp="")
         {
             if (! String.IsNullOrEmpty(debugHelp))
-                Debug.Log("BeginVertical(\""+debugHelp+"\") Nest "+verticalSectionCount);
+                kOS.Safe.Utilities.Debug.Logger.SuperVerbose("BeginVertical(\""+debugHelp+"\") Nest "+verticalSectionCount);
             GUILayout.BeginVertical();
             ++verticalSectionCount;
         }
@@ -563,7 +566,7 @@ namespace kOS.Screen
             GUILayout.EndVertical();
             --verticalSectionCount;            
             if (! String.IsNullOrEmpty(debugHelp))
-                Debug.Log("EndVertical(\""+debugHelp+"\") Nest "+verticalSectionCount);
+                kOS.Safe.Utilities.Debug.Logger.SuperVerbose("EndVertical(\""+debugHelp+"\") Nest "+verticalSectionCount);
         }
         
         // Tracking the count to help detect when there's a mismatch:
@@ -572,7 +575,7 @@ namespace kOS.Screen
         private void CountBeginHorizontal(string debugHelp="")
         {
             if (! String.IsNullOrEmpty(debugHelp))
-                Debug.Log("BeginHorizontal(\""+debugHelp+"\"): Nest "+horizontalSectionCount);
+                kOS.Safe.Utilities.Debug.Logger.SuperVerbose("BeginHorizontal(\""+debugHelp+"\"): Nest "+horizontalSectionCount);
             GUILayout.BeginHorizontal();
             ++horizontalSectionCount;
         }
@@ -585,7 +588,7 @@ namespace kOS.Screen
             GUILayout.EndHorizontal();
             --horizontalSectionCount;            
             if (! String.IsNullOrEmpty(debugHelp))
-                Debug.Log("EndHorizontal(\""+debugHelp+"\"): Nest "+horizontalSectionCount);
+                kOS.Safe.Utilities.Debug.Logger.SuperVerbose("EndHorizontal(\""+debugHelp+"\"): Nest "+horizontalSectionCount);
         }
         
         


### PR DESCRIPTION
The problem is that I was using the states of the game as a bitfield, when
they aren't in fact set up as a bitfield (the values don't go 1,2,4,8,16, etc).

I was trying to set up the applauncher to trigger on EditorAny|Flight, but
you can't bit-OR them like that to get that effect.  SQUAD didn't design them
that way.

So now it just activates in ALL scenes, since it only has to run the setup
once, and then after that it will suppress its own Start() behavior on all
additional activations.
