### PR TITLE
fixed warning from skin creation and make sure that MM shows us with the correct version

### DIFF
--- a/src/kOS/Properties/AssemblyInfo.cs
+++ b/src/kOS/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("0.15.4.0")]
+[assembly: AssemblyVersion("0.15.4.0")]
 [assembly: KSPAssembly("kOS", 0, 15)]

--- a/src/kOS/Screen/KOSToolBarWindow.cs
+++ b/src/kOS/Screen/KOSToolBarWindow.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using kOS.Safe.Utilities;
 using UnityEngine;
 using kOS.Utilities;
 using kOS.Suffixed;
@@ -96,7 +95,7 @@ namespace kOS.Screen
         public KOSToolBarWindow()
         {
             // This really needs fixing - the name ambiguity between UnityEngine's Debug and ours forces this long fully qualified name:
-            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolbarWindow: PROOF that constructor was called.");
+            Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolbarWindow: PROOF that constructor was called.");
             launcherButtonTexture = new Texture2D(0, 0, TextureFormat.DXT1, false);
             terminalClosedIconTexture = new Texture2D(0, 0, TextureFormat.DXT1, false);
             terminalOpenIconTexture = new Texture2D(0, 0, TextureFormat.DXT1, false);
@@ -110,7 +109,7 @@ namespace kOS.Screen
         {
             ++countInstances;
             myInstanceNum = countInstances;
-            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: Now making instance number "+myInstanceNum+" of KOSToolBarWindow");
+            Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: Now making instance number "+myInstanceNum+" of KOSToolBarWindow");
 
             const string LAUNCHER_BUTTON_PNG = "GameData/kOS/GFX/launcher-button.png";
             const string TERMINAL_OPEN_ICON_PNG = "GameData/kOS/GFX/terminal-icon-open.png";
@@ -135,7 +134,7 @@ namespace kOS.Screen
 
         public void Start()
         {
-            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolbarWindow: PROOF that Start() was called.");
+            Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolbarWindow: PROOF that Start() was called.");
             // Prevent multiple calls of this:
             if (alreadyAwake) return;
             alreadyAwake = true;
@@ -145,7 +144,7 @@ namespace kOS.Screen
         
         public void RunWhenReady()
         {
-            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: Instance number " + myInstanceNum + " is trying to ready the hooks");
+            Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: Instance number " + myInstanceNum + " is trying to ready the hooks");
             // KSP claims the hook ApplicationLauncherReady.Add will not run until
             // the application is ready, even though this is emphatically false.  It actually
             // fires the event a few times before the one that "sticks" and works:
@@ -154,7 +153,7 @@ namespace kOS.Screen
             thisInstanceHasHooks = true;
             someInstanceHasHooks = true;
             
-            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: Instance number " + myInstanceNum + " will now actually make its hooks");
+            Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: Instance number " + myInstanceNum + " will now actually make its hooks");
             ApplicationLauncher launcher = ApplicationLauncher.Instance;
             
             launcherButton = launcher.AddModApplication(
@@ -174,10 +173,10 @@ namespace kOS.Screen
         
         public void GoAway()
         {
-            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: Instance " + myInstanceNum + " is in GoAway().");
+            Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: Instance " + myInstanceNum + " is in GoAway().");
             if (thisInstanceHasHooks)
             {
-                kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: Instance " + myInstanceNum + " has hooks and is entering the guts of GoAway().");
+                Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: Instance " + myInstanceNum + " has hooks and is entering the guts of GoAway().");
                 if (isOpen) Close();
                 clickedOn = false;
                 thisInstanceHasHooks = false;
@@ -202,7 +201,7 @@ namespace kOS.Screen
         /// <summary>Callback for when the button is toggled on</summary>
         public void CallbackOnTrue()
         {
-            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnTrue()");
+            Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnTrue()");
             clickedOn = true;
             Open();
         }
@@ -210,7 +209,7 @@ namespace kOS.Screen
         /// <summary>Callback for when the button is toggled off</summary>
         public void CallbackOnFalse()
         {            
-            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnFalse()");
+            Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnFalse()");
             clickedOn = false;
             Close();
         }
@@ -218,7 +217,7 @@ namespace kOS.Screen
         /// <summary>Callback for when the mouse is hovering over the button</summary>
         public void CallbackOnHover()
         {            
-            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnHover()");
+            Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnHover()");
             if (!clickedOn)
                 Open();
         }
@@ -226,7 +225,7 @@ namespace kOS.Screen
         /// <summary>Callback for when the mouse is hover is off the button</summary>
         public void CallbackOnHoverOut()
         {            
-            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnHoverOut()");
+            Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnHoverOut()");
             if (!clickedOn)
                 Close();
         }
@@ -234,7 +233,7 @@ namespace kOS.Screen
         /// <summary>Callback for when the mouse is hovering over the button</summary>
         public void CallbackOnShow()
         {            
-            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnShow()");
+            Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnShow()");
             if (!clickedOn && !isOpen)
                 Open();
         }
@@ -242,7 +241,7 @@ namespace kOS.Screen
         /// <summary>Callback for when the mouse is hover is off the button</summary>
         public void CallbackOnHide()
         {            
-            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnHide()");
+            Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnHide()");
             if (!clickedOn && isOpen)
             {
                 Close();
@@ -252,7 +251,7 @@ namespace kOS.Screen
         
         public void Open()
         {
-            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: Open()");
+            Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: Open()");
             
             bool isTop = ApplicationLauncher.Instance.IsPositionedAtTop;
 
@@ -266,14 +265,14 @@ namespace kOS.Screen
             float topEdge = isTop ? (40f) : (UnityEngine.Screen.height - (height+40) );
             
             windowRect = new Rect(leftEdge, topEdge, 0, 0); // will resize upon first GUILayout-ing.
-            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: Open(), windowRect = " + windowRect);
+            Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: Open(), windowRect = " + windowRect);
             
             isOpen = true;
         }
 
         public void Close()
         {
-            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: Close()");
+            Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: Close()");
             if (! isOpen)
                 return;
 
@@ -283,14 +282,14 @@ namespace kOS.Screen
         /// <summary>Callback for when the button is shown or enabled by the application launcher</summary>
         public void CallbackOnEnable()
         {
-            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnEnable()");
+            Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnEnable()");
             // do nothing, but leaving the hook here as a way to document "this thing exists and might be used".
         }
         
         /// <summary>Callback for when the button is hidden or disabled by the application launcher</summary>
         public void CallbackOnDisable()
         {            
-            kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnDisable()");
+            Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: CallbackOnDisable()");
             // do nothing, but leaving the hook here as a way to document "this thing exists and might be used".
         }
         
@@ -302,7 +301,7 @@ namespace kOS.Screen
 
             if (!onGUICalledThisInstance) // I want proof it was called, but without spamming the log:
             {
-                kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: OnGUI() was called at least once on instance number " + myInstanceNum);
+                Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: OnGUI() was called at least once on instance number " + myInstanceNum);
                 onGUICalledThisInstance = true;
             }
             
@@ -310,7 +309,7 @@ namespace kOS.Screen
 
             if (!onGUIWasOpenThisInstance) // I want proof it was called, but without spamming the log:
             {
-                kOS.Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: OnGUI() was called while the window was supposed to be open at least once on instance number " + myInstanceNum);
+                Safe.Utilities.Debug.Logger.SuperVerbose("KOSToolBarWindow: PROOF: OnGUI() was called while the window was supposed to be open at least once on instance number " + myInstanceNum);
                 onGUIWasOpenThisInstance = true;
             }
             
@@ -551,7 +550,7 @@ namespace kOS.Screen
         private void CountBeginVertical(string debugHelp="")
         {
             if (! String.IsNullOrEmpty(debugHelp))
-                kOS.Safe.Utilities.Debug.Logger.SuperVerbose("BeginVertical(\""+debugHelp+"\") Nest "+verticalSectionCount);
+                Safe.Utilities.Debug.Logger.SuperVerbose("BeginVertical(\""+debugHelp+"\") Nest "+verticalSectionCount);
             GUILayout.BeginVertical();
             ++verticalSectionCount;
         }
@@ -564,7 +563,7 @@ namespace kOS.Screen
             GUILayout.EndVertical();
             --verticalSectionCount;            
             if (! String.IsNullOrEmpty(debugHelp))
-                kOS.Safe.Utilities.Debug.Logger.SuperVerbose("EndVertical(\""+debugHelp+"\") Nest "+verticalSectionCount);
+                Safe.Utilities.Debug.Logger.SuperVerbose("EndVertical(\""+debugHelp+"\") Nest "+verticalSectionCount);
         }
         
         // Tracking the count to help detect when there's a mismatch:
@@ -573,7 +572,7 @@ namespace kOS.Screen
         private void CountBeginHorizontal(string debugHelp="")
         {
             if (! String.IsNullOrEmpty(debugHelp))
-                kOS.Safe.Utilities.Debug.Logger.SuperVerbose("BeginHorizontal(\""+debugHelp+"\"): Nest "+horizontalSectionCount);
+                Safe.Utilities.Debug.Logger.SuperVerbose("BeginHorizontal(\""+debugHelp+"\"): Nest "+horizontalSectionCount);
             GUILayout.BeginHorizontal();
             ++horizontalSectionCount;
         }
@@ -586,7 +585,7 @@ namespace kOS.Screen
             GUILayout.EndHorizontal();
             --horizontalSectionCount;            
             if (! String.IsNullOrEmpty(debugHelp))
-                kOS.Safe.Utilities.Debug.Logger.SuperVerbose("EndHorizontal(\""+debugHelp+"\"): Nest "+horizontalSectionCount);
+                Safe.Utilities.Debug.Logger.SuperVerbose("EndHorizontal(\""+debugHelp+"\"): Nest "+horizontalSectionCount);
         }
         
         

--- a/src/kOS/Utilities/Utils.cs
+++ b/src/kOS/Utilities/Utils.cs
@@ -202,32 +202,32 @@ namespace kOS.Utilities
             // causes this next block of code.  It's starting off theSkin as a deep
             // copy of HighLogic.Skin, at least as much as it can:
             //
-            return new GUISkin
-            {
-                // This is literally every GUISTyle mentioned in Unity's documention for
-                // GUISkin, as of 11/11/2014.  If Unity updates these, we could be screwed:
-                //
-                box = new GUIStyle(toCopy.box),
-                button = new GUIStyle(toCopy.button),
-                horizontalScrollbar = new GUIStyle(toCopy.horizontalScrollbar),
-                horizontalScrollbarLeftButton = new GUIStyle(toCopy.horizontalScrollbarLeftButton),
-                horizontalScrollbarRightButton = new GUIStyle(toCopy.horizontalScrollbarRightButton),
-                horizontalScrollbarThumb = new GUIStyle(toCopy.horizontalScrollbarThumb),
-                horizontalSlider = new GUIStyle(toCopy.horizontalSlider),
-                horizontalSliderThumb = new GUIStyle(toCopy.horizontalSliderThumb),
-                label = new GUIStyle(toCopy.label),
-                scrollView = new GUIStyle(toCopy.scrollView),
-                textArea = new GUIStyle(toCopy.textArea),
-                textField = new GUIStyle(toCopy.textField),
-                toggle = new GUIStyle(toCopy.toggle),
-                verticalScrollbar = new GUIStyle(toCopy.verticalScrollbar),
-                verticalScrollbarDownButton = new GUIStyle(toCopy.verticalScrollbarDownButton),
-                verticalScrollbarThumb = new GUIStyle(toCopy.verticalScrollbarThumb),
-                verticalScrollbarUpButton = new GUIStyle(toCopy.verticalScrollbarUpButton),
-                verticalSlider = new GUIStyle(toCopy.verticalSlider),
-                verticalSliderThumb = new GUIStyle(toCopy.verticalSliderThumb),
-                window = new GUIStyle(toCopy.window),
-            };
+            var skin = ScriptableObject.CreateInstance<GUISkin>();
+
+            // This is literally every GUISTyle mentioned in Unity's documention for
+            // GUISkin, as of 11/11/2014.  If Unity updates these, we could be screwed:
+            //
+            skin.box = new GUIStyle(toCopy.box);
+            skin.button = new GUIStyle(toCopy.button);
+            skin.horizontalScrollbar = new GUIStyle(toCopy.horizontalScrollbar);
+            skin.horizontalScrollbarLeftButton = new GUIStyle(toCopy.horizontalScrollbarLeftButton);
+            skin.horizontalScrollbarRightButton = new GUIStyle(toCopy.horizontalScrollbarRightButton);
+            skin.horizontalScrollbarThumb = new GUIStyle(toCopy.horizontalScrollbarThumb);
+            skin.horizontalSlider = new GUIStyle(toCopy.horizontalSlider);
+            skin.horizontalSliderThumb = new GUIStyle(toCopy.horizontalSliderThumb);
+            skin.label = new GUIStyle(toCopy.label);
+            skin.scrollView = new GUIStyle(toCopy.scrollView);
+            skin.textArea = new GUIStyle(toCopy.textArea);
+            skin.textField = new GUIStyle(toCopy.textField);
+            skin.toggle = new GUIStyle(toCopy.toggle);
+            skin.verticalScrollbar = new GUIStyle(toCopy.verticalScrollbar);
+            skin.verticalScrollbarDownButton = new GUIStyle(toCopy.verticalScrollbarDownButton);
+            skin.verticalScrollbarThumb = new GUIStyle(toCopy.verticalScrollbarThumb);
+            skin.verticalScrollbarUpButton = new GUIStyle(toCopy.verticalScrollbarUpButton);
+            skin.verticalSlider = new GUIStyle(toCopy.verticalSlider);
+            skin.verticalSliderThumb = new GUIStyle(toCopy.verticalSliderThumb);
+            skin.window = new GUIStyle(toCopy.window);
+            return skin;
         }
 
         /// <summary>


### PR DESCRIPTION
most of this is just pruning the kOS. off of some logging

the skin creation change came from a warning that we were getting in the log #410 
the file version change is because that is the version ModuleManager reports on. it would be nice to show up correctly there