### PR TITLE
Add AGX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,3 @@ Addon release thread: http://forum.kerbalspaceprogram.com/threads/68089-0-23-kOS
 
 Addon development thread: http://forum.kerbalspaceprogram.com/threads/68096-kOS-Autopilot
 
-
-This fork for adding Action Group Extended support.

--- a/README.md
+++ b/README.md
@@ -8,3 +8,6 @@ Documentation : http://ksp-kos.github.io/KOS_DOC/
 Addon release thread: http://forum.kerbalspaceprogram.com/threads/68089-0-23-kOS-Scriptable-Autopilot-System-v0-11-2-13
 
 Addon development thread: http://forum.kerbalspaceprogram.com/threads/68096-kOS-Autopilot
+
+
+This fork for adding Action Group Extended support.

--- a/src/kOS/AddOns/ActionGroupsExtended/ActionGroupsExtendedAPI.cs
+++ b/src/kOS/AddOns/ActionGroupsExtended/ActionGroupsExtendedAPI.cs
@@ -53,7 +53,7 @@ namespace kOS.AddOns.ActionGroupsExtended
         /// </summary>
         /// <param name="vessel">The vessel that will catch the action</param>
         /// <param name="group">A ActionGroup number from 11-251</param>
-        /// <returns>The Action group state</returns>
+        /// <returns>Did the action execute? If yes, return True</returns>
         public bool GetGroupState(Vessel vessel, int group)
         {
             var args = new System.Object[] {vessel.rootPart.flightID, group};

--- a/src/kOS/AddOns/ActionGroupsExtended/ActionGroupsExtendedAPI.cs
+++ b/src/kOS/AddOns/ActionGroupsExtended/ActionGroupsExtendedAPI.cs
@@ -41,7 +41,7 @@ namespace kOS.AddOns.ActionGroupsExtended
         /// <param name="vessel">The vessel that will catch the action</param>
         /// <param name="group">A ActionGroup number from 11-251</param>
         /// <param name="forceDir">The value you want to set the action group to</param>
-        /// <returns>The Action group state</returns>
+        /// <returns>Did the action execute? If yes, return True</returns>
         public bool ActivateGroup(Vessel vessel, int group, bool forceDir) //activate/deactivate an action group
         {
             var args = new System.Object[] {vessel.rootPart.flightID, group, forceDir};

--- a/src/kOS/AddOns/ActionGroupsExtended/ActionGroupsExtendedAPI.cs
+++ b/src/kOS/AddOns/ActionGroupsExtended/ActionGroupsExtendedAPI.cs
@@ -53,7 +53,7 @@ namespace kOS.AddOns.ActionGroupsExtended
         /// </summary>
         /// <param name="vessel">The vessel that will catch the action</param>
         /// <param name="group">A ActionGroup number from 11-251</param>
-        /// <returns>Did the action execute? If yes, return True</returns>
+        /// <returns>The group's state. </returns>
         public bool GetGroupState(Vessel vessel, int group)
         {
             var args = new System.Object[] {vessel.rootPart.flightID, group};


### PR DESCRIPTION
Add AG11 through AG250 get/set commands.
Does not support group names
Requires AGX Version 1.29 or newer
No clue on how documentation should update for this.