### PR TITLE
Gimbal struct

### DIFF
--- a/doc/source/structures.rst
+++ b/doc/source/structures.rst
@@ -27,6 +27,7 @@ A general discussion of structures :ref:`can be found here <language structures>
     * :struct:`Engine`
     * :struct:`AggregateResource`
     * :struct:`DockingPort`
+    * :struct:`Gimbal`
     * :struct:`Part`
     * :struct:`PartModule`
     * :struct:`Sensor`

--- a/doc/source/structures/vessels/gimbal.rst
+++ b/doc/source/structures/vessels/gimbal.rst
@@ -1,12 +1,12 @@
-.. _dockingport:
+.. _gimbal:
 
-DockingPort
-===========
+Gimbal
+======
 
-Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type :struct:`DockingPort`.
+Many engines in KSP have thrust vectoring gimbals and in ksp they are their own module
 
 
-.. structure:: DockingPort
+.. structure:: Gimbal
 
     .. list-table::
         :header-rows: 1
@@ -16,116 +16,69 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type :
           - Type
           - Description
 
-        * - All suffixes of :struct:`Part`
-          -
-          - A :struct:`DockingPort` is a kind of :struct:`Part`
+        * - :attr:`RANGE`
+          - scalar
+          - The Gimbal's Possible Range of movement
 
-        * - :attr:`AQUIRERANGE`
+        * - :attr:`RESPONSESPEED`
           - scalar
-          - active range of the port
-        * - :attr:`AQUIREFORCE`
+          - The Gimbal's Possible Rate of travel
+
+        * - :attr:`PITCHANGLE`
           - scalar
-          - force experienced when docking
-        * - :attr:`AQUIRETORQUE`
+          - Current Gimbal Pitch 
+		  
+        * - :attr:`YAWANGLE`
           - scalar
-          - torque experienced when docking
-        * - :attr:`REENGAGEDDISTANCE`
+          - Current Gimbal Yaw 
+		  
+        * - :attr:`ROLLANGLE`
           - scalar
-          - distance at which the port is reset
-        * - :attr:`DOCKEDSHIPNAME`
-          - string
-          - name of vessel the port is docked to
-        * - :attr:`PORTFACING`
-          - :struct:`Direction`
-          - facing of the port
-        * - :attr:`STATE`
-          - string
-          - current state of the port
-        * - :meth:`UNDOCK`
-          - 
-          - callable to release the dock
-        * - :attr:`TARGETABLE`
+          - Current Gimbal Roll 
+		  
+        * - :attr:`LOCK`
           - boolean
-          - check if this port can be targeted
-
-.. note::
-
-    :struct:`DockingPort` is a type of :struct:`Part`, and therefore can use all the suffixes of :struct:`Part`. Shown below are only the suffixes that are unique to :struct:`DockingPort`.
-
-
-.. attribute:: DockingPort:AQUIRERANGE
+          - Is the gimbal free to travel? 
+		  
+.. attribute:: Gimbal:RANGE
 
     :type: scalar
     :access: Get only
 
-    gets the range at which the port will "notice" another port and pull on it.
+    The maximum extent of travel possible for the gimbal along all 3 axis (Pitch, Yaw, Roll) 
 
-.. attribute:: DockingPort:AQUIREFORCE
-
-    :type: scalar
-    :access: Get only
-
-    gets the force with which the port pulls on another port.
-
-.. attribute:: DockingPort:AQUIRETORQUE
+.. attribute:: Gimbal:RESPONSESPEED
 
     :type: scalar
     :access: Get only
 
-    gets the rotational force with which the port pulls on another port.
+    A Measure of the rate of travel for the gimbal
 
-.. attribute:: DockingPort:REENGAGEDDISTANCE
+.. attribute:: Gimbal:PITCHANGLE
 
     :type: scalar
     :access: Get only
 
-    how far the port has to get away after undocking in order to re-enable docking.
+    The gimbals current pitch, has a range of -1 to 1. Will always be 0 when LOCK is true
 
-.. attribute:: DockingPort:DOCKEDSHIPNAME
+.. attribute:: Gimbal:YAWANGLE
+
+    :type: scalar
+    :access: Get only
+
+    The gimbals current yaw, has a range of -1 to 1. Will always be 0 when LOCK is true
+
+.. attribute:: Gimbal:ROLLANGLE
+
+    :type: scalar
+    :access: Get only
+
+    The gimbals current roll, has a range of -1 to 1. Will always be 0 when LOCK is true
+
+.. attribute:: Gimbal:LOCK
 
     :type: string
-    :access: Get only
-
-    name of vessel on the other side of the docking port.
-
-.. attribute:: DockingPort:PORTFACING
-
-    :type: :struct:`Direction`
-    :access: Get only
-
-    Gets the facing of this docking port which may differ from the facing of the part itself if the docking port is aimed out the side of the part, as in the case of the inline shielded docking port.
-
-.. attribute:: DockingPort:STATE
-
-    :type: string
-    :access: Get only
-
-    One of the following string values:
-
-    ``Ready``
-        Docking port is not yet attached and will attach if it touches another.
-    ``Docked (docker)``
-        One port in the joined pair is called the docker, and has this state
-    ``Docked (dockee)``
-        One port in the joined pair is called the dockee, and has this state
-    ``Docked (same vessel)``
-        Sometimes KSP says this instead. It's unclear what it means.
-    ``Disabled``
-        Docking port will refuse to dock if it bumps another docking port.
-    ``PreAttached``
-        Temporary state during the "wobbling" while two ports are magnetically touching but not yet docked solidly. During this state the two vessels are still tracked as separate vessels and haven't become one yet.
-
-
-.. method:: DockingPort:UNDOCK
-
-    Call this to cause the docking port to detach.
-
-.. attribute:: DockingPort:TARGETABLE
-
-    :type: boolean
-    :access: Get only
-
-    True if this part can be picked with ``SET TARGET TO``.
-
-
+    :access: Get/Set
+        
+    Can this Gimbal produce torque right now, when you set it to false it will snap the engine back to 0s for pitch,yaw and roll
 

--- a/doc/source/structures/vessels/gimbal.rst
+++ b/doc/source/structures/vessels/gimbal.rst
@@ -1,0 +1,131 @@
+.. _dockingport:
+
+DockingPort
+===========
+
+Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type :struct:`DockingPort`.
+
+
+.. structure:: DockingPort
+
+    .. list-table::
+        :header-rows: 1
+        :widths: 2 1 4
+
+        * - Suffix
+          - Type
+          - Description
+
+        * - All suffixes of :struct:`Part`
+          -
+          - A :struct:`DockingPort` is a kind of :struct:`Part`
+
+        * - :attr:`AQUIRERANGE`
+          - scalar
+          - active range of the port
+        * - :attr:`AQUIREFORCE`
+          - scalar
+          - force experienced when docking
+        * - :attr:`AQUIRETORQUE`
+          - scalar
+          - torque experienced when docking
+        * - :attr:`REENGAGEDDISTANCE`
+          - scalar
+          - distance at which the port is reset
+        * - :attr:`DOCKEDSHIPNAME`
+          - string
+          - name of vessel the port is docked to
+        * - :attr:`PORTFACING`
+          - :struct:`Direction`
+          - facing of the port
+        * - :attr:`STATE`
+          - string
+          - current state of the port
+        * - :meth:`UNDOCK`
+          - 
+          - callable to release the dock
+        * - :attr:`TARGETABLE`
+          - boolean
+          - check if this port can be targeted
+
+.. note::
+
+    :struct:`DockingPort` is a type of :struct:`Part`, and therefore can use all the suffixes of :struct:`Part`. Shown below are only the suffixes that are unique to :struct:`DockingPort`.
+
+
+.. attribute:: DockingPort:AQUIRERANGE
+
+    :type: scalar
+    :access: Get only
+
+    gets the range at which the port will "notice" another port and pull on it.
+
+.. attribute:: DockingPort:AQUIREFORCE
+
+    :type: scalar
+    :access: Get only
+
+    gets the force with which the port pulls on another port.
+
+.. attribute:: DockingPort:AQUIRETORQUE
+
+    :type: scalar
+    :access: Get only
+
+    gets the rotational force with which the port pulls on another port.
+
+.. attribute:: DockingPort:REENGAGEDDISTANCE
+
+    :type: scalar
+    :access: Get only
+
+    how far the port has to get away after undocking in order to re-enable docking.
+
+.. attribute:: DockingPort:DOCKEDSHIPNAME
+
+    :type: string
+    :access: Get only
+
+    name of vessel on the other side of the docking port.
+
+.. attribute:: DockingPort:PORTFACING
+
+    :type: :struct:`Direction`
+    :access: Get only
+
+    Gets the facing of this docking port which may differ from the facing of the part itself if the docking port is aimed out the side of the part, as in the case of the inline shielded docking port.
+
+.. attribute:: DockingPort:STATE
+
+    :type: string
+    :access: Get only
+
+    One of the following string values:
+
+    ``Ready``
+        Docking port is not yet attached and will attach if it touches another.
+    ``Docked (docker)``
+        One port in the joined pair is called the docker, and has this state
+    ``Docked (dockee)``
+        One port in the joined pair is called the dockee, and has this state
+    ``Docked (same vessel)``
+        Sometimes KSP says this instead. It's unclear what it means.
+    ``Disabled``
+        Docking port will refuse to dock if it bumps another docking port.
+    ``PreAttached``
+        Temporary state during the "wobbling" while two ports are magnetically touching but not yet docked solidly. During this state the two vessels are still tracked as separate vessels and haven't become one yet.
+
+
+.. method:: DockingPort:UNDOCK
+
+    Call this to cause the docking port to detach.
+
+.. attribute:: DockingPort:TARGETABLE
+
+    :type: boolean
+    :access: Get only
+
+    True if this part can be picked with ``SET TARGET TO``.
+
+
+

--- a/src/kOS/Suffixed/Part/EngineValue.cs
+++ b/src/kOS/Suffixed/Part/EngineValue.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using kOS.Safe.Encapsulation.Part;
 using kOS.Safe.Encapsulation.Suffixes;
-using kOS.Safe.Utilities;
 
 namespace kOS.Suffixed.Part
 {

--- a/src/kOS/Suffixed/Part/GimbalValue.cs
+++ b/src/kOS/Suffixed/Part/GimbalValue.cs
@@ -1,0 +1,35 @@
+﻿using kOS.Safe.Encapsulation.Suffixes;
+
+namespace kOS.Suffixed.Part
+{
+    public class GimbalValue : PartValue
+    {
+        private readonly ModuleGimbal gimbal;
+
+        public GimbalValue(ModuleGimbal gimbal, SharedObjects sharedObj):base(gimbal.part, sharedObj)
+        {
+            this.gimbal = gimbal;
+            InitializeGimbalSuffixes();
+        }
+
+        private void InitializeGimbalSuffixes()
+        {
+            AddSuffix("LOCK", new SetSuffix<bool>(() => gimbal.gimbalLock, value =>
+            {
+                if (value)
+                {
+                    gimbal.LockGimbal();
+                }
+                else
+                {
+                    gimbal.FreeGimbal();
+                }
+            }));
+            AddSuffix("RANGE", new Suffix<float>(() => gimbal.gimbalRange ));
+            AddSuffix("RESPONSESPEED", new Suffix<float>(() => gimbal.gimbalResponseSpeed ));
+            AddSuffix("PITCHANGLE", new Suffix<float>(() => gimbal.gimbalAnglePitch ));
+            AddSuffix("YAWANGLE", new Suffix<float>(() => gimbal.gimbalAngleYaw ));
+            AddSuffix("ROLLANGLE", new Suffix<float>(() => gimbal.gimbalAngleRoll ));
+        }
+    }
+}

--- a/src/kOS/Suffixed/Part/GimbalValue.cs
+++ b/src/kOS/Suffixed/Part/GimbalValue.cs
@@ -24,12 +24,12 @@ namespace kOS.Suffixed.Part
                 {
                     gimbal.FreeGimbal();
                 }
-            }));
-            AddSuffix("RANGE", new Suffix<float>(() => gimbal.gimbalRange ));
-            AddSuffix("RESPONSESPEED", new Suffix<float>(() => gimbal.gimbalResponseSpeed ));
-            AddSuffix("PITCHANGLE", new Suffix<float>(() => gimbal.gimbalAnglePitch ));
-            AddSuffix("YAWANGLE", new Suffix<float>(() => gimbal.gimbalAngleYaw ));
-            AddSuffix("ROLLANGLE", new Suffix<float>(() => gimbal.gimbalAngleRoll ));
+            }, "Is the Gimbal free to travel?"));
+            AddSuffix("RANGE", new Suffix<float>(() => gimbal.gimbalRange ,"The Gimbal's Possible Range of movement"));
+            AddSuffix("RESPONSESPEED", new Suffix<float>(() => gimbal.gimbalResponseSpeed, "The Gimbal's Possible Rate of travel"));
+            AddSuffix("PITCHANGLE", new Suffix<float>(() =>  gimbal.gimbalLock ? 0 : gimbal.gimbalAnglePitch, "Current Gimbal Pitch"));
+            AddSuffix("YAWANGLE", new Suffix<float>(() =>  gimbal.gimbalLock ? 0 : gimbal.gimbalAngleYaw, "Current Gimbal Yaw" ));
+            AddSuffix("ROLLANGLE", new Suffix<float>(() => gimbal.gimbalLock ? 0 : gimbal.gimbalAngleRoll, "Current Gimbal Roll"));
         }
     }
 }

--- a/src/kOS/Suffixed/Part/PartValueFactory.cs
+++ b/src/kOS/Suffixed/Part/PartValueFactory.cs
@@ -34,6 +34,9 @@ namespace kOS.Suffixed.Part
                 ModuleEnviroSensor mSense = module as ModuleEnviroSensor;
                 if (mSense != null)
                     return new SensorValue(part, mSense, shared);
+                var moduleGimbal = module as ModuleGimbal;
+                if (moduleGimbal != null)
+                    return new GimbalValue(moduleGimbal, shared);
                 
             }
             

--- a/src/kOS/kOS.csproj
+++ b/src/kOS/kOS.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Suffixed\BodyTarget.cs" />
     <Compile Include="Suffixed\Career.cs" />
     <Compile Include="Suffixed\Orbitable.cs" />
+    <Compile Include="Suffixed\Part\GimbalValue.cs" />
     <Compile Include="Suffixed\Part\ModuleEngineAdapter.cs" />
     <Compile Include="Suffixed\Part\PartModuleFieldsFactory.cs" />
     <Compile Include="Suffixed\Part\PartValueFactory.cs" />


### PR DESCRIPTION
fixes #498

just adds gimbals to the group of well known modules. first requested by @ferram4.

you should now be able to get a list of engines and then find the gimbal modules for each one.
