### PR TITLE
fixes #501 and fixes #459

### DIFF
--- a/src/kOS.Safe.Test/StructureTest.cs
+++ b/src/kOS.Safe.Test/StructureTest.cs
@@ -31,6 +31,11 @@ namespace kOS.Safe.Test
             {
                 AddSuffix(name,suffix);
             }
+            
+            public override bool KOSEquals(object other)
+            {
+                return false; // dummy because it's required for all structures.
+            } 
         }
 
         [TestFixtureSetUp]

--- a/src/kOS.Safe/Compilation/Calculator.cs
+++ b/src/kOS.Safe/Compilation/Calculator.cs
@@ -33,6 +33,8 @@ namespace kOS.Safe.Compilation
             if (argument2 is float) argument2 = Convert.ToDouble(argument2);
 
             if (argument1 is int) intCount++;
+            if (argument1 is Int32) intCount++;
+            if (argument1 is Int64) intCount++;
             if (argument1 is double) doubleCount++;
             if (argument1 is string) stringCount++;
             if (argument1 is ISuffixed) specialCount++;
@@ -50,7 +52,7 @@ namespace kOS.Safe.Compilation
             if (boolCount > 0) return new CalculatorBool();
             if (specialCount > 0) return new CalculatorStructure();
 
-            throw new NotImplementedException(string.Format("Can't operate types {0} and {1}", argument1.GetType(), argument2.GetType()));
+            throw new KOSBinaryOperandTypeException(argument1,"perform opeations between", "and", argument2);
         }
     }
 

--- a/src/kOS.Safe/Encapsulation/ConstantValue.cs
+++ b/src/kOS.Safe/Encapsulation/ConstantValue.cs
@@ -1,5 +1,6 @@
 using System;
 using kOS.Safe.Encapsulation.Suffixes;
+using kOS.Safe.Exceptions;
 
 namespace kOS.Safe.Encapsulation
 {
@@ -16,6 +17,11 @@ namespace kOS.Safe.Encapsulation
         public override string ToString()
         {
             return string.Format("{0} Constants", base.ToString());
+        }
+        
+        public override bool KOSEquals(object other)
+        {
+            throw new KOSBinaryOperandTypeException(this.GetType(),"=","and",other.GetType());
         }
     }
 

--- a/src/kOS.Safe/Encapsulation/Enumerator.cs
+++ b/src/kOS.Safe/Encapsulation/Enumerator.cs
@@ -33,6 +33,13 @@ namespace kOS.Safe.Encapsulation
             AddSuffix("INDEX", new NoArgsSuffix<int>(() => index));
             AddSuffix("VALUE", new NoArgsSuffix<object>(() => enumerator.Current));
         }
+        
+        public override bool KOSEquals(object other)
+        {
+            Enumerator otherEnum = other as Enumerator;
+            if (otherEnum == null) return false;
+            return this.enumerator.Equals(otherEnum.enumerator);
+        } 
 
         public override string ToString()
         {

--- a/src/kOS.Safe/Encapsulation/FileInfo.cs
+++ b/src/kOS.Safe/Encapsulation/FileInfo.cs
@@ -48,6 +48,13 @@ namespace kOS.Safe.Encapsulation
             return base.GetSuffix(suffixName);
         }
 
+        public override bool KOSEquals(object other)
+        {
+            FileInfo otherFileInfo = other as FileInfo;
+            if (otherFileInfo == null) return false;
+            return this.Name == otherFileInfo.Name && this.Extension == otherFileInfo.Extension && this.Size == otherFileInfo.Size;
+        } 
+
         public override string ToString()
         {
             return Name;

--- a/src/kOS.Safe/Encapsulation/IOperable.cs
+++ b/src/kOS.Safe/Encapsulation/IOperable.cs
@@ -3,5 +3,6 @@
     public interface IOperable
     {
         object TryOperation(string op, object other, bool reverseOrder);
+        bool KOSEquals(object other);
     }
 }

--- a/src/kOS.Safe/Encapsulation/ListValue.cs
+++ b/src/kOS.Safe/Encapsulation/ListValue.cs
@@ -141,6 +141,13 @@ namespace kOS.Safe.Encapsulation
             }
         }
 
+        public override bool KOSEquals(object other)
+        {
+            ListValue<T> otherList = other as ListValue<T>;
+            if (otherList == null) return false;
+            return this.internalList.Equals(otherList.internalList);
+        } 
+
         // Using Statics for this is not thread-safe, but kOS doesn't do threads at the moment.
         // TODO: find a better way later to track the nesting level through all the messy
         // calls of nested objects' ToStrings.

--- a/src/kOS.Safe/Encapsulation/Structure.cs
+++ b/src/kOS.Safe/Encapsulation/Structure.cs
@@ -121,9 +121,29 @@ namespace kOS.Safe.Encapsulation
             return suffix.Get();
         }
 
+        /// <summary>
+        /// All types of Structure must implement this equals check that a kOS script can use
+        /// to compare, given then kOS tends to wrap C# objects inside a kOS wrapper such that
+        /// the default reference comparison for equallity does not suffice.
+        /// This will be called by the default TryOperator implementation.  If you override
+        /// TryOperation that will bypass the user of this and you will need to call this manually.
+        /// <br/>
+        /// This is NOT the C# IEquatable interface, so that it is still possible to distinguish underlying
+        /// equality from script-level equality.
+        /// </summary>
+        /// <param name="other">the other Structure object you are comparing with</param>
+        /// <returns>true if a kos script should consider these two objects identical</returns>
+        public abstract bool KOSEquals(object other);
+
         public virtual object TryOperation(string op, object other, bool reverseOrder)
         {
-            return null;
+            // Force all Structures to have to implement an Equality checker to be used if they don't override TryOperation.
+            if (op == "==")
+                return KOSEquals(other);
+            else if (op == "<>")
+                return !(KOSEquals(other));
+            else
+                throw new KOSBinaryOperandTypeException(this,"perform '"+op+"' between", "and", other);
         }
 
         protected object ConvertToDoubleIfNeeded(object value)

--- a/src/kOS.Safe/Encapsulation/VersionInfo.cs
+++ b/src/kOS.Safe/Encapsulation/VersionInfo.cs
@@ -23,6 +23,13 @@ namespace kOS.Safe.Encapsulation
             AddSuffix("BUILD", new StaticSuffix<int>(() => build));
         }
 
+        public override bool KOSEquals(object other)
+        {
+            VersionInfo otherVInfo = other as VersionInfo;
+            if (otherVInfo == null) return false;
+            return this.major == otherVInfo.major && this.minor == otherVInfo.minor && this.build == otherVInfo.build;
+        } 
+
         public override string ToString()
         {
             return string.Format("{0}.{1}.{2}", major, minor, build);

--- a/src/kOS.Safe/Persistence/Archive.cs
+++ b/src/kOS.Safe/Persistence/Archive.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using kOS.Safe.Utilities;
+using kOS.Safe.Exceptions;
 using FileInfo = kOS.Safe.Encapsulation.FileInfo;
 
 namespace kOS.Safe.Persistence
@@ -262,5 +263,12 @@ namespace kOS.Safe.Persistence
                 outfile.Write(bytesToAppend);
             }
         }
+
+        public override bool KOSEquals(object other)
+        {
+            // Archive attaches to a real filesystem directory.  Not sure how we'd ever have more than one to compare anyway:
+            throw new KOSBinaryOperandTypeException(this.GetType(),"=","and",other.GetType());
+        } 
+
     }
 }

--- a/src/kOS.Safe/Persistence/Harddisk.cs
+++ b/src/kOS.Safe/Persistence/Harddisk.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using kOS.Safe.Utilities;
+using kOS.Safe.Exceptions;
 
 namespace kOS.Safe.Persistence
 {
@@ -33,5 +34,12 @@ namespace kOS.Safe.Persistence
 
             return ((Capacity - usedSpace) >= newFile.GetSize());
         }
-    }
+
+        public override bool KOSEquals(object other)
+        {
+            // Harddisk attaches to a real filesystem directory.  Not sure how we'd ever have more than one to compare anyway:
+            throw new KOSBinaryOperandTypeException(this.GetType(),"=","and",other.GetType());
+        } 
+
+   }
 }

--- a/src/kOS/Suffixed/ActiveResourceValue.cs
+++ b/src/kOS/Suffixed/ActiveResourceValue.cs
@@ -24,6 +24,13 @@ namespace kOS.Suffixed
             AddSuffix("PARTS", new Suffix<ListValue<PartValue>>(() => PartValueFactory.ConstructGeneric(activeResource.parts, shared), "The containers for this resource"));
         }
 
+        public override bool KOSEquals(object other)
+        {
+            ActiveResourceValue that = other as ActiveResourceValue;
+            if (that == null) return false;
+            return this.activeResource.Equals(that.activeResource);
+        } 
+
         public override string ToString()
         {
             return string.Format("ACTIVERESOURCE({0},{1},{2})", activeResource.info.name, activeResource.amount, activeResource.maxAmount);

--- a/src/kOS/Suffixed/AggregateResourceValue.cs
+++ b/src/kOS/Suffixed/AggregateResourceValue.cs
@@ -38,6 +38,13 @@ namespace kOS.Suffixed
             parts.Add(new PartValue(resource.part, shared));
         }
 
+        public override bool KOSEquals(object other)
+        {
+            // AggregateResourceValue is not just a wrapper around a simple single C# object.  It's something invented
+            // by kOS, and so it doesn't need to pass equality through to the inner objects - just a ref equals is good enough:
+            return this.Equals(other);
+        } 
+
         public override string ToString()
         {
             return string.Format("SHIPRESOURCE({0},{1},{2})", name, amount, capacity);

--- a/src/kOS/Suffixed/BodyAtmosphere.cs
+++ b/src/kOS/Suffixed/BodyAtmosphere.cs
@@ -19,6 +19,13 @@ namespace kOS.Suffixed
             AddSuffix("HEIGHT", new Suffix<double>(()=> celestialBody.atmosphere ? celestialBody.maxAtmosphereAltitude : 0));
         }
 
+        public override bool KOSEquals(object other)
+        {
+            BodyAtmosphere that = other as BodyAtmosphere;
+            if (that == null) return false;
+            return this.celestialBody.Equals(that.celestialBody);
+        } 
+
         public override string ToString()
         {
             return "BODYATMOSPHERE(\"" + celestialBody.bodyName + "\")";

--- a/src/kOS/Suffixed/BodyTarget.cs
+++ b/src/kOS/Suffixed/BodyTarget.cs
@@ -99,6 +99,13 @@ namespace kOS.Suffixed
             return base.GetSuffix(suffixName);
         }
 
+        public override bool KOSEquals(object other)
+        {
+            BodyTarget that = other as BodyTarget;
+            if (that == null) return false;
+            return this.Body.Equals(that.Body);
+        } 
+
         public override string ToString()
         {
             if (Body != null)

--- a/src/kOS/Suffixed/Career.cs
+++ b/src/kOS/Suffixed/Career.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Encapsulation;
+using kOS.Safe.Exceptions;
 
 namespace kOS.Suffixed
 {
@@ -164,6 +165,10 @@ namespace kOS.Suffixed
             return CanTagInEditor(whichEditor, out dummy);
         }
         
+        public override bool KOSEquals(object other)
+        {
+            throw new KOSBinaryOperandTypeException(this.GetType(),"=","and",other.GetType());
+        }
 
         public override string ToString()
         {

--- a/src/kOS/Suffixed/Config.cs
+++ b/src/kOS/Suffixed/Config.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using KSP.IO;
 using kOS.Safe.Encapsulation;
+using kOS.Safe.Exceptions;
 
 namespace kOS.Suffixed
 {
@@ -159,7 +160,12 @@ namespace kOS.Suffixed
         {
             return keys.Values.ToList();
         }
-                
+
+        public override bool KOSEquals(object other)
+        {
+            throw new KOSBinaryOperandTypeException(this.GetType(),"=","and",other.GetType());
+        }
+
         public override string ToString()
         {
             return "Use \"list config.\" to view all configurations";

--- a/src/kOS/Suffixed/Direction.cs
+++ b/src/kOS/Suffixed/Direction.cs
@@ -197,6 +197,19 @@ namespace kOS.Suffixed
             return new Direction(Quaternion.RotateTowards(fromDir.rotation, rotation, 99999.0f));
         }
 
+        /// <summary>
+        /// Comparing for exact equality with floating point structures is usually a bad thing,
+        /// but it's worthwhile for things like unit vectors where it will come out exact.
+        /// </summary>
+        /// <param name="other">the other rotation being compared to</param>
+        /// <returns>true if they are exactly identical according to their quaternion representations</returns>
+        public override bool KOSEquals(object other)
+        {
+            Direction that = other as Direction;
+            if (that == null) return false;
+            return this.rotation.Equals(that.rotation);
+        } 
+
         public override string ToString()
         {
             return "R(" + Math.Round(euler.x, 3) + "," + Math.Round(euler.y, 3) + "," + Math.Round(euler.z, 3) + ")";

--- a/src/kOS/Suffixed/ElementValue.cs
+++ b/src/kOS/Suffixed/ElementValue.cs
@@ -34,6 +34,16 @@ namespace kOS.Suffixed
             return toReturn;
         }
 
+        public override bool KOSEquals(object other)
+        {
+            ElementValue that = other as ElementValue;
+            if (that == null) return false;
+            return this.name.Equals(that.name) && this.parts.Equals(that.parts);
+            // @erendrake - I'm not sure if this is correct, because I have no clue what
+            // LIST ELEMENTS IN FOO, which is what this is, is actually supposed to mean.
+            // So I just made it compare all the member fields, not knowing what it means.
+        } 
+
         public override string ToString()
         {
             return "ELEMENT(" + name + ", " + parts.Count + ")";

--- a/src/kOS/Suffixed/FlightControl.cs
+++ b/src/kOS/Suffixed/FlightControl.cs
@@ -489,5 +489,12 @@ namespace kOS.Suffixed
             if(Math.Abs(wheelThrottleTrim) > SETTING_EPILSON) st.wheelThrottleTrim = wheelThrottleTrim;
 
         }
+
+        public override bool KOSEquals(object other)
+        {
+            FlightControl that = other as FlightControl;
+            if (that == null) return false;
+            return this.Vessel.Equals(that.Vessel); // call them the same if the vessel they are on is the same
+        } 
     }
 }

--- a/src/kOS/Suffixed/GeoCoordinates.cs
+++ b/src/kOS/Suffixed/GeoCoordinates.cs
@@ -213,6 +213,13 @@ namespace kOS.Suffixed
                                                                            "of this lat/long, at this (sea level) altitude"));
         }
 
+        public override bool KOSEquals(object other)
+        {
+            GeoCoordinates that = other as GeoCoordinates;
+            if (that == null) return false;
+            return this.Lat.Equals(that.Lat) && this.Lng.Equals(that.Lng) && this.Body.Equals(that.Body);
+        } 
+
         public override string ToString()
         {
             return "LATLNG(" + Lat + ", " + Lng + ")";

--- a/src/kOS/Suffixed/Node.cs
+++ b/src/kOS/Suffixed/Node.cs
@@ -157,6 +157,13 @@ namespace kOS.Suffixed
             vesselRef = null;
         }
 
+        public override bool KOSEquals(object other)
+        {
+            Node that = other as Node;
+            if (that == null) return false;
+            return this.nodeRef.Equals(that.nodeRef) && this.vesselRef.Equals(that.vesselRef);
+        } 
+
         public override string ToString()
         {
             UpdateValues();

--- a/src/kOS/Suffixed/OrbitInfo.cs
+++ b/src/kOS/Suffixed/OrbitInfo.cs
@@ -137,6 +137,13 @@ namespace kOS.Suffixed
             return base.GetSuffix(suffixName);
         }
 
+        public override bool KOSEquals(object other)
+        {
+            OrbitInfo that = other as OrbitInfo;
+            if (that == null) return false;
+            return this.orbit.Equals(that.orbit);
+        } 
+
         public override string ToString()
         {
             return "ORBIT of " + name;

--- a/src/kOS/Suffixed/OrbitableVelocity.cs
+++ b/src/kOS/Suffixed/OrbitableVelocity.cs
@@ -55,6 +55,13 @@ namespace kOS.Suffixed
             return base.GetSuffix(suffixName);
         }
 
+        public override bool KOSEquals(object other)
+        {
+            OrbitableVelocity that = other as OrbitableVelocity;
+            if (that == null) return false;
+            return this.Orbital.Equals(that.Orbital) && this.Surface.Equals(that.Surface);
+        } 
+
         public override string ToString()
         {
             return "OrbitableVelocity(\n" +

--- a/src/kOS/Suffixed/Part/PartModuleFields.cs
+++ b/src/kOS/Suffixed/Part/PartModuleFields.cs
@@ -45,6 +45,13 @@ namespace kOS.Suffixed.Part
             return partModule.moduleName;
         }
 
+        public override bool KOSEquals(object other)
+        {
+            PartModuleFields that = other as PartModuleFields;
+            if (that == null) return false;
+            return this.partModule.Equals(that.partModule);
+        } 
+
         public override string ToString()
         {
             var returnValue = new StringBuilder();

--- a/src/kOS/Suffixed/Part/PartValue.cs
+++ b/src/kOS/Suffixed/Part/PartValue.cs
@@ -70,7 +70,14 @@ namespace kOS.Suffixed.Part
             KOSNameTag tagModule = Part.Modules.OfType<KOSNameTag>().FirstOrDefault();
             return tagModule == null ? string.Empty : tagModule.nameTag;
         }
-        
+
+        public override bool KOSEquals(object other)
+        {
+            PartValue that = other as PartValue;
+            if (that == null) return false;
+            return this.Part.Equals(that.Part);
+        } 
+
         public override string ToString()
         {
             string tagName = GetTagName();

--- a/src/kOS/Suffixed/RgbaColor.cs
+++ b/src/kOS/Suffixed/RgbaColor.cs
@@ -32,6 +32,13 @@ namespace kOS.Suffixed
             return new Color(color.r,color.g,color.b,color.a); 
         }
 
+        public override bool KOSEquals(object other)
+        {
+            RgbaColor that = other as RgbaColor;
+            if (that == null) return false;
+            return this.color.Equals(that.color);
+        } 
+
         public override string ToString()
         {
             return "RGBA(" + color.r + ", " + color.g + ", " + color.b + ", " + color.a + ")";

--- a/src/kOS/Suffixed/SingleResourceValue.cs
+++ b/src/kOS/Suffixed/SingleResourceValue.cs
@@ -30,6 +30,13 @@ namespace kOS.Suffixed
             }));
         }
 
+        public override bool KOSEquals(object other)
+        {
+            SingleResourceValue that = other as SingleResourceValue;
+            if (that == null) return false;
+            return this.partResource.Equals(that.partResource);
+        } 
+
         public override string ToString()
         {
             return string.Format("RESOURCE({0},{1},{2}", partResource.resourceName, partResource.amount, partResource.maxAmount);

--- a/src/kOS/Suffixed/StageValues.cs
+++ b/src/kOS/Suffixed/StageValues.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
+using kOS.Safe.Exceptions;
 
 namespace kOS.Suffixed
 {
@@ -57,6 +58,10 @@ namespace kOS.Suffixed
             var match = resource.FirstOrDefault(r => string.Equals(r.info.name, resourceName, StringComparison.InvariantCultureIgnoreCase));
             return match == null ? null : (double?) Math.Round(match.amount, 2);
         }
+        public override bool KOSEquals(object other)
+        {
+            throw new KOSBinaryOperandTypeException(this.GetType(),"=","and",other.GetType());
+        } 
 
         public override string ToString()
         {

--- a/src/kOS/Suffixed/Timespan.cs
+++ b/src/kOS/Suffixed/Timespan.cs
@@ -147,6 +147,13 @@ namespace kOS.Suffixed
             return base.TryOperation(op, other, reverseOrder);
         }
 
+        public override bool KOSEquals(object other)
+        {
+            kOS.Suffixed.TimeSpan that = other as kOS.Suffixed.TimeSpan;
+            if (that == null) return false;
+            return this.span.Equals(that.span) && this.kerbinTimeSetting.Equals(that.kerbinTimeSetting);
+        } 
+
         public override string ToString()
         {
             return string.Format("TIME({0:0})", span);

--- a/src/kOS/Suffixed/Vector.cs
+++ b/src/kOS/Suffixed/Vector.cs
@@ -211,6 +211,13 @@ namespace kOS.Suffixed
             return new Vector3((float)X, (float)Y, (float)Z);
         }
 
+        public override bool KOSEquals(object other)
+        {
+            Vector that = other as Vector;
+            if (that == null) return false;
+            return this.X.Equals(that.X) && this.Y.Equals(that.Y) && this.Z.Equals(that.Z);
+        } 
+
         public override string ToString()
         {
             return "V(" + X + ", " + Y + ", " + Z + ")";

--- a/src/kOS/Suffixed/VectorRenderer.cs
+++ b/src/kOS/Suffixed/VectorRenderer.cs
@@ -454,6 +454,18 @@ namespace kOS.Suffixed
             }
         }
 
+        public override bool KOSEquals(object other)
+        {
+            VectorRenderer that = other as VectorRenderer;
+            if (that == null) return false;
+            return
+                this.Vector.Equals(that.Vector) &&
+                this.Color.Equals(that.Color) &&
+                this.Start.Equals(that.Start) &&
+                this.Scale.Equals(that.Scale) &&
+                this.Width.Equals(that.Width);
+        } 
+
         public override string ToString()
         {
             return string.Format("{0} VectorRenderer", base.ToString());

--- a/src/kOS/Suffixed/VesselSensors.cs
+++ b/src/kOS/Suffixed/VesselSensors.cs
@@ -1,4 +1,5 @@
 using kOS.Safe.Encapsulation;
+using kOS.Safe.Exceptions;
 
 namespace kOS.Suffixed
 {
@@ -62,6 +63,11 @@ namespace kOS.Suffixed
 
             return base.GetSuffix(suffixName);
         }
+
+        public override bool KOSEquals(object other)
+        {
+            throw new KOSBinaryOperandTypeException(this.GetType(),"=","and",other.GetType());
+        } 
 
         public override string ToString()
         {

--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -214,6 +214,13 @@ namespace kOS.Suffixed
 
         public static string[] ShortCuttableShipSuffixes { get; private set; }
 
+        public override bool KOSEquals(object other)
+        {
+            VesselTarget that = other as VesselTarget;
+            if (that == null) return false;
+            return this.Vessel.Equals(that.Vessel);
+        } 
+
         public override string ToString()
         {
             return "SHIP(\"" + Vessel.vesselName + "\")";

--- a/src/kOS/Suffixed/WaypointValue.cs
+++ b/src/kOS/Suffixed/WaypointValue.cs
@@ -45,7 +45,14 @@ namespace kOS.Suffixed
             GeoCoordinates gCoord = BuildGeoCoordinates();
             return gCoord.GetTerrainAltitude() + WayPoint.altitude;
         }
-        
+
+        public override bool KOSEquals(object other)
+        {
+            WaypointValue that = other as WaypointValue;
+            if (that == null) return false;
+            return this.WayPoint.Equals(that.WayPoint);
+        } 
+
         public override string ToString()
         {
             return String.Format("Waypoint \"{0}\"", WayPoint.name);


### PR DESCRIPTION
Both problems were caused by how equality comparison worked, or didn't,
between structures.

There's a lot of files changed, but only because each individual file
had a small change in it to add one short KOSEquals method.