### PR TITLE
Add new PART:GETMODULEINDEX function

### DIFF
--- a/src/kOS/Suffixed/Part/PartValue.cs
+++ b/src/kOS/Suffixed/Part/PartValue.cs
@@ -40,7 +40,8 @@ namespace kOS.Suffixed.Part
             AddSuffix("TARGETABLE", new Suffix<bool>(() => Part.Modules.OfType<ITargetable>().Any()));
             AddSuffix("SHIP", new Suffix<VesselTarget>(() => new VesselTarget(Part.vessel, shared)));
             AddSuffix("GETMODULE", new OneArgsSuffix<PartModuleFields,string>(GetModule));
-            AddSuffix(new [] {"MODULES","ALLMODULES"}, new Suffix<ListValue>(GetAllModules, "A List of all the modules' names on this part"));
+            AddSuffix("GETMODULEINDEX", new OneArgsSuffix<PartModuleFields, int>(GetModuleIndex));
+            AddSuffix(new[] { "MODULES", "ALLMODULES" }, new Suffix<ListValue>(GetAllModules, "A List of all the modules' names on this part"));
             AddSuffix("PARENT", new Suffix<PartValue>(() => PartValueFactory.Construct(Part.parent,shared), "The parent part of this part"));
             AddSuffix("HASPARENT", new Suffix<bool>(() => Part.parent != null, "Tells you if this part has a parent, is used to avoid null exception from PARENT"));
             AddSuffix("CHILDREN", new Suffix<ListValue<PartValue>>(() => PartValueFactory.ConstructGeneric(Part.children, shared), "A LIST() of the children parts of this part"));
@@ -63,6 +64,15 @@ namespace kOS.Suffixed.Part
                 }
             }
             throw new KOSLookupFailException( "module", modName.ToUpper(), this );
+        }
+
+        private PartModuleFields GetModuleIndex(int moduleIndex)
+        {
+            if (moduleIndex < Part.Modules.Count)
+            {
+                return PartModuleFieldsFactory.Construct(Part.Modules.GetModule(moduleIndex), shared);
+            }
+            throw new KOSLookupFailException("module", String.Format("MODULEINDEX[{0}]", moduleIndex), this);
         }
         
         public string GetTagName() // public because I picture this being a useful API method later


### PR DESCRIPTION
Adds a new function to get a PartModule at a specified index.  Allows
accessing PartModules that share the same name.

Address issue #510 