### PR TITLE
specify that the kosnametag is for kos

### DIFF
--- a/Resources/GameData/kOS/kOS-module-manager.cfg
+++ b/Resources/GameData/kOS/kOS-module-manager.cfg
@@ -1,4 +1,4 @@
-@PART[*]
+@PART[*]:FOR[kOS]
 {
 	MODULE
 	{


### PR DESCRIPTION
right now when we add the kosnametag module, we do it in the 'legacy' pass. this is the pass that you fall in if you do not specify what mod the change is for.