### PR TITLE
Fixes #523 and Fixes #524

### DIFF
--- a/doc/source/structures/waypoint.rst
+++ b/doc/source/structures/waypoint.rst
@@ -41,6 +41,8 @@ Waypoints are the location markers you can see on the map view showing you where
           - `BodyTarget`
         * - :attr:`GEOPOSITION`
           - `GeoCoordinates`
+        * - :attr:`POSITION`
+          - `Vector`
         * - :attr:`ALTITUDE`
           - scalar
         * - :attr:`AGL`
@@ -48,6 +50,10 @@ Waypoints are the location markers you can see on the map view showing you where
         * - :attr:`NEARSURFACE`
           - boolean
         * - :attr:`GROUNDED`
+          - boolean
+        * - :attr:`INDEX`
+          - scalar
+        * - :attr:`CLUSTERED`
           - boolean
 
 
@@ -72,6 +78,13 @@ Waypoints are the location markers you can see on the map view showing you where
     :access: Get only
 
     The LATLNG of this waypoint
+
+.. attribute:: Waypoint:POSITION
+
+    :type: Vector
+    :access: Get only
+
+    The Vector position of this waypoint in 3D space, in ship-raw coords.
 
 .. attribute:: Waypoint:ALTITUDE
 
@@ -103,4 +116,18 @@ Waypoints are the location markers you can see on the map view showing you where
     :access: Get only
 
     True if waypoint is actually glued to the ground.
+
+.. attribute:: Waypoint:INDEX
+
+    :type: scalar
+    :access: Get only
+
+    The integer index of this waypoint amongst its cluster of sibling waypoints.  In other words, when you have a cluster of waypoints called "Somewhere Alpha", "Somewhere Beta", and "Somewhere Gamma", then the alpha site has index 0, the beta site has index 1 and the gamma site has index 2. When Waypoint:CLUSTERED is false, this value is zero but meaningless.
+
+.. attribute:: Waypoint:CLUSTERED
+
+    :type: boolean
+    :access: Get only
+
+    True if this waypoint is part of a set of clustered waypoints with greek letter names appended (Alpha, Beta, Gamma, etc).  If true, there should be a one-to-one correspondence with the greek letter name and the :INDEX suffix. (0 = Alpha, 1 = Beta, 2 = Gamma, etc).
 

--- a/src/kOS/Function/Suffixed.cs
+++ b/src/kOS/Function/Suffixed.cs
@@ -349,16 +349,20 @@ namespace kOS.Function
             string pointName = shared.Cpu.PopValue().ToString();
 
             WaypointManager wpm = WaypointManager.Instance();
-            if (wpm == null)
+            if (wpm == null) // When zero waypoints exist, there might not even be a waypoint manager.
             {
-                shared.Cpu.PushStack(null); // When no waypoints exist, there isn't even a waypoint manager.
+                shared.Cpu.PushStack(null);
                 // I don't like returning null here without the user being able to test for that, but
                 // we don't have another way to communicate "no such waypoint".  We really need to address
                 // that problem once and for all.
                 return;
             }
-
-            Waypoint point = wpm.AllWaypoints().FirstOrDefault(p => String.Equals(p.name, pointName,StringComparison.CurrentCultureIgnoreCase));
+            
+            string baseName;
+            int index;
+            bool hasGreek = WaypointValue.GreekToInteger(pointName, out index, out baseName);
+            Waypoint point = wpm.AllWaypoints().FirstOrDefault(
+                p => String.Equals(p.name, baseName,StringComparison.CurrentCultureIgnoreCase) && (!hasGreek || p.index == index));
 
             shared.Cpu.PushStack(new WaypointValue(point, shared));
         }

--- a/src/kOS/Suffixed/WaypointValue.cs
+++ b/src/kOS/Suffixed/WaypointValue.cs
@@ -91,20 +91,18 @@ namespace kOS.Suffixed
             return String.Format("A Waypoint consisting of\n" +
                                  "  name= {0}\n" +
                                  "  body= {1}\n" +
-                                 "  latitude= {2}\n" +
-                                 "  longitude= {3}\n" +
+                                 "  geoposition= {2}\n" +
+                                 "  agl= {3}\n" +
                                  "  altitude= {4}\n" +
-                                 "  height= {5}\n" +
-                                 "  isOnSurface= {6}\n" +
-                                 "  worldPosition= {7}\n" +
-                                 "  index= {8}\n" +
-                                 "  clustered= {9}\n",
+                                 "  nearsurface= {5}\n" +
+                                 "  position= {6}\n" +
+                                 "  index= {7}\n" +
+                                 "  clustered= {8}\n",
                                  CookedName(),
                                  WrappedWaypoint.celestialName,
-                                 WrappedWaypoint.latitude,
-                                 WrappedWaypoint.longitude,
+                                 new GeoCoordinates(GetBody(), Shared, WrappedWaypoint.latitude, WrappedWaypoint.longitude),
                                  WrappedWaypoint.altitude, // A location inside the contract range's altitude range - and NOT the edge of it.
-                                 WrappedWaypoint.height,
+                                 BuildSeaLevelAltitude(),
                                  WrappedWaypoint.isOnSurface,
                                  GetPosition(),
                                  WrappedWaypoint.index,

--- a/src/kOS/Suffixed/WaypointValue.cs
+++ b/src/kOS/Suffixed/WaypointValue.cs
@@ -100,7 +100,7 @@ namespace kOS.Suffixed
                                  "  clustered= {8}\n",
                                  CookedName(),
                                  WrappedWaypoint.celestialName,
-                                 new GeoCoordinates(GetBody(), Shared, WrappedWaypoint.latitude, WrappedWaypoint.longitude),
+                                 BuildGeoCoordinates(),
                                  WrappedWaypoint.altitude, // A location inside the contract range's altitude range - and NOT the edge of it.
                                  BuildSeaLevelAltitude(),
                                  WrappedWaypoint.isOnSurface,

--- a/src/kOS/Suffixed/WaypointValue.cs
+++ b/src/kOS/Suffixed/WaypointValue.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using kOS.Utilities;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Encapsulation;
@@ -8,47 +9,80 @@ namespace kOS.Suffixed
 {
     public class WaypointValue : Structure
     {
-        protected Waypoint WayPoint { get; set; }
+        protected Waypoint WrappedWaypoint { get; set; }
         protected CelestialBody CachedBody { get; set; }
         protected SharedObjects Shared { get; set; }
+        private static Dictionary<string,int> greekMap;
         
         public WaypointValue(Waypoint wayPoint, SharedObjects shared)
         {
-            WayPoint = wayPoint;
+            WrappedWaypoint = wayPoint;
             Shared = shared;
             AddSuffix("DUMP", new NoArgsSuffix<string>(ToVerboseString)); // for debugging
-            AddSuffix("NAME", new NoArgsSuffix<string>(() => wayPoint.name, "Name of waypoint as it appears on the map and contract"));
-            AddSuffix("BODY", new NoArgsSuffix<BodyTarget>(() => new BodyTarget(GetBody(),shared), "Celestial body the waypoint is attached to"));
+            AddSuffix("NAME", new NoArgsSuffix<string>(() => CookedName(), "Name of waypoint as it appears on the map and contract"));
+            AddSuffix("BODY", new NoArgsSuffix<BodyTarget>(() => new BodyTarget(GetBody(),Shared), "Celestial body the waypoint is attached to"));
             AddSuffix("GEOPOSITION", new NoArgsSuffix<GeoCoordinates>(BuildGeoCoordinates, "the LATLNG of this waypoint"));
+            AddSuffix("POSITION", new NoArgsSuffix<Vector>(() => GetPosition() - new Vector( Shared.Vessel.findWorldCenterOfMass())));
             AddSuffix("ALTITUDE", new NoArgsSuffix<double>(BuildSeaLevelAltitude,
                                                            "Altitude of waypoint above sea level.  Warning, this a point somewhere in the " +
                                                            "midst of the contract altitude range, not the edge of the altitude range."));
-            AddSuffix("AGL", new NoArgsSuffix<double>(() => wayPoint.altitude,
+            AddSuffix("AGL", new NoArgsSuffix<double>(() => WrappedWaypoint.altitude,
                                                       "Altitude of waypoint above ground.  Warning, this a point somewhere" +
                                                       "in the midst of the contract altitude range, not the edge of the altitude range."));
-            AddSuffix("NEARSURFACE", new NoArgsSuffix<bool>(() => wayPoint.isOnSurface, "True if waypoint is a point near or on the body rather than high in orbit."));
-            AddSuffix("GROUNDED", new NoArgsSuffix<bool>(() => wayPoint.landLocked, "True if waypoint is actually glued to the ground."));
+            AddSuffix("NEARSURFACE", new NoArgsSuffix<bool>(() => WrappedWaypoint.isOnSurface, "True if waypoint is a point near or on the body rather than high in orbit."));
+            AddSuffix("GROUNDED", new NoArgsSuffix<bool>(() => WrappedWaypoint.landLocked, "True if waypoint is actually glued to the ground."));
+            AddSuffix("INDEX", new NoArgsSuffix<int>(() => WrappedWaypoint.index, "Number of this waypoint if this is a grouped waypoint (i.e. alpha/beta/gamma.."));
+            AddSuffix("CLUSTERED", new NoArgsSuffix<bool>(() => WrappedWaypoint.isClustered, "True if this is a member of a cluster of waypoints (i.e. alpha/beta/gamma.."));
+            // greekMap is static, so whichever waypoint instance's constructor happens to
+            // get called first will make it, and from then on other waypoints don't need to
+            // keep re-initializing it:
+            if (greekMap == null)
+                InitializeGreekMap();
+        }
+        
+        private static void InitializeGreekMap()
+        {
+            greekMap = new Dictionary<string, int>();
+            for (int i = 0 ; i < 20 ; ++i)
+                greekMap.Add(FinePrint.Utilities.StringUtilities.IntegerToGreek(i).ToLower(), i);
         }
         
         public CelestialBody GetBody()
         {
-            return CachedBody ?? (CachedBody = VesselUtils.GetBodyByName(WayPoint.celestialName));
+            return CachedBody ?? (CachedBody = VesselUtils.GetBodyByName(WrappedWaypoint.celestialName));
         }
 
         public GeoCoordinates BuildGeoCoordinates()
         {
-            return new GeoCoordinates(GetBody(), Shared, WayPoint.latitude, WayPoint.longitude);
+            return new GeoCoordinates(GetBody(), Shared, WrappedWaypoint.latitude, WrappedWaypoint.longitude);
+        }
+        
+        public Vector GetPosition()
+        {
+            return new Vector(GetBody().GetWorldSurfacePosition(WrappedWaypoint.latitude, WrappedWaypoint.longitude, BuildSeaLevelAltitude()));
         }
         
         public double BuildSeaLevelAltitude()
         {
             GeoCoordinates gCoord = BuildGeoCoordinates();
-            return gCoord.GetTerrainAltitude() + WayPoint.altitude;
+            return gCoord.GetTerrainAltitude() + WrappedWaypoint.altitude;
         }
         
         public override string ToString()
         {
-            return String.Format("Waypoint \"{0}\"", WayPoint.name);
+            return String.Format("Waypoint \"{0}\"", CookedName() );
+        }
+        
+        public string CookedName()
+        {
+            return String.Format("{0}{1}",
+                                 WrappedWaypoint.name,
+                                 (
+                                     WrappedWaypoint.isClustered ?
+                                     (" " + FinePrint.Utilities.StringUtilities.IntegerToGreek(WrappedWaypoint.index)) :
+                                      ""
+                                 )
+                                );
         }
         
         public string ToVerboseString()
@@ -62,15 +96,62 @@ namespace kOS.Suffixed
                                  "  altitude= {4}\n" +
                                  "  height= {5}\n" +
                                  "  isOnSurface= {6}\n" +
-                                 "  worldPosition= {7}\n",
-                                 WayPoint.name,
-                                 WayPoint.celestialName,
-                                 WayPoint.latitude,
-                                 WayPoint.longitude,
-                                 WayPoint.altitude, // A location inside the contract range's altitude range - and NOT the edge of it.
-                                 WayPoint.height,
-                                 WayPoint.isOnSurface,
-                                 WayPoint.worldPosition);
+                                 "  worldPosition= {7}\n" +
+                                 "  index= {8}\n" +
+                                 "  clustered= {9}\n",
+                                 CookedName(),
+                                 WrappedWaypoint.celestialName,
+                                 WrappedWaypoint.latitude,
+                                 WrappedWaypoint.longitude,
+                                 WrappedWaypoint.altitude, // A location inside the contract range's altitude range - and NOT the edge of it.
+                                 WrappedWaypoint.height,
+                                 WrappedWaypoint.isOnSurface,
+                                 GetPosition(),
+                                 WrappedWaypoint.index,
+                                 WrappedWaypoint.isClustered);
+        }
+        
+        /// <summary>
+        /// Return an integer to go with the alphabet position of the
+        /// string given in greek lettering.  For example, input "alpha" and 
+        /// get out 0.  input "beta" and get out 1.  If no match is found,
+        /// -1 is returned.
+        /// <br/>
+        /// This is used by waypoints so that you can figure out that a waypoint
+        /// named like "Jebadiah's lament Gamma" is really the 3rd (index 2) member
+        /// of the "Jebadiah's lament" cluster of waypoints.
+        /// <br/>
+        /// Because that is its purpose, it actually operates on the LASTMOST word
+        /// in the string it is given.  given a string like "foo bar baz", it will 
+        /// check if "baz" is a greek letter, not "foo".  Thus you can pass in exactly
+        /// the name as it appears onscreen.
+        /// </summary>
+        /// <param name="greekLetterName">string name to check.  Case insensitively.</param>
+        /// <param name="index">integer position in alphabet.  -1 if no match.</param>
+        /// <param name="baseName">the name after the greek suffix has been stripped off, if there is one.</param>
+        /// <returns>true if there was a greek letter suffix</returns>
+        public static bool GreekToInteger(string greekLetterName, out int index, out string baseName )
+        {
+            // Get lastmost word (or whole string if there's no spaces):
+            int lastSpace = greekLetterName.LastIndexOf(' ');
+            string lastTerm;
+            if (lastSpace >= 0 && lastSpace < greekLetterName.Length - 1)
+            {
+                // last space is real, and isn't the lastmost char but actually has
+                // nonspaces that follow it:
+                lastTerm = greekLetterName.Substring(lastSpace+1).ToLower(); // ToLower for the dictionary hashmap lookup
+                baseName = greekLetterName.Substring(0,lastSpace);
+            }
+            else
+            {
+                lastTerm = greekLetterName.ToLower(); // ToLower for the dictionary hashmap lookup
+                baseName = greekLetterName;
+            }
+            
+            bool worked = greekMap.TryGetValue(lastTerm, out index);
+            if (!worked)
+                index = -1;
+            return worked;
         }
             
     }


### PR DESCRIPTION
Making waypoints a bit better.

For #523: Fixed the lookup of user-provided waypoint names to be able to find clustered sites.

  It turns out that clustered sites' names as they appear on screen to the user are NOT how they're actually stored internally.  If a site has a name like "Jebadiah's Lament Gamma" on the screen, then in *reality* it's waypoint name is *really* this:

Waypoint.name = "Jebadiah's Lament",
Waypoint.index = 2,
Waypoint.clustered = true.

When  presenting the name to the user, the game **builds** the name by looking up what greek letter name to use for index=2 ("Gamma") and then appending it to the name for display only.  

Since the API provides no nice way to go the other way in this system (decompose a display name to its component parts), nor does it actually store the display name in the class or provide it as a Property built on the fly that I can query with Linq tests, that means I had to make presumptions about the display-name making algorithm and repeat the algorithm (backward) in kOS's own code.  I spoke with the author of Fineprint and the assumptions *are* correct, but because we're not using any built-in method for it, the danger exists that the assumption could become wrong in the future.

One example of a potential problem is that if you use a greek letter term in the name, kOS assumes that cannot happen unless it's a clustered waypoint.  In other words, if there's a waypoint called "FooFiFum beta", and it's not *really* a cluster, but just utterly coincidentally happens to end in the word "beta", kOS won't find it because upon seeing the "beta" it will presume it is a clustered waypoint and look for just the prefix name "FooFiFum".

None of these are problems NOW in KSP 0.90.  They're just gotchas to look for later in future releases.

For #524: Added suffix waypoints:

   :POSITION - 3D vector position of the waypoint.
   :CLUSTERED - boolean for if the waypoint is part of an alpha/beta/gamma... cluster
   :INDEX - if :CLUSTERED is true, is this the zeroth, first, second, etc member of the cluster.
