### PR TITLE
fixes #522 with new suffixes for BodyTarget

### DIFF
--- a/doc/source/structures/celestial_bodies/body.rst
+++ b/doc/source/structures/celestial_bodies/body.rst
@@ -56,6 +56,8 @@ All of the main celestial bodies in the game are reserved variable names. The fo
     :attr:`MU`                       scalar (:math:`m^3 s^{−2}`)
     :attr:`ATM`                      :struct:`Atmosphere`
     :attr:`ANGULARVEL`               :struct:`Direction` in :ref:`SHIP-RAW <ship-raw>`
+    :attr:`GEOPOSITIONOF`            :struct:`GeoCoordinates` in :ref:`SHIP-RAW <ship-raw>`
+    :attr:`ALTITUDEOF`               scalar (m)
     ================================ ============
 
 .. attribute:: Body:NAME
@@ -95,4 +97,12 @@ All of the main celestial bodies in the game are reserved variable names. The fo
 .. attribute:: Body:ANGULARVEL
 
     Despite the name, this is technically not a velocity. It only tells you the axis of rotation, not the speed of rotation around that axis.
+
+.. attribute:: Body:GEOPOSITIONOF
+
+    The geoposition underneath the given vector position.  SHIP:BODY:GEOPOSITIONOF(SHIP:POSITION) should, in principle, give the same thing as SHIP:GEOPOSITION, while SHIP:BODY:GEOPOSITIONOF(SHIP:POSITION + 1000*SHIP:NORTH) would give you the lat/lng of the position 1 kilometer north of you.  Be careful not to confuse this with :GEOPOSITION (no "OF" in the name), which is also a suffix of Body by virtue of the fact that Body is an Orbitable, but it doesn't mean the same thing.
+
+.. attribute:: Body:ALTITUDEOF
+
+    The altitude of the given vector position, above this body's 'sea level'.  SHIP:BODY:ALTITUDEOF(SHIP:POSITION) should, in principle, give the same thing as SHIP:ALTITUDE.  Example: Eve:ALTITUDEOF(GILLY:POSITION) gives the altitude of gilly's current position above Eve, even if you're not actually anywhere near the SOI of Eve at the time.  Be careful not to confuse this with :ALTITUDE (no "OF" in the name), which is also a suffix of Body by virtue of the fact that Body is an Orbitable, but it doesn't mean the same thing.
 

--- a/src/kOS/Suffixed/BodyTarget.cs
+++ b/src/kOS/Suffixed/BodyTarget.cs
@@ -86,6 +86,38 @@ namespace kOS.Suffixed
             AddSuffix("ROTATIONPERIOD", new Suffix<double>(()=> Body.rotationPeriod));
             AddSuffix("ATM", new Suffix<BodyAtmosphere>(()=> new BodyAtmosphere(Body)));
             AddSuffix("ANGULARVEL", new Suffix<Direction>(()=> new Direction(Body.angularVelocity, true)));
+            AddSuffix("GEOPOSITIONOF",
+                      new OneArgsSuffix<GeoCoordinates,Vector>(
+                              GeoCoordinatesFromPosition,
+                              "Interpret the vector given as a 3D position, and return the geocoordinates directly underneath it on this body."));
+            AddSuffix("ALTITUDEOF",
+                      new OneArgsSuffix<double,Vector>(
+                              AltitudeFromPosition,
+                              "Interpret the vector given as a 3D position, and return its altitude above 'sea level' of this body."));
+        }
+
+        /// <summary>
+        /// Interpret the vector given as a 3D position, and return the geocoordinates directly underneath it on this body.
+        /// </summary>
+        /// <param name="position">Vector to use as the 3D position in ship-raw coords</param>
+        /// <returns>The GeoCoordinates under the position.</returns>
+        public GeoCoordinates GeoCoordinatesFromPosition(Vector position)
+        {
+            Vector3d unityWorldPosition = Shared.Vessel.findWorldCenterOfMass() + position.ToVector3D();
+            double lat = Body.GetLatitude(unityWorldPosition);
+            double lng = Body.GetLongitude(unityWorldPosition);
+            return new GeoCoordinates(Body, Shared, lat, lng);
+        }
+        
+        /// <summary>
+        /// Interpret the vector given as a 3D position, and return the altitude above sea level of this body.
+        /// </summary>
+        /// <param name="position">Vector to use as the 3D position in ship-raw coords</param>
+        /// <returns>The altitude above 'sea level'.</returns>
+        public double AltitudeFromPosition(Vector position)
+        {
+            Vector3d unityWorldPosition = Shared.Vessel.findWorldCenterOfMass() + position.ToVector3D();
+            return Body.GetAltitude(unityWorldPosition);
         }
         
         public double GetDistance()

--- a/src/kOS/Suffixed/Vector.cs
+++ b/src/kOS/Suffixed/Vector.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using kOS.Safe.Encapsulation;
+using kOS.Safe.Encapsulation.Suffixes;
 using UnityEngine;
 
 namespace kOS.Suffixed


### PR DESCRIPTION
The changes are pretty self-explanatory - just read my changes to the docs files that come with the PR.

I picked the names GEOPOSITION**OF**() and ALTITUDE**OF**() because I can't overload methods in kOS suffixes, and there already exist zero-args suffixes called GEOPOSITION and ALTITUDE due to the fact that BodyTarget is an Orbitable.  When I tried calling the new suffiix by the same name, the system didn't find it - hitting the zero-args version first and throwing an exception because of the wrong number of args.

