### PR TITLE
Fixes #536 just moving the attachment point.

### DIFF
--- a/Resources/GameData/kOS/Parts/kOSMachine1m/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSMachine1m/part.cfg
@@ -13,8 +13,8 @@ iconCenter = 0, 3, 0
 
 // --- node definitions ---
 node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
-node_stack_bottom = 0.0, -0.14, 0.0, 0.0, -1.0, 0.0
-node_stack_top = 0.0, 0.14, 0.0, 0.0, 1.0, 0.0
+node_stack_bottom = 0.0, -0.173, 0.0, 0.0, -1.0, 0.0
+node_stack_top = 0.0, 0.173, 0.0, 0.0, 1.0, 0.0
 
 // --- Tech tree ---
 TechRequired = flightControl


### PR DESCRIPTION
 New screenshot:

![overlap_fix_illustration](https://cloud.githubusercontent.com/assets/5216848/5987897/cde3272e-a90a-11e4-8113-356cb7f7a8b7.jpg)


Note, it does sometimes make parts seem to hover a bit off the connection, as shown, but then again normal parts do that too a bit (as shown).

