### PR TITLE
added HudTxt function

### DIFF
--- a/src/kOS/Function/Misc.cs
+++ b/src/kOS/Function/Misc.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using kOS.Execution;
 using kOS.Safe.Compilation;
@@ -17,6 +17,51 @@ namespace kOS.Function
             shared.Screen.ClearScreen();
         }
     }
+
+	[Function("hudtxt")]
+	public class FunctionHudTxt : FunctionBase
+	{
+
+		public override void Execute(SharedObjects shared)
+
+		{
+			int mirror 			= Convert.ToInt32(shared.Cpu.PopValue());
+			string color 		= shared.Cpu.PopValue().ToString();
+			int size 			= Convert.ToInt32(shared.Cpu.PopValue());	
+			int style 			= Convert.ToInt32(shared.Cpu.PopValue());
+			int delay 			= Convert.ToInt32(shared.Cpu.PopValue());	
+			string textToHud 	= shared.Cpu.PopValue().ToString();
+
+			if (style == 1)
+				{
+				ScreenMessages.PostScreenMessage("<color="+color+"><size="+size+">"+textToHud+"</size></color>", delay, ScreenMessageStyle.UPPER_LEFT);
+				}
+			else if (style == 2)
+				{
+				ScreenMessages.PostScreenMessage("<color="+color+"><size="+size+">"+textToHud+"</size></color>", delay, ScreenMessageStyle.UPPER_CENTER);
+				}
+			else if (style == 3)
+				{
+				ScreenMessages.PostScreenMessage("<color="+color+"><size="+size+">"+textToHud+"</size></color>", delay, ScreenMessageStyle.UPPER_RIGHT);
+				}
+			else if (style == 4)
+				{
+				ScreenMessages.PostScreenMessage("<color="+color+"><size="+size+">"+textToHud+"</size></color>", delay, ScreenMessageStyle.LOWER_CENTER);
+				}
+			else 
+				{
+				ScreenMessages.PostScreenMessage("*"+textToHud, 3f, ScreenMessageStyle.UPPER_CENTER);
+				}
+			if (mirror == 1) 
+				{
+				shared.Screen.Print ("HUD: " + textToHud);
+				//shared.Screen.Print ("delay " + delay);
+				//shared.Screen.Print ("color " + color);
+				//shared.Screen.Print ("size " + size);
+				}
+		}
+	} 
+
 
     [Function("print")]
     public class FunctionPrint : FunctionBase


### PR DESCRIPTION
command format hudtxt ( "text"+var, int delay, int style, int size, "color", bool(0|1) mirror in terminal).
e.g.:   hudtxt ("Hello Kerbin!, I'm "+round(alt:radar)+"m above you", 2, 3, 25, "red", 0).


Text to display = normal rules; text must be in quotes. Variables are bare text. Join text and variables with +.
                           in addition you can enter some HTML tags. I haven't explored this one much "<i>Hello world</i>" will produce italics.
Delay = seconds integers only, the amount of time the message will be displayed. New messages within this time will cause message to scroll
Style = choice of styles between 1 and 4 ~ 1=Upper_left 2=Upper_center 3=Upper_right 4=Lower_center   The positions of upper right is actually lower right... comes from KSP code. If an improper choice is made i.e.:5 then defaults and prefixes with *.
Size = ? not really sure what this is in terms of how big the text is. 15 will get you started on any. 150 is huge. Effect varies depending on style
Color = (hurts my Canadian eyes, COLOUR!) this is the same as an HTML color tag. e.g. "red" or "#ff0099ff"
Mirror = mirror the on screen display in the terminal 0=no 1=yes (I want to change this to a real boolean when I figure out how)

That's all I got. The command lines are long, but easily remembered.