### PR TITLE
HudTxt function

### DIFF
--- a/src/kOS/Function/Misc.cs
+++ b/src/kOS/Function/Misc.cs
@@ -28,7 +28,7 @@ namespace kOS.Function
         }
     }
 
-[Function("hudtxt")]
+[Function("hudtext")]
     public class FunctionHudTxt : FunctionBase
     {
 

--- a/src/kOS/Function/Misc.cs
+++ b/src/kOS/Function/Misc.cs
@@ -27,52 +27,40 @@ namespace kOS.Function
             shared.Screen.Print(textToPrint);
         }
     }
-
-[Function("hudtext")]
+    
+    [Function("hudtext")]
     public class FunctionHudText : FunctionBase
     {
-
-        public override void Execute(SharedObjects shared)
+        public override void Execute (SharedObjects shared)
 
         {
-            int mirror          = Convert.ToInt32(shared.Cpu.PopValue());
-            string color        = shared.Cpu.PopValue().ToString();
-            int size            = Convert.ToInt32(shared.Cpu.PopValue());   
-            int style           = Convert.ToInt32(shared.Cpu.PopValue());
-            int delay           = Convert.ToInt32(shared.Cpu.PopValue());   
-            string textToHud    = shared.Cpu.PopValue().ToString();
-
-            if (style == 1)
-                {
-                ScreenMessages.PostScreenMessage("<color="+color+"><size="+size+">"+textToHud+"</size></color>", delay, ScreenMessageStyle.UPPER_LEFT);
-                }
-            else if (style == 2)
-                {
-                ScreenMessages.PostScreenMessage("<color="+color+"><size="+size+">"+textToHud+"</size></color>", delay, ScreenMessageStyle.UPPER_CENTER);
-                }
-            else if (style == 3)
-                {
-                ScreenMessages.PostScreenMessage("<color="+color+"><size="+size+">"+textToHud+"</size></color>", delay, ScreenMessageStyle.UPPER_RIGHT);
-                }
-            else if (style == 4)
-                {
-                ScreenMessages.PostScreenMessage("<color="+color+"><size="+size+">"+textToHud+"</size></color>", delay, ScreenMessageStyle.LOWER_CENTER);
-                }
-            else 
-                {
-                ScreenMessages.PostScreenMessage("*"+textToHud, 3f, ScreenMessageStyle.UPPER_CENTER);
-                }
-            if (mirror == 1) 
-                {
+            bool      echo      = Convert.ToBoolean(shared.Cpu.PopValue());
+            RgbaColor rgba      = GetRgba(shared.Cpu.PopValue());
+            int       size      = Convert.ToInt32 (shared.Cpu.PopValue ());    
+            int       style     = Convert.ToInt32 (shared.Cpu.PopValue ());
+            int       delay     = Convert.ToInt32 (shared.Cpu.PopValue ());   
+            string    textToHud = shared.Cpu.PopValue ().ToString ();
+            string   htmlColour = rgba.ToHTMLString();
+            {                            
+            if (style == 1) {
+                ScreenMessages.PostScreenMessage("<color=" + htmlColour + "><size=" + size + ">" + textToHud + "</size></color>",delay,ScreenMessageStyle.UPPER_LEFT);
+            } else if (style == 2) {
+                ScreenMessages.PostScreenMessage("<color=" + htmlColour + "><size=" + size + ">" + textToHud + "</size></color>",delay,ScreenMessageStyle.UPPER_CENTER);
+            } else if (style == 3) {
+                ScreenMessages.PostScreenMessage("<color=" + htmlColour + "><size=" + size + ">" + textToHud + "</size></color>",delay,ScreenMessageStyle.UPPER_RIGHT);
+            } else if (style == 4) {
+                ScreenMessages.PostScreenMessage("<color=" + htmlColour + "><size=" + size + ">" + textToHud + "</size></color>",delay,ScreenMessageStyle.LOWER_CENTER);
+            } else {
+                ScreenMessages.PostScreenMessage("*" + textToHud, 3f, ScreenMessageStyle.UPPER_CENTER);
+            }
+            if (echo) {
                 shared.Screen.Print ("HUD: " + textToHud);
-                //shared.Screen.Print ("delay " + delay);
-                //shared.Screen.Print ("color " + color);
-                //shared.Screen.Print ("size " + size);
-                }
-        }
-    } 
+            }
+            }
 
+         }
 
+    
     [Function("printat")]
     public class FunctionPrintAt : FunctionBase
     {

--- a/src/kOS/Function/Misc.cs
+++ b/src/kOS/Function/Misc.cs
@@ -28,6 +28,51 @@ namespace kOS.Function
         }
     }
 
+[Function("hudtxt")]
+    public class FunctionHudTxt : FunctionBase
+    {
+
+        public override void Execute(SharedObjects shared)
+
+        {
+            int mirror          = Convert.ToInt32(shared.Cpu.PopValue());
+            string color        = shared.Cpu.PopValue().ToString();
+            int size            = Convert.ToInt32(shared.Cpu.PopValue());   
+            int style           = Convert.ToInt32(shared.Cpu.PopValue());
+            int delay           = Convert.ToInt32(shared.Cpu.PopValue());   
+            string textToHud    = shared.Cpu.PopValue().ToString();
+
+            if (style == 1)
+                {
+                ScreenMessages.PostScreenMessage("<color="+color+"><size="+size+">"+textToHud+"</size></color>", delay, ScreenMessageStyle.UPPER_LEFT);
+                }
+            else if (style == 2)
+                {
+                ScreenMessages.PostScreenMessage("<color="+color+"><size="+size+">"+textToHud+"</size></color>", delay, ScreenMessageStyle.UPPER_CENTER);
+                }
+            else if (style == 3)
+                {
+                ScreenMessages.PostScreenMessage("<color="+color+"><size="+size+">"+textToHud+"</size></color>", delay, ScreenMessageStyle.UPPER_RIGHT);
+                }
+            else if (style == 4)
+                {
+                ScreenMessages.PostScreenMessage("<color="+color+"><size="+size+">"+textToHud+"</size></color>", delay, ScreenMessageStyle.LOWER_CENTER);
+                }
+            else 
+                {
+                ScreenMessages.PostScreenMessage("*"+textToHud, 3f, ScreenMessageStyle.UPPER_CENTER);
+                }
+            if (mirror == 1) 
+                {
+                shared.Screen.Print ("HUD: " + textToHud);
+                //shared.Screen.Print ("delay " + delay);
+                //shared.Screen.Print ("color " + color);
+                //shared.Screen.Print ("size " + size);
+                }
+        }
+    } 
+
+
     [Function("printat")]
     public class FunctionPrintAt : FunctionBase
     {

--- a/src/kOS/Function/Misc.cs
+++ b/src/kOS/Function/Misc.cs
@@ -29,7 +29,7 @@ namespace kOS.Function
     }
 
 [Function("hudtext")]
-    public class FunctionHudTxt : FunctionBase
+    public class FunctionHudText : FunctionBase
     {
 
         public override void Execute(SharedObjects shared)


### PR DESCRIPTION
Adds function to allow text to be displayed on screen via kOS script.

command format hudtxt ( "text"+var, int delay, int style, int size, "color", bool(true/false) echo in terminal).
e.g.: hudtxt ("Hello Kerbin!, I'm "+round(alt:radar)+"m above you", 2, 3, 25, "red", 0).

Text to display = normal rules; text must be in quotes. Variables are bare text. Join text and variables with +.
in addition you can enter some HTML tags in the text field. I haven't explored this one much <i>"Hello world"</i> will produce italics.
Delay = seconds in integers only, the amount of time the message will be displayed. New messages within this time will cause previous message to scroll up.
Style = choice of styles between 1 and 4 ~ 1=Upper_left 2=Upper_center 3=Upper_right 4=Lower_center The positions of upper right is actually lower right... comes from KSP code. If an improper choice is made i.e.:5 then defaults and prefixes with *.
Size = ? not really sure what this is in terms of how big the text is. 15 will get you started on any. 150 is huge. Effect varies depending on style.
Colour = you can enter an rgb colour value in the form rgb(0.002,0.768,0.768) (this is a nice turquoise)
Colour values are floats between 0 and 1, per Unity. Take your normal RGB numbers and divide by 255 to get the float. 
Echo = echo's the on screen display in the terminal false=no true=yes