### PR TITLE
Added RgbaColor.ToHTMLString() so HUDTEXT can use it.

### DIFF
--- a/doc/source/structures/misc/colors.rst
+++ b/doc/source/structures/misc/colors.rst
@@ -51,6 +51,32 @@ Method 1: Use one of these pre-arranged named colors:
     ``a``
         A floating point number from 0.0 to 1.0 for the alpha component. (1.0 means opaque, 0.0 means invisibly transparent).
 
+.. structure:: RGBA
+
+    .. list-table:: Members
+        :header-rows: 1
+        :widths: 2 1 4
+
+        * - Suffix
+          - Type
+          - Description
+
+        * - :R or :RED
+          - scalar
+          - the red component of the color
+        * - :G or :GREEN
+          - scalar
+          - the green component of the color
+        * - :B or :BLUE
+          - scalar
+          - the blue component of the color
+        * - :A or :ALPHA
+          - scalar
+          - the alpha (how opaque: 1 = opaque, 0 = transparent) component of the color
+        * - :HTML
+          - string
+          - the color rendered into a HTML tag string i.e. "#ff0000".  This format ignores the alpha channel and treats all colors as opaue.
+
 Examples::
 
     SET myarrow TO VECDRAW.
@@ -65,4 +91,6 @@ Examples::
 
     // half transparent yellow.
     SET myarrow:COLOR to RGBA(1.0,1.0,0.0,0.5).
+
+    PRINT GREEN:HTML. // prints #00ff00
 

--- a/src/kOS/Suffixed/RgbaColor.cs
+++ b/src/kOS/Suffixed/RgbaColor.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
 
@@ -25,6 +26,7 @@ namespace kOS.Suffixed
             AddSuffix(new [] { "G", "GREEN" } , new ClampSetSuffix<float>(() => color.g, value => color.g = value, 0, 255));
             AddSuffix(new [] { "B", "BLUE" } , new ClampSetSuffix<float>(() => color.b, value => color.b = value, 0, 255));
             AddSuffix(new [] { "A", "ALPHA" } , new ClampSetSuffix<float>(() => color.a, value => color.a = value, 0, 1));
+            AddSuffix("HTML", new NoArgsSuffix<string>(ToHTMLString, "Returns a string representing the color in HTML, i.e. \"#ff0000\".  Ignores transparency (alpha) information."));
         }
         
         public Color Color()
@@ -35,6 +37,24 @@ namespace kOS.Suffixed
         public override string ToString()
         {
             return "RGBA(" + color.r + ", " + color.g + ", " + color.b + ", " + color.a + ")";
+        }
+        
+        /// <summary>
+        /// Returns a string represnting the HTML color code "#rrggbb" format
+        /// for the color.  (i.e. RED is "#ff0000").  Note that this cannot represent
+        /// the transparency (alpha) information, and will treat the color as if it was
+        /// fully opaque regardless of whether it really is or not.  Although there have
+        /// been some extensions to the HTML specification that added a fourth byte for
+        /// alpha information, i.e. "#80ff0000" would be a semitransparent red, those never
+        /// got accepted as standard and remain special proprietary extensions.
+        /// </summary>
+        /// <returns>The html spec string returned, using lowercase lettering for the alpha digits</returns>
+        public string ToHTMLString()
+        {
+            byte redByte   = (byte)(Mathf.Min(255, (int)(color.r * 255f)));
+            byte greenByte = (byte)(Mathf.Min(255, (int)(color.g * 255f)));
+            byte blueByte  = (byte)(Mathf.Min(255, (int)(color.b * 255f)));
+            return String.Format("#{0:x2}{1:x2}{2:x2}", redByte, greenByte, blueByte);
         }
 
     }


### PR DESCRIPTION
Also added the :HTML suffix to use it from in a program,
even though I can't think of any logical reason yet why it would
be useful to a script - there's no reason not to let people see it.