### PR TITLE
fixes #72 and resolves #548

### DIFF
--- a/doc/source/structures.rst
+++ b/doc/source/structures.rst
@@ -28,6 +28,7 @@ A general discussion of structures :ref:`can be found here <language structures>
     * :struct:`AggregateResource`
     * :struct:`DockingPort`
     * :struct:`Gimbal`
+    * :struct:`Stage`
     * :struct:`Part`
     * :struct:`PartModule`
     * :struct:`Sensor`

--- a/doc/source/structures/vessels/stage.rst
+++ b/doc/source/structures/vessels/stage.rst
@@ -1,0 +1,98 @@
+.. _stage:
+
+Stage
+=============
+
+*Contents*
+
+    - :global:`EXAMPLE`
+    - :global:`READY`
+    - :global:`RESOURCES`
+    - :struct:`Stage`
+
+A planned velocity change along an orbit. These are the nodes that you can set in the KSP user interface. Setting one through kOS will make it appear on the in-game map view, and creating one manually on the in-game map view will cause it to be visible to kOS.
+
+Access
+--------
+
+You access the current stage for the vessel the kOS core is attached to with the STAGE: command.
+
+.. global::EXAMPLE	 
+	
+	
+    A very simple auto-stager using :READY
+	
+	LIST ENGINES IN elist.
+
+	UNTIL false {
+	    PRINT "Stage: " + STAGE:NUMBER AT (0,0).
+		FOR e IN elist {
+			IF e:FLAMEOUT {
+				STAGE.
+				PRINT "STAGING!" AT (0,0).
+				
+				UNTIL STAGE:READY {	} 
+				
+				LIST ENGINES IN elist.
+				CLEARSCREEN.
+				BREAK.    
+			}
+		}
+	}
+
+.. global::NUMBER
+
+	Every craft has a current stage, and that stage is represented by a number, this is it!
+	
+.. global::RESOURCES
+    
+	
+	
+Structure
+---------
+
+.. structure:: Stage
+
+    .. list-table:: Members
+        :header-rows: 1
+        :widths: 1 1 1 2
+
+        * - Suffix
+          - Type (units)
+          - Access
+          - Description
+
+        * - :attr:`READY`
+          - bool
+          - Get only
+          - Is the craft ready to activate the next stage.
+        * - :attr:`NUMBER`
+          - scalar
+          - Get only
+          - The current stage number for the craft
+        * - :attr:`RESOURCES`
+          - :struct:`List`
+          - Get only
+          - the :struct:`List` of :struct:`Resource` in the current stage
+
+.. attribute:: Stage:READY
+
+    :access: Get only
+    :type: bool
+
+	Kerbal Space Program enforces a small delay between staging commands, this is to allow the last staging command to complete. This bool value will let you know if kOS can activate the next stage.
+
+.. attribute:: Stage:NUMBER
+
+    :access: Get only
+    :type: scalar
+	
+    Every craft has a current stage, and that stage is represented by a number, this is it!
+
+.. attribute:: Stage:Resources
+
+    :access: Get
+    :type: :struct:`List`
+
+    This is a collection of the available :struct:`Resource` for the current stage.
+	

--- a/doc/source/structures/vessels/stage.rst
+++ b/doc/source/structures/vessels/stage.rst
@@ -6,18 +6,11 @@ Stage
 *Contents*
 
     - :global:`EXAMPLE`
-    - :global:`READY`
-    - :global:`RESOURCES`
     - :struct:`Stage`
-
-A planned velocity change along an orbit. These are the nodes that you can set in the KSP user interface. Setting one through kOS will make it appear on the in-game map view, and creating one manually on the in-game map view will cause it to be visible to kOS.
-
-Access
---------
 
 You access the current stage for the vessel the kOS core is attached to with the STAGE: command.
 
-.. global::EXAMPLE	 
+.. global::EXAMPLE	
 	
 	
     A very simple auto-stager using :READY

--- a/src/kOS/Function/Misc.cs
+++ b/src/kOS/Function/Misc.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using FinePrint.Utilities;
 using kOS.Execution;
 using kOS.Safe.Compilation;
+using kOS.Safe.Exceptions;
 using kOS.Safe.Function;
 using kOS.Safe.Module;
 using kOS.Safe.Persistence;
 using kOS.Suffixed;
+using kOS.Utilities;
 
 namespace kOS.Function
 {
@@ -57,7 +60,18 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            Staging.ActivateNextStage();
+            if (Staging.separate_ready && shared.Vessel.isActiveVessel)
+            {
+                Staging.ActivateNextStage();
+            }
+            else if (!Staging.separate_ready)
+            {
+                Safe.Utilities.Debug.Logger.Log("FAIL SILENT: Stage is called before it is ready, Use STAGE:READY to check first if staging rapidly");
+            }
+            else if (!shared.Vessel.isActiveVessel)
+            {
+                throw new KOSCommandInvalidHere("STAGE", "a non-active SHIP, KSP does not support this", "Core is on the active vessel");
+            }
         }
     }
 

--- a/src/kOS/Suffixed/StageValues.cs
+++ b/src/kOS/Suffixed/StageValues.cs
@@ -18,7 +18,10 @@ namespace kOS.Suffixed
 
         private void InitializeSuffixes()
         {
+            AddSuffix("NUMBER", new Suffix<int>(() => Staging.CurrentStage));
+            AddSuffix("READY", new Suffix<bool>(() => shared.Vessel.isActiveVessel && Staging.separate_ready));
             AddSuffix("RESOURCES", new Suffix<ListValue<ActiveResourceValue>>(GetResourceManifest));
+
         }
 
         private ListValue<ActiveResourceValue> GetResourceManifest()


### PR DESCRIPTION
this PR gives us two new suffixes

* STAGE:READY
* STAGE:NUMBER

this will let someone who wants to know when they can stage and what stage number they are on the ability to do so.

This also resolves #548 by not letting you stage and having STAGE:READY always be false on craft other than the active craft. This is a Kerbal Space Program restriction :(