### PR TITLE
fixes #571 - telnet clearsceen bug.

### DIFF
--- a/src/kOS.Safe/Screen/ScreenSnapshot.cs
+++ b/src/kOS.Safe/Screen/ScreenSnapshot.cs
@@ -47,6 +47,24 @@ namespace kOS.Safe.Screen
         private ScreenSnapShot()
         {
         }
+
+        /// <summary>
+        /// A factory that constructs an empty screen buffer of a correct size for the fromScreen
+        /// </summary>
+        /// <param name="fromScreen">The screen - only used to determine the needed width/height</param>
+        /// <returns>An empty snapshot buffer</returns>
+        public static ScreenSnapShot EmptyScreen(IScreenBuffer fromScreen)
+        {
+            ScreenSnapShot newThing = new ScreenSnapShot();
+            newThing.TopRow = fromScreen.TopRow;
+            newThing.CursorColumn = fromScreen.CursorColumnShow;
+            newThing.CursorRow = fromScreen.CursorRowShow;
+            newThing.RowCount = fromScreen.RowCount;
+            newThing.Buffer = new List<IScreenBufferLine>();
+            for (int i = 0; i < newThing.RowCount ; ++i)
+                newThing.Buffer.Add(new ScreenBufferLine(fromScreen.ColumnCount));
+            return newThing;
+        }
         
         /// <summary>
         /// Make a copy of me for later diffing against.

--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -459,6 +459,14 @@ namespace kOS.Screen
             }
         }
         
+        /// <summary>
+        /// Get the newest copy of the screen buffer once, for use in all calculations for a while.
+        /// This was added when telnet clients were added.  The execution cost of obtaining a buffer snapshot
+        /// from the ScreenBuffer class is non-trivial, and therefore shouldn't be done over and over
+        /// for each telnet client that needs it within the span of a short time.  This gets it
+        /// once for all of them to borrow.  All calls will re-use this copy for a while,
+        /// until the next terminal refresh (1/20th of a second, at the moment).
+        /// </summary>
         void GetNewestBuffer()
         {
             DateTime newTime = DateTime.Now;
@@ -796,7 +804,10 @@ namespace kOS.Screen
         {
             shared.Screen.ClearScreen();
             foreach (TelnetSingletonServer telnet in telnets)
+            {
                 telnet.Write((char)UnicodeCommand.CLEARSCREEN);
+                prevTelnetScreens[telnet] = ScreenSnapShot.EmptyScreen(shared.Screen);
+            }
         }
 
         public int NumTelnets()


### PR DESCRIPTION
Needed to explixitly set the prev screen buffer snapshot
to a blank buffer when the telnet client is given a
CLEARSCREEN directive, else the prev buffer stays at whatever
the previous snapshot looked like prior to the clearscreen.
So it does not represent what the terminal really looks like.