### PR TITLE
Fixes #555 by altering the new vessel check logic.

### DIFF
--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -381,7 +381,7 @@ namespace kOS.Module
 
         public void UpdateParts()
         {
-            // Trigger whenever the number of parts in the vessel changes (like when staging, docking or undocking)
+            // Trigger whenever the number of parts in the vessel changes (like when staging, docking or undocking).
             if (vessel.parts.Count == vesselPartCount) return;
 
             var missingHardDisks = false;


### PR DESCRIPTION
The old code had some wonky behavior where as long as the new
vessel being switched to was valid... it refused to do the switch.

Here's a screenshot of the previous wonky behavior:

The vessel before decoupling
[!http://i.imgur.com/nQILanS.png]

The vessel after decoupling:  The terminal with the errors on it is the one attached to the lower half of the ship.
[!http://i.imgur.com/sXtBcyj.png]

The same test works fine now with the new change, and I tested the that controls do in fact try to control the new ship( not the old ship), by adding a bunch of overpowered torque wheel units and proving that I can yaw and pitch the new detached ship with SHIP:CONTROL:YAW or SHIP:CONTROL:PITCH and it won't try to yaw and pitch the old ship like it used to.
