### PR TITLE
Fixes #570 - angular velocity.

### DIFF
--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using kOS.Binding;
+using UnityEngine;
 using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Exceptions;
@@ -403,7 +404,7 @@ namespace kOS.Suffixed
             AddSuffix("MAXTHRUST", new Suffix<double>(() => VesselUtils.GetMaxThrust(Vessel)));
             AddSuffix("FACING", new Suffix<Direction>(() => VesselUtils.GetFacing(Vessel)));
             AddSuffix("ANGULARMOMENTUM", new Suffix<Vector>(() => new Vector(Vessel.angularMomentum)));
-            AddSuffix("ANGULARVEL", new Suffix<Vector>(() => new Vector(Vessel.angularVelocity)));
+            AddSuffix("ANGULARVEL", new Suffix<Vector>(() => RawAngularVelFromRelative(Vessel.angularVelocity)));
             AddSuffix("MASS", new Suffix<float>(() => Vessel.GetTotalMass()));
             AddSuffix("VERTICALSPEED", new Suffix<double>(() => Vessel.verticalSpeed));
             AddSuffix("SURFACESPEED", new Suffix<double>(() => Vessel.horizontalSrfSpeed));
@@ -441,6 +442,21 @@ namespace kOS.Suffixed
             {
                 Vessel.vesselName = value;
             }
+        }
+        
+        /// <summary>
+        /// Annoyingly, KSP returns vessel.angularVelociy in a frame of reference 
+        /// relative to the ship facing instead of the universe facing.  This would be
+        /// wonderful if that was their philosophy everywhere, but it's not - its just a
+        /// weird exception for this one case.  This transforms it back into raw universe
+        /// axes again:
+        /// </summary>
+        /// <param name="kSPAngularVel">the value KSP is returning for angular velocity</param>
+        /// <returns>altered velocity in the new reference frame</returns>
+        private Vector RawAngularVelFromRelative(Vector3 angularVelFromKSP)
+        {
+            return new Vector(VesselUtils.GetFacing(Vessel).Rotation *
+                              new Vector3d(angularVelFromKSP.x, -angularVelFromKSP.z, angularVelFromKSP.y));
         }
 
         public override object GetSuffix(string suffixName)

--- a/src/kOS/Utilities/VesselUtils.cs
+++ b/src/kOS/Utilities/VesselUtils.cs
@@ -418,5 +418,12 @@ namespace kOS.Utilities
             Quaternion vesselFacing = Quaternion.Inverse(Quaternion.Euler(90, 0, 0) * Quaternion.Inverse(vesselRotation) * Quaternion.identity);
             return new Direction(vesselFacing);
         }
+        
+        public static Direction GetFacing(CelestialBody body)
+        {
+            var bodyRotation = body.transform.rotation;
+            Quaternion bodyFacing = Quaternion.Inverse(Quaternion.Euler(90, 0, 0) * Quaternion.Inverse(bodyRotation) * Quaternion.identity);
+            return new Direction(bodyFacing);
+        }
     }
 }


### PR DESCRIPTION
The fix also was done to Body's angular velocity even though I can't imagine
anyone using that.  (i.e any body's angularvel now points along its south
pole axis direction, which makes sense for a counterclockwise rotation of
a body in left-handed space)