### PR TITLE
Add support for switching to default volume on mode change

### DIFF
--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -528,8 +528,15 @@ namespace kOS.Module
                 switch (newProcessorMode)
                 {
                     case ProcessorModes.READY:
-                        if ((ProcessorMode == ProcessorModes.STARVED || ProcessorMode == ProcessorModes.OFF) && shared.Cpu != null)
-                            shared.Cpu.Boot();
+                        if (Config.Instance.StartOnArchive)
+                        {
+                            shared.VolumeMgr.SwitchTo(shared.VolumeMgr.GetVolume(0));
+                        }
+                        else
+                        {
+                            shared.VolumeMgr.SwitchTo(HardDisk);
+                        }
+                        if (shared.Cpu != null) shared.Cpu.Boot();
                         if (shared.Interpreter != null) shared.Interpreter.SetInputLock(false);
                         if (shared.Window != null) shared.Window.IsPowered = true;
                         break;


### PR DESCRIPTION
kOSProcessor.cs - added logic to switch to the default volume if the cpu
is being turned on.  Also removed the check for STARVED or OFF modes
before calling Cpu.Boot, since one of those two conditions must be true.