### PR TITLE
Fixes #610 and #612 - two telnet terminal issues.

### DIFF
--- a/src/kOS.Safe/Screen/ScreenBuffer.cs
+++ b/src/kOS.Safe/Screen/ScreenBuffer.cs
@@ -80,6 +80,18 @@ namespace kOS.Safe.Screen
             return ScrollVerticalInternal(deltaRows);
         }
 
+        /// <summary>
+        /// Marks the given section of rows in the buffer as dirty and
+        /// in need of a diff check.
+        /// </summary>
+        /// <param name="startRow">Starting with this row number</param>
+        /// <param name="numRows">for this many rows</param>
+        public void MarkRowsDirty(int startRow, int numRows)
+        {
+            for( int i = 0; i < numRows ; ++i)
+                buffer[startRow + i].TouchTime();
+        }
+
         public void MoveCursor(int row, int column)
         {
             if (row >= RowCount)
@@ -232,7 +244,7 @@ namespace kOS.Safe.Screen
 
                         // remove the replaced rows
                         mergedBuffer.RemoveRange(mergeRow, rowsToMerge);
-                        // insert the new ones
+                        // Replace them:
                         mergedBuffer.InsertRange(mergeRow, bufferRange);
                     }
                 }

--- a/src/kOS.Safe/Screen/ScreenBufferLine.cs
+++ b/src/kOS.Safe/Screen/ScreenBufferLine.cs
@@ -54,6 +54,7 @@ namespace kOS.Safe.Screen
         public ScreenBufferLine(int size)
         {
             charArray = new char[size];
+            TouchTime();
         }
 
         /// <summary>
@@ -84,6 +85,9 @@ namespace kOS.Safe.Screen
             TouchTime();
         }
 
+        /// <summary>
+        /// Marks the line as recent by updating its "last change time" marker to now.
+        /// </summary>
         public void TouchTime()
         {
             LastChangeTick = TickGen.Next;

--- a/src/kOS.Safe/Screen/SubBuffer.cs
+++ b/src/kOS.Safe/Screen/SubBuffer.cs
@@ -27,6 +27,8 @@ namespace kOS.Safe.Screen
         /// <param name="columnCount">Desired new number of columns (this will be adhered to faithfully).</param>
         public void SetSize(int rowCount, int columnCount)
         {
+            foreach( IScreenBufferLine lineBuff in Buffer)
+                lineBuff.TouchTime();
             RowCount = rowCount;
             ColumnCount = columnCount;
             ResizeBuffer();

--- a/src/kOS.Safe/Screen/TextEditor.cs
+++ b/src/kOS.Safe/Screen/TextEditor.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Text;
+using System;
 using kOS.Safe.UserIO;
 
 namespace kOS.Safe.Screen
@@ -107,6 +108,7 @@ namespace kOS.Safe.Screen
                 if (LineCursorIndex >= 0 && LineCursorIndex < LineBuilder.Length)
                 {
                     LineBuilder.Remove(LineCursorIndex, 1);
+                    MarkRowsDirty(LineSubBuffer.PositionRow, LineSubBuffer.RowCount); // just in case removing it reduces the number of subbuffer lines.
                     UpdateLineSubBuffer();
                 }
             }
@@ -132,7 +134,9 @@ namespace kOS.Safe.Screen
             List<string> lines = SplitIntoLinesPreserveNewLine(commandText);
                         
             if (lines.Count != LineSubBuffer.RowCount)
+            {
                 LineSubBuffer.SetSize(lines.Count, LineSubBuffer.ColumnCount);
+            }
 
             for (int lineIndex = 0; lineIndex < lines.Count; lineIndex++)
             {

--- a/src/kOS.Safe/Utilities/TickGen.cs
+++ b/src/kOS.Safe/Utilities/TickGen.cs
@@ -7,7 +7,7 @@ namespace kOS.Safe.Utilities
     /// for a number.  That's all.  Its meant to be used to timestamp the relative age of things.
     /// Bigger numbers were returned later in the life of the program than smaller ones.
     /// It could potentially overflow, but only if the program ran nonstop without crashing for
-    /// a ludicrous amount of time.  (Uint64 can store a number more than two orders of magnitude
+    /// a ludicrous amount of time.  (Int64 can store a number more than two orders of magnitude
     /// larger than the number of NANOseconds in a year.)
     /// </summary>
     public class TickGen

--- a/src/kOS/Screen/Interpreter.cs
+++ b/src/kOS/Screen/Interpreter.cs
@@ -71,7 +71,6 @@ namespace kOS.Screen
             switch (key)
             {
                 case (char)UnicodeCommand.UPCURSORONE:
-                    System.Console.WriteLine("Just pressed UPCURSOR");
                     ShowCommandHistoryEntry(-1);
                     break;
                 case (char)UnicodeCommand.DOWNCURSORONE:

--- a/src/kOS/Screen/Interpreter.cs
+++ b/src/kOS/Screen/Interpreter.cs
@@ -71,6 +71,7 @@ namespace kOS.Screen
             switch (key)
             {
                 case (char)UnicodeCommand.UPCURSORONE:
+                    System.Console.WriteLine("Just pressed UPCURSOR");
                     ShowCommandHistoryEntry(-1);
                     break;
                 case (char)UnicodeCommand.DOWNCURSORONE:
@@ -103,6 +104,7 @@ namespace kOS.Screen
                     LineBuilder = new StringBuilder();
                     LineBuilder.Append(commandHistory[commandHistoryIndex]);
                     LineCursorIndex = LineBuilder.Length;
+                    MarkRowsDirty(LineSubBuffer.PositionRow, LineSubBuffer.RowCount);
                     LineSubBuffer.Wipe();
                     UpdateLineSubBuffer();
                 }


### PR DESCRIPTION
Problem #610:
    The problem was caused by the screen differ attempting
    to actually print the nullchars stored in the screen
    buffer instead of printing them as space chars.  Thus a
    diff chunk that should have been printed as "AAA   BBB" got
    printed out as "AAA" followed by 3 null chars, followed by
    "BBB".  The terminal on the client end will not advance the
    cursor forward when printing a null char, thus the "BBB" got
    printed adjacent to the "AAA".

    Interestingly, the reason I didn't detect the problem in my own testing
    before release is that it need exactly the following conditions to be true
    in order to trigger it:

    (A) the area of the screen being PRINT AT'ed to has to have been
        previously unused. (If it had been populated by some text and then
        the text overwritten by  the PRINT AT, then the PRINT AT worked
        fine.  For example, if you print out a decorative border with spaces
        filling its inside, then paint the values atop those spaces, the bug
        didn't appear - which is why I didn't catch it.)
    and
    (B) The run of space between the "AAA" and the "BBB" has to be no
        larger than JOIN_DIFF_DIST (6) to trigger the problem, thus
        PRINT "AAAAAA" AT (20,5). PRINT "BBB" AT (30,5).
        will trigger the problem, while
        PRINT "AAAAAA" AT (20,5). PRINT "BBB" AT (40,5).
        will not.  If the two strings are far enough apart, then the
        system will teleport the cursor from one to the other instead
        of trying to print out the intervening space.

Problem #612:
    The problem was caused by slight messy behavior about the
    timestamp ages on rows of the screen that are occluded by a
    subbuffer and then the subbuffer shrinks to reveal more of
    the screen it was masking.  The system didn't mark the screen
    rows it previously masked off as being newly changed and in
    need of an update.