### PR TITLE
Fixes #609 by running FOR bodies through the preprocessor

### DIFF
--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -176,6 +176,7 @@ namespace kOS.Safe.Compilation.KS
                 case TokenType.instruction:
                 case TokenType.if_stmt:
                 case TokenType.until_stmt:
+                case TokenType.for_stmt:
                     PreProcessChildNodes(node);
                     break;
                 case TokenType.on_stmt:


### PR DESCRIPTION
This problem must have been broken like this for a long time and only just now got noticed.


The problem was caused by one omitted alternation of a switch/case statement in PreProcessStatements().

RUN is a statement that needs to be visited by the PreProcessor to work right.

FOR was not allowing PreProcessor to recurse down into itself.

The same problem would have happened if you tried to have a WHEN/THEN inside a FOR, or a WAIT UNTIL inside a FOR.

The only statements that worked inside FOR loops were ones that could operate entirely from Visit**Foo** calls and didn't need any PreProcess**Foo** calls.

Fixed now.  One line change.