### PR TITLE
Fixes #618 Boot selection, hidden and system files

### DIFF
--- a/src/kOS.Safe/Persistence/Archive.cs
+++ b/src/kOS.Safe/Persistence/Archive.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Xml.Linq;
 using kOS.Safe.Utilities;
 using FileInfo = kOS.Safe.Encapsulation.FileInfo;
 
@@ -172,7 +173,14 @@ namespace kOS.Safe.Persistence
             try
             {
                 SafeHouse.Logger.Log(string.Format("Archive: Listing Files"));
-                var kosFiles = Directory.GetFiles(ArchiveFolder);
+                var listFiles = Directory.GetFiles(ArchiveFolder);
+                var filterHid =  Directory.GetFiles(ArchiveFolder).Select(f => f)
+                    .Where(f => (File.GetAttributes (f) & FileAttributes.Hidden) != 0);
+                var filterSys =  Directory.GetFiles(ArchiveFolder).Select(f => f)
+                    .Where(f => (File.GetAttributes (f) & FileAttributes.System ) != 0);
+                var noHid    =   listFiles.Except(filterHid);
+                var visFiles =   noHid.Except(filterSys);
+                var kosFiles =   visFiles.Except(Directory.GetFiles(ArchiveFolder, ".*"));
                 retList.AddRange(kosFiles.Select(file => new System.IO.FileInfo(file)).Select(sysFileInfo => new FileInfo(sysFileInfo)));
             }
             catch (DirectoryNotFoundException)


### PR DESCRIPTION
Hidden and system files on PC/Windows and "dot" files on Mac disrupt file enumeration for boot file selection.
This filters those out.
Strange but true... Mac has a "hidden" file attribute as does Linux/Unix, that is different from PC/Windows attribute.
Chased this special hidden attribute down for a while, but this is so obscure it's not likely to ever come up.