### PR TITLE
made cleaner way to print the debug_each_opcode.

### DIFF
--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -1377,7 +1377,10 @@ namespace kOS.Safe.Compilation
 
             if ( (shouldBeArgMarker == null) || (!(shouldBeArgMarker.Equals(OpcodeCall.ARG_MARKER_STRING))) )
             {
-                throw new KOSArgumentMismatchException("(detected when returning from function)");
+                cpu.DumpVariables(); // eraseme.
+                throw new KOSArgumentMismatchException(
+                    "(detected when returning from function and the stack still had " +
+                    (shouldBeArgMarker ?? "a non-string value") + " on it)");
             }
             // If the proper argument marker was found, then it's all okay, so put the return value
             // back, where it belongs, now that the arg start marker was popped off:


### PR DESCRIPTION
In trying to diagnose another problem, I attempted to turn on the DEBUG_EACH_OPCODE check in Cpu.ExecuteInstruction(), like so:
```
   bool DEBUG_EACH_OPCODE = true;
```
The code that this enabled prints out a log of each and every execution of every opcode.  That's very verbose, but that's what it's for.

The problem is that it massively kills the framerate, and the reason is that it runs each opcode through the Unity.Debug.Log() method, which RE-OPENS the log file, writes one thing, and then closes the log file again.  That's why it's so slow.

To speed it up, and make it still possible to use that option without killing the framerate (and thus invalidating whatever you are testing for as the timings are all wrong), I changed it to append the per-instruction messages to a StringBuilder in memory, and then only dump the result through Unity.Debug.Log() once per Update() rather than once per Instruction.  (there's also a try/catch to make sure it prints the partial Update()'s worth of stuff when it hits an exception and stops.)


Here's an example of what the new output looks like if you set DEBUG_EACH_OPCODE to true:
```
(Filename: C:/BuildAgent/work/d63dfc6385190b60/artifacts/StandalonePlayerGenerated/UnityEngineDebug.cpp Line: 49)

kOS: Executing Opcode 0014/2239 @0016 push $throttle
Executing Opcode 0015/2239 @0017 push $<argstart>
Executing Opcode 0016/2239 @0018 call $throttle*
Executing Opcode 0549/2239 @0496 push $tset
Executing Opcode 0550/2239 @0497 return
Executing Opcode 0017/2239 @0019 store
Executing Opcode 0018/2239 @0020 EOF

 
(Filename: C:/BuildAgent/work/d63dfc6385190b60/artifacts/StandalonePlayerGenerated/UnityEngineDebug.cpp Line: 49)

kOS: Executing Opcode 1368/2239 @1363 push $status
Executing Opcode 1369/2239 @1364 push PRELAUNCH
Executing Opcode 1370/2239 @1365 ne
Executing Opcode 1371/2239 @1366 push $ship
Executing Opcode 1372/2239 @1367 push maxthrust
Executing Opcode 1373/2239 @1368 getmember
Executing Opcode 1374/2239 @1369 push $stagemaxthrust
Executing Opcode 1375/2239 @1370 lt
Executing Opcode 1376/2239 @1371 push $ship
Executing Opcode 1377/2239 @1372 push maxthrust
Executing Opcode 1378/2239 @1373 getmember
Executing Opcode 1379/2239 @1374 push 1
Executing Opcode 1380/2239 @1375 lt
Executing Opcode 1381/2239 @1376 or
Executing Opcode 1382/2239 @1377 and
Executing Opcode 1383/2239 @1378 br.false 25
Executing Opcode 1408/2239 @1403 EOF

 
(Filename: C:/BuildAgent/work/d63dfc6385190b60/artifacts/StandalonePlayerGenerated/UnityEngineDebug.cpp Line: 49)

kOS: Executing Opcode 0009/2239 @0004 push $steering
Executing Opcode 0010/2239 @0005 push $<argstart>
Executing Opcode 0011/2239 @0006 call $steering*
Executing Opcode 1554/2239 @1545 push $np
Executing Opcode 1555/2239 @1546 return
Executing Opcode 0012/2239 @0007 store
Executing Opcode 0013/2239 @0008 EOF
```

