### PR TITLE
Fixes #707 : Trigger hashcodes now forced to differ per compile.

### DIFF
--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -79,6 +79,8 @@ namespace kOS.Safe.Compilation.KS
             this.context = context;
             this.options = options;
             this.startLineNum = startLineNum;
+            
+            ++context.NumCompilesSoFar;
 
             try
             {
@@ -359,14 +361,26 @@ namespace kOS.Safe.Compilation.KS
                 branchOpcode.DestinationLabel = eofOpcode.Label;
             }
         }
+        
 
+        /// <summary>
+        /// Create a unique string out of a sub-branch of the parse tree that
+        /// can be used to uniquely identify it.  The purpose is so that two
+        /// sub-branches of the parse tree can be compared to see if they are 
+        /// the exact same code as each other.</br>
+        /// </summary>
         private string ConcatenateNodes(ParseNode node)
         {
-            string concatenated = node.Token.Text;
+            return context.NumCompilesSoFar.ToString() + ConcatenateNodesRecurse(node);
+        }
+        
+        private string ConcatenateNodesRecurse(ParseNode node)
+        {
+            string concatenated = context.NumCompilesSoFar.ToString() + node.Token.Text;
 
             if (node.Nodes.Any())
             {
-                return node.Nodes.Aggregate(concatenated, (current, childNode) => current + ConcatenateNodes(childNode));
+                return node.Nodes.Aggregate(concatenated, (current, childNode) => current + ConcatenateNodesRecurse(childNode));
             }
 
             return concatenated;

--- a/src/kOS.Safe/Compilation/KS/Context.cs
+++ b/src/kOS.Safe/Compilation/KS/Context.cs
@@ -7,6 +7,7 @@ namespace kOS.Safe.Compilation.KS
         public UserFunctionCollection UserFunctions { get; private set; }
         public TriggerCollection Triggers { get; private set; }
         public SubprogramCollection Subprograms { get; private set; }
+        public int NumCompilesSoFar {get; set;}
         public int LabelIndex { get; set; }
         public string LastSourceName { get; set; }
         
@@ -25,6 +26,7 @@ namespace kOS.Safe.Compilation.KS
             LabelIndex = 0;
             LastSourceName = "";
             MaxScopeIdSoFar = 0;
+            NumCompilesSoFar = 0;
         }
         
     }


### PR DESCRIPTION
Thus the compiler will not treat the hashcodes from one
program compile as identical to the ones from another program compile,
even when the content of the code sections is identical.
It will now be forced to treat them as different, and therefore compile
them separately rather than clobbering over program code like it used to do.
