### PR TITLE
Resolves #688, #722 - WAIT is no longer a trigger.

### DIFF
--- a/doc/source/general/cpu_hardware.rst
+++ b/doc/source/general/cpu_hardware.rst
@@ -43,6 +43,14 @@ Triggers are all of the following:
 -  ON condition { some commands }.
 -  WHEN condition THEN { some commands }.
 
+.. note::
+
+    The :ref:`WAIT <wait>` command only causes mainline code
+    to be suspended.  Trigger code such as WHEN, ON, LOCK STEERING,
+    and LOCK THROTTLE, will continue executing while your program
+    is sitting still on the WAIT command.
+
+
 The way these work is that once per **update tick**, all the LOCK expressions which directly affect flight control are re-executed, and then each conditional trigger's condition is checked, and if true, then the entire body of the trigger is executed all the way to the bottom \*before any more instructions of the main body are executed\*. This means that execution of a trigger never gets interleaved with the main code. Once a trigger happens, the entire trigger occurs all in one go before the rest of the main body continues.
 
 Do Not Loop a Long Time in a Trigger Body!
@@ -81,6 +89,14 @@ But the duration of the next update tick is actually 0.09 seconds, then you will
     WAIT UNTIL TRUE.
 
 Then even though the condition is immediately true, it will still wait one update tick to discover this fact and continue.
+
+.. note::
+
+    The :ref:`WAIT <wait>` command only causes mainline code
+    to be suspended.  Trigger code such as WHEN, ON, LOCK STEERING,
+    and LOCK THROTTLE, will continue executing while your program
+    is sitting still on the WAIT command.
+
 
 The Frozen Universe
 -------------------
@@ -161,7 +177,3 @@ forums. You may put this code up near the top of your script::
       PRESERVE.
     }
 
-An Even Better Solution
-~~~~~~~~~~~~~~~~~~~~~~~
-
-There has been talk of instituting a special command: WAIT UNTIL PHYSICS that will sleep until there has been a physics update, and it's a good idea but it hasn't been implemented yet.

--- a/doc/source/language/flow.rst
+++ b/doc/source/language/flow.rst
@@ -172,6 +172,14 @@ Halts execution for a specified amount of time, or until a specific set of crite
 
 Note that any ``WAIT`` statement, no matter what the actual expression is, will always result in a wait time that lasts at least :ref:`one physics tick <cpu hardware>`.
 
+.. note::
+
+    The :ref:`WAIT <wait>` command only causes mainline code
+    to be suspended.  Trigger code such as WHEN, ON, LOCK STEERING,
+    and LOCK THROTTLE, will continue executing while your program
+    is sitting still on the WAIT command.
+    
+
 .. index:: WHEN
 .. _when:
 

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -245,9 +245,6 @@ namespace kOS.Safe.Compilation.KS
                     PreProcessChildNodes(node);
                     PreProcessWhenStatement(node);
                     break;
-                case TokenType.wait_stmt:
-                    PreProcessWaitStatement(node);
-                    break;
                 case TokenType.declare_stmt:
                     PreProcessProgramParameters(node);
                     break;
@@ -339,28 +336,6 @@ namespace kOS.Safe.Compilation.KS
             branchOpcode.DestinationLabel = eofOpcode.Label;
             skipRemoval.DestinationLabel = eofOpcode.Label;
         }
-
-        private void PreProcessWaitStatement(ParseNode node)
-        {
-            NodeStartHousekeeping(node);
-            if (node.Nodes.Count == 4)
-            {
-                // wait condition
-                int expressionHash = ConcatenateNodes(node).GetHashCode();
-                string triggerIdentifier = "wait-" + expressionHash.ToString();
-                Trigger triggerObject = context.Triggers.GetTrigger(triggerIdentifier);
-
-                currentCodeSection = triggerObject.Code;
-                VisitNode(node.Nodes[2]);
-                Opcode branchOpcode = AddOpcode(new OpcodeBranchIfFalse());
-                AddOpcode(new OpcodeEndWait());
-                AddOpcode(new OpcodePushRelocateLater(null), triggerObject.GetFunctionLabel());
-                AddOpcode(new OpcodeRemoveTrigger());
-                Opcode eofOpcode = AddOpcode(new OpcodeEOF());
-                branchOpcode.DestinationLabel = eofOpcode.Label;
-            }
-        }
-        
 
         /// <summary>
         /// Create a unique string out of a sub-branch of the parse tree that
@@ -1963,7 +1938,7 @@ namespace kOS.Safe.Compilation.KS
                     {
                         Trigger triggerObject = context.Triggers.GetTrigger(triggerIdentifier);
                         AddOpcode(new OpcodePushRelocateLater(null), triggerObject.GetFunctionLabel());
-                        AddOpcode(new OpcodeAddTrigger(false));
+                        AddOpcode(new OpcodeAddTrigger());
                     }
 
                     // enable this FlyByWire parameter
@@ -2043,7 +2018,7 @@ namespace kOS.Safe.Compilation.KS
                 AddOpcode(new OpcodePush(triggerObject.VariableName));
                 AddOpcode(new OpcodeStore());
                 AddOpcode(new OpcodePushRelocateLater(null), triggerObject.GetFunctionLabel());
-                AddOpcode(new OpcodeAddTrigger(false));
+                AddOpcode(new OpcodeAddTrigger());
             }
         }
 
@@ -2057,7 +2032,7 @@ namespace kOS.Safe.Compilation.KS
             if (triggerObject.IsInitialized())
             {
                 AddOpcode(new OpcodePushRelocateLater(null), triggerObject.GetFunctionLabel());
-                AddOpcode(new OpcodeAddTrigger(false));
+                AddOpcode(new OpcodeAddTrigger());
             }
         }
 
@@ -2070,22 +2045,18 @@ namespace kOS.Safe.Compilation.KS
 
             if (node.Nodes.Count == 3)
             {
-                // wait time
+                // For commands of the form:  WAIT N. where N is a number:
                 VisitNode(node.Nodes[1]);
                 AddOpcode(new OpcodeWait());
             }
             else
             {
-                // wait condition
-                int expressionHash = ConcatenateNodes(node).GetHashCode();
-                string triggerIdentifier = "wait-" + expressionHash.ToString();
-                Trigger triggerObject = context.Triggers.GetTrigger(triggerIdentifier);
-
-                if (triggerObject.IsInitialized())
-                {
-                    AddOpcode(new OpcodePushRelocateLater(null), triggerObject.GetFunctionLabel());
-                    AddOpcode(new OpcodeAddTrigger(true));
-                }
+                // For commands of the form:  WAIT UNTIL expr. where expr is any boolean expression:
+                Opcode waitLoopStart = AddOpcode(new OpcodePush(0));       // Loop start: Gives OpcodeWait an argument of zero.
+                AddOpcode(new OpcodeWait());                               // Avoid busy polling.  Even a WAIT 0 still forces 1 fixedupdate 'tick'.
+                VisitNode(node.Nodes[2]);                                  // Inserts instructions here to evaluate the expression
+                AddOpcode(new OpcodeBranchIfFalse(), waitLoopStart.Label); // Repeat the loop as long as expression is false.
+                // Falls through to whatever comes next when expression is true.
             }
         }
 

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -1680,41 +1680,18 @@ namespace kOS.Safe.Compilation
     
     public class OpcodeAddTrigger : Opcode
     {
-        [MLField(1,false)]
-        private bool ShouldWait { get; set; }
-
         protected override string Name { get { return "addtrigger"; } }
         public override ByteCode Code { get { return ByteCode.ADDTRIGGER; } }
-
-        public OpcodeAddTrigger(bool shouldWait)
-        {
-            ShouldWait = shouldWait;
-        }
-
-        /// <summary>
-        /// This variant of the constructor is just for ML save/load to use.
-        /// </summary>
-        protected OpcodeAddTrigger() { }
-
-        public override void PopulateFromMLFields(List<object> fields)
-        {
-            // Expect fields in the same order as the [MLField] properties of this class:
-            if (fields == null || fields.Count<1)
-                throw new Exception("Saved field in ML file for OpcodeAddTrigger seems to be missing.  Version mismatch?");
-            ShouldWait = (bool)(fields[0]); // should throw error if it's not a bool.
-        }
 
         public override void Execute(ICpu cpu)
         {
             var functionPointer = (int)cpu.PopValue();
             cpu.AddTrigger(functionPointer);
-            if (ShouldWait)
-                cpu.StartWait(0);
         }
 
         public override string ToString()
         {
-            return Name + " " + ShouldWait.ToString().ToLower();
+            return Name;
         }
     }
 
@@ -1739,11 +1716,8 @@ namespace kOS.Safe.Compilation
 
         public override void Execute(ICpu cpu)
         {
-            object waitTime = cpu.PopValue();
-            if (waitTime is double)
-                cpu.StartWait((double)waitTime);
-            else if (waitTime is int)
-                cpu.StartWait((int)waitTime);
+            object arg = cpu.PopValue();
+            cpu.StartWait(Convert.ToDouble(arg));
         }
     }
 

--- a/src/kOS/Execution/CPU.cs
+++ b/src/kOS/Execution/CPU.cs
@@ -759,10 +759,7 @@ namespace kOS.Execution
 
         public void StartWait(double waitTime)
         {
-            if (waitTime > 0)
-            {
-                timeWaitUntil = currentTime + waitTime;
-            }
+            timeWaitUntil = currentTime + waitTime;
             currentStatus = Status.Waiting;
         }
 
@@ -873,7 +870,7 @@ namespace kOS.Execution
 
         private void ProcessWait()
         {
-            if (currentStatus == Status.Waiting && timeWaitUntil > 0)
+            if (currentStatus == Status.Waiting)
             {
                 if (currentTime >= timeWaitUntil)
                 {


### PR DESCRIPTION
In addition to fixing the mentioned issues, this should also be slightly simpler and more efficient.

Removed WAIT from the trigger system and just made it do a simple loop right there in the mainline code where it was defined,  akin to this psuedocode:
```
    do
            wait 1 (fixed)update tick.
            evaluate expression
    until expression is true
```
This is literally exactly the same performance as the old way (because the trigger checked the condition every (fixed)update, and so does this), but without eating into the precious limited resource of trigger instructions per update.

This will also be slightly less ML code *except* in the case where the script uses the same WAIT UNTIL expression repeatedly in more than one place in the source code.  Then this will admittedly result in a slightly bigger ML file than it would have before (because before the expression's instructions were only compiled once regardless of how many times the expression was mentioned in wait statements, and all the additional places the same wait expression existed it just referred back to the existing trigger.)

I would argue that that's actually a "good" thing, though, because users *should* expect that programming by cut-and-paste would result in inefficiently repeated code in the ML file, and not rely on the compiler to optimize away what is essentially a redundancy that exists in the source code.
