### PR TITLE
Bound Variables set instantly 

### DIFF
--- a/src/kOS.Safe/Binding/BoundVariable.cs
+++ b/src/kOS.Safe/Binding/BoundVariable.cs
@@ -33,5 +33,10 @@ namespace kOS.Safe.Binding
                 Set(value);
             }
         }
+
+        public void ClearCache()
+        {
+            currentValue = null;
+        }
     }
 }

--- a/src/kOS.Safe/Binding/BoundVariable.cs
+++ b/src/kOS.Safe/Binding/BoundVariable.cs
@@ -9,7 +9,6 @@ namespace kOS.Safe.Binding
         public BindingGetDlg Get;
 
         private object currentValue;
-        private bool wasUpdated;
 
         public override object Value
         {
@@ -31,23 +30,7 @@ namespace kOS.Safe.Binding
             set
             {
                 if (Set == null) return;
-
-                currentValue = value;
-                wasUpdated = true;
-            }
-        }
-
-        public void ClearValue()
-        {
-            currentValue = null;
-            wasUpdated = false;
-        }
-
-        public void SaveValue()
-        {
-            if (wasUpdated && currentValue != null)
-            {
-                Set(currentValue);
+                Set(value);
             }
         }
     }

--- a/src/kOS/Binding/BindingManager.cs
+++ b/src/kOS/Binding/BindingManager.cs
@@ -89,21 +89,11 @@ namespace kOS.Binding
             {
                 b.Update();
             }
-
-            // clear bound variables values
-            foreach (var variable in variables.Values)
-            {
-                variable.ClearValue();
-            }
         }
 
         public void PostUpdate()
         {
-            // save bound variables values
-            foreach (BoundVariable variable in variables.Values)
-            {
-                variable.SaveValue();
-            }
+
         }
 
         public void ToggleFlyByWire(string paramName, bool enabled)

--- a/src/kOS/Binding/BindingManager.cs
+++ b/src/kOS/Binding/BindingManager.cs
@@ -84,6 +84,10 @@ namespace kOS.Binding
 
         public void PreUpdate()
         {
+            foreach (var variable in variables)
+            {
+                variable.Value.ClearCache();
+            }
             // update the bindings
             foreach (var b in bindings)
             {


### PR DESCRIPTION
#193 turned out to be an issue where the target was not actually being set until the end of the update. I considered making some kind of new bound variable that would interrupt the existing flow. Then i looked at the API calls we were making and I could not understand the reason for continuing to defer. 