### PR TITLE
Fixes #767 with a simple one-liner in kRISC.tpg

### DIFF
--- a/kerboscript_tests/user_functions/testreturn1.ks
+++ b/kerboscript_tests/user_functions/testreturn1.ks
@@ -1,0 +1,68 @@
+// Testing some deeply nested returns
+
+declare function outer1 {
+  print "function outer1: before for loop".
+  set foo to list().
+  foo:add(1).
+  foo:add(2).
+  foo:add(3).
+  for thing in foo {
+    print "thing is " + thing.
+    if thing = 3 {
+      return true.
+    }.
+  }.
+  print "function outer1: after for loop".
+  return false.
+}.
+
+declare function outer2 {
+  print "function outer2: before inner function".
+
+  print "function outer2 is now calling function outer1 again.".
+
+  if outer1() {
+    print "outer returned early.".
+  } else {
+    print "outer executed all the way to the bottom.".
+  }
+
+  print "function outer2 is done with function outer1.".
+
+  declare function inner {
+    set foo to list().
+    foo:add(1).
+    foo:add(2).
+    foo:add(3).
+    for thing in foo {
+      print "inner: thing is " + thing.
+      if thing = 3 {
+	return true.
+      }.
+    }.
+    return false.
+  }.
+
+  print "function outer2 is going to now call inner.".
+  if inner() {
+    print "inner returned early.".
+  } else {
+    print "inner executed all the way to the bottom.".
+  }
+  print "function outer2 is done calling inner.".
+
+  print "function outer2: after inner function".
+}.
+
+print "before calling function outer1.".
+if outer1() {
+  print "outer returned early.".
+} else {
+  print "outer executed all the way to the bottom.".
+}
+print "after calling function outer1.".
+
+print "before calling function outer2.".
+outer2().
+print "done calling function outer2.".
+

--- a/kerboscript_tests/user_functions/testreturn2.ks
+++ b/kerboscript_tests/user_functions/testreturn2.ks
@@ -1,0 +1,23 @@
+// Testing returns without arguments.
+
+print "testing return statements without an argument".
+
+declare function outer1 {
+  print "function outer1: before for loop".
+  set foo to list().
+  foo:add(1).
+  foo:add(2).
+  foo:add(3).
+  for thing in foo {
+    print "thing is " + thing.
+    if thing = 3 {
+      return.
+    }.
+  }.
+  print "function outer1: after for loop".
+  return.
+}.
+
+print "before calling function outer1.".
+outer1().
+

--- a/src/kOS.Safe/Compilation/KS/Parser.cs
+++ b/src/kOS.Safe/Compilation/KS/Parser.cs
@@ -1400,7 +1400,19 @@ namespace kOS.Safe.Compilation.KS
             }
 
             
-            Parseexpr(node);
+            tok = scanner.LookAhead(TokenType.PLUSMINUS, TokenType.NOT, TokenType.INTEGER, TokenType.DOUBLE, TokenType.TRUEFALSE, TokenType.IDENTIFIER, TokenType.FILEIDENT, TokenType.BRACKETOPEN, TokenType.STRING);
+            if (tok.Type == TokenType.PLUSMINUS
+                || tok.Type == TokenType.NOT
+                || tok.Type == TokenType.INTEGER
+                || tok.Type == TokenType.DOUBLE
+                || tok.Type == TokenType.TRUEFALSE
+                || tok.Type == TokenType.IDENTIFIER
+                || tok.Type == TokenType.FILEIDENT
+                || tok.Type == TokenType.BRACKETOPEN
+                || tok.Type == TokenType.STRING)
+            {
+                Parseexpr(node);
+            }
 
             
             tok = scanner.Scan(TokenType.EOI);

--- a/src/kOS.Safe/Compilation/KS/kRISC.tpg
+++ b/src/kOS.Safe/Compilation/KS/kRISC.tpg
@@ -153,7 +153,7 @@ log_stmt       -> LOG expr TO expr EOI;
 break_stmt     -> BREAK EOI;
 preserve_stmt  -> PRESERVE EOI;
 declare_stmt   -> DECLARE ( (PARAMETER IDENTIFIER (COMMA IDENTIFIER)* EOI) | (FUNCTION IDENTIFIER instruction_block EOI?) | (IDENTIFIER TO expr) EOI);
-return_stmt    -> RETURN expr EOI;
+return_stmt    -> RETURN expr? EOI;
 switch_stmt    -> SWITCH TO expr EOI;
 copy_stmt      -> COPY expr (FROM | TO) expr EOI;
 rename_stmt    -> RENAME (VOLUME | FILE)? expr TO expr EOI;


### PR DESCRIPTION
The code in the compiler to handle the case where
the expression was left off actually already existed,
but the parser never allowed such a pattern to be
considered valid.