### PR TITLE
Resolves #732 and #746

### DIFF
--- a/kerboscript_tests/user_functions/functest10.ks
+++ b/kerboscript_tests/user_functions/functest10.ks
@@ -1,0 +1,12 @@
+// Testing a script calling a script with arguments.
+
+declare parameter arg1,arg2,arg3.
+
+print "Outer script (functest10) called with arguments:".
+print "   arg1=" + arg1.
+print "   arg2=" + arg2.
+print "   arg3=" + arg3.
+
+print "Now functest10 is going to call functest10_inner,".
+print "Giving it the same args in the same order:".
+run functest10_inner(arg1,arg2,arg3).

--- a/kerboscript_tests/user_functions/functest10_inner.ks
+++ b/kerboscript_tests/user_functions/functest10_inner.ks
@@ -1,0 +1,8 @@
+declare parameter inner1, inner2, inner3.
+
+print "This is functest10_inner talking.".
+print "I think my args are:".
+
+print "  arg1="+arg1.
+print "  arg2="+arg2.
+print "  arg3="+arg3.

--- a/kerboscript_tests/user_functions/functest11.ks
+++ b/kerboscript_tests/user_functions/functest11.ks
@@ -1,0 +1,12 @@
+// Testing the case of a function that calls a RUN
+// command from inside of itself:
+
+declare function foo {
+  print "Inside function: about to run functest10".
+  run functest10(10,20,30).
+  print "Inside function: done running functest10".
+}.
+
+print "Outside function: about to call function".
+foo().
+print "Outside function: done calling function".

--- a/kerboscript_tests/user_functions/functest12.ks
+++ b/kerboscript_tests/user_functions/functest12.ks
@@ -1,0 +1,39 @@
+// Testing the case of a function that contains a WHEN trigger
+// inside of itself:
+
+set x to 0.
+
+// Try this twice to ensure it gets re-enabled in the second 
+// function call too.
+reinit_triggers().
+print "pass 1: triggers initialized... ".
+wait 1.
+set x to 1.
+wait 1.
+set x to 2.
+
+wait 1.
+
+reinit_triggers().
+print "pass 2: triggers initialized... ".
+wait 1.
+set x to 1.
+wait 1.
+set x to 2.
+wait 1.
+
+print "done with test".
+
+declare function reinit_triggers {
+  set x to 0.
+
+  when x = 1 then {
+    print "When x = 1 trigger has been invoked.".
+  }.
+
+  when x = 2 then {
+    print "When x = 2 trigger has been invoked.".
+  }.
+}.
+
+

--- a/kerboscript_tests/user_functions/functest13.ks
+++ b/kerboscript_tests/user_functions/functest13.ks
@@ -1,0 +1,24 @@
+// Testing the nesting of function calls and locks inside triggers.
+
+declare function do_print {
+  declare parameter str.
+  print("doprint: printing: " + str).
+}.
+
+when x = 1 then {
+  do_print("trigger body, when x = 1, y = " + y).
+}.
+
+when x = 2 then {
+  do_print("trigger body, when x = 2, y = " + y).
+}.
+
+set x to 0.
+// Also need to ensure that locks compile correctly here:
+lock y to -x.
+
+wait 1.
+set x to 1.
+wait 1.
+set x to 2.
+wait 1.

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -173,14 +173,9 @@ namespace kOS.Safe.Compilation.KS
         {
             ParseNode rootNode = tree.Nodes[0];
             TraverseScopeBranch(rootNode);
+            IterateUserFunctions(rootNode, IdentifyUserFunctions);
             PreProcessStatements(rootNode);
-            PreProcessUserFunctions(rootNode);
-        }
-
-        private void PreProcessUserFunctions(ParseNode node)
-        {
-            IterateUserFunctions(node, IdentifyUserFunctions);
-            IterateUserFunctions(node, PreProcessUserFunctionStatement);
+            IterateUserFunctions(rootNode, PreProcessUserFunctionStatement);
         }
 
         private void IterateUserFunctions(ParseNode node, Action<ParseNode> action)

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -173,8 +173,8 @@ namespace kOS.Safe.Compilation.KS
         {
             ParseNode rootNode = tree.Nodes[0];
             TraverseScopeBranch(rootNode);
-            PreProcessUserFunctions(rootNode);
             PreProcessStatements(rootNode);
+            PreProcessUserFunctions(rootNode);
         }
 
         private void PreProcessUserFunctions(ParseNode node)
@@ -246,6 +246,7 @@ namespace kOS.Safe.Compilation.KS
                     PreProcessWhenStatement(node);
                     break;
                 case TokenType.declare_stmt:
+                    PreProcessChildNodes(node);
                     PreProcessProgramParameters(node);
                     break;
                 case TokenType.run_stmt:
@@ -529,6 +530,8 @@ namespace kOS.Safe.Compilation.KS
                     programParameters.Add(node.Nodes[index]);
                 }
             }
+            // If it's any other sort of Declare statement, do nothing and instead
+            // allow the PreProcessChildNodes handle all the work.
         }
 
         private void PreProcessRunStatement(ParseNode node)


### PR DESCRIPTION
These two things were in fact caused by the same exact problem - PreProcessStatements() wasn't recursing down into the children of a DECLARE statement, which meant it never looked inside the bodies of functions for the things that need preprocess work, like the run command, and triggers.

Also, had to split up the order of identifying functions versus identifying triggers, to solve a chicken-and-egg problem trying to nest them inside each other.
