### PR TITLE
Removed `shaired.`

### DIFF
--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -422,7 +422,7 @@ namespace kOS.Suffixed
                 () => System.Math.Min(Vessel.distanceLandedPackThreshold, Vessel.distancePackThreshold), 
                 value => { Vessel.distanceLandedPackThreshold = Vessel.distancePackThreshold = value; }));
             AddSuffix("ISDEAD", new NoArgsSuffix<bool>(() => (Vessel.state == Vessel.State.DEAD) ));
-            AddSuffix("STATUS", new Suffix<String>(() => shared.Vessel.situation.ToString()));
+            AddSuffix("STATUS", new Suffix<String>(() => Vessel.situation.ToString()));
 
             //// Although there is an implementation of lat/long/alt in Orbitible,
             //// it's better to use the methods for vessels that are faster if they're


### PR DESCRIPTION
was failing to build with `shaired.` removed and tested. This fixes #685