### PR TITLE
Fixes #676 no more second error on syntax errors.

### DIFF
--- a/src/kOS/Execution/CPU.cs
+++ b/src/kOS/Execution/CPU.cs
@@ -112,7 +112,7 @@ namespace kOS.Execution
             else {
                 shared.ScriptHandler.ClearContext("program");
 
-                var programContext = ((CPU)shared.Cpu).GetProgramContext();
+                var programContext = ((CPU)shared.Cpu).SwitchToProgramContext();
                 programContext.Silent = true;
                 var options = new CompilerOptions { LoadProgramsInSameAddressSpace = true };
                 string filePath = shared.VolumeMgr.GetVolumeRawIdentifier(shared.VolumeMgr.CurrentVolume) + "/" + "boot";
@@ -238,7 +238,7 @@ namespace kOS.Execution
             return contexts[0];
         }
         
-        public ProgramContext GetProgramContext()
+        public ProgramContext SwitchToProgramContext()
         {
             if (contexts.Count == 1)
             {


### PR DESCRIPTION
When I examined it, I saw that this is how it's
meant to work in normal cases:

There are two instruction pointers - one for where
you are in the interpreter context and another for
where you are in the program context.

When you run a program, it does this:

  1. Interpreter context has an OpcodeCall that calls built-in function run().
  2. Function run() tells CPU it should switch to program context on the
     next instruction.
  3. Function run() calls compiler, and populates the CPU's program context
     with the resulting program.
  4. Function run() finishes.
  5. CPU, like it does for all opcode executions, updates the instruction
     pointer of the current context to the next opcode.
  6. CPU finishes loop iteration, and begins new loop.
  7. CPU now is in the new program context, and is running the program.
  8. When program finishes or errors out, CPU returns to interpreter context and picks up where it left the instruction pointer for the interpreter.

The problem is when step 3 barfs and throws an exception, the CPU was
*already* told in step 2 that it is no longer going to be in interpreter
context, so when it handles the error it's handling it as if it had come
from a program instead of from the interpreter, and thus is does NOT advance
the interpreter's instruction pointer, thinking that had already been
done before in step 5 of the previous iteration just before it had
jumped into the "program" it thought it was running.

Thus the interpreter tries to run the same Opcode a second time, and gets
the new error because the stack was already popped in the first attempt
to call the run() function.  The second time it tries to call run(), the
args it needs aren't there on the stack anymore, thus the null ref error.

The fix was to detect when the compiler failed in step 3, and when it did,
to undo the "you are now in program context" setup it did in step 2, so
the CPU knows it's still in interpreter context and it does therefore need
to advance the interpreter's instruction pointer.