### PR TITLE
coerced some more degrees into reasonable range.

### DIFF
--- a/src/kOS/Suffixed/GeoCoordinates.cs
+++ b/src/kOS/Suffixed/GeoCoordinates.cs
@@ -7,8 +7,30 @@ namespace kOS.Suffixed
 {
     public class GeoCoordinates : Structure
     {
-        public double Lat { get; private set; }
-        public double Lng { get; private set; }
+        private double lat;
+        private double lng;
+        public double Lat
+        {
+            get
+            {
+                return Utils.DegreeFix(lat,-180);
+            }
+            private set
+            {
+                lat = value;
+            }
+        }
+        public double Lng
+        {
+            get
+            {
+                return Utils.DegreeFix(lng,-180);
+            }
+            private set
+            {
+                lng = value;
+            }
+        }
         public CelestialBody Body { get; private set; }
         public SharedObjects Shared { get; set; } // for finding the current CPU's vessel, as per issue #107
 
@@ -36,12 +58,12 @@ namespace kOS.Suffixed
         /// </summary>
         /// <param name="body">A different celestial body to select a lat/long for that might not be the curent one</param>
         /// <param name="sharedObj">to know the current CPU's running vessel</param>
-        /// <param name="lat">latitude</param>
-        /// <param name="lng">longitude</param>
-        public GeoCoordinates(CelestialBody body, SharedObjects sharedObj, double lat, double lng)
+        /// <param name="latitude">latitude</param>
+        /// <param name="longitude">longitude</param>
+        public GeoCoordinates(CelestialBody body, SharedObjects sharedObj, double latitude, double longitude)
         {
-            Lat = lat;
-            Lng = lng;
+            Lat = latitude;
+            Lng = longitude;
             Shared = sharedObj;
             Body = body;
             GeoCoordsInitializeSuffixes();
@@ -51,10 +73,10 @@ namespace kOS.Suffixed
         ///   Build a GeoCoordinates from any arbitrary lat/long pair of floats.
         /// </summary>
         /// <param name="sharedObj">to know the current CPU's running vessel</param>
-        /// <param name="lat">latitude</param>
-        /// <param name="lng">longitude</param>
-        public GeoCoordinates(SharedObjects sharedObj, float lat, float lng) :
-            this(sharedObj.Vessel.GetOrbit().referenceBody, sharedObj, lat, lng)
+        /// <param name="latitude">latitude</param>
+        /// <param name="lnongitude">longitude</param>
+        public GeoCoordinates(SharedObjects sharedObj, float latitude, float longitude) :
+            this(sharedObj.Vessel.GetOrbit().referenceBody, sharedObj, latitude, longitude)
         {
         }
 
@@ -62,12 +84,12 @@ namespace kOS.Suffixed
         ///   Build a GeoCoordinates from any arbitrary lat/long pair of doubles.
         /// </summary>
         /// <param name="sharedObj">to know the current CPU's running vessel</param>
-        /// <param name="lat">latitude</param>
-        /// <param name="lng">longitude</param>
-        public GeoCoordinates(SharedObjects sharedObj, double lat, double lng)
+        /// <param name="latitude">latitude</param>
+        /// <param name="longitude">longitude</param>
+        public GeoCoordinates(SharedObjects sharedObj, double latitude, double longitude)
         {
-            Lat = lat;
-            Lng = lng;
+            Lat = latitude;
+            Lng = longitude;
             Shared = sharedObj;
             Body = Shared.Vessel.GetOrbit().referenceBody;
             GeoCoordsInitializeSuffixes();

--- a/src/kOS/Suffixed/Orbitable.cs
+++ b/src/kOS/Suffixed/Orbitable.cs
@@ -187,7 +187,7 @@ namespace kOS.Suffixed
             if (parent == null) //happens when this Orbitable is the Sun
                 return 0.0;
             Vector3d unityWorldPos = GetPosition() + (Vector3d)Shared.Vessel.findWorldCenterOfMass();
-            return parent.GetLatitude(unityWorldPos);
+            return Utils.DegreeFix(parent.GetLatitude(unityWorldPos),-180);
         }
         public double PositionToLongitude( Vector pos )
         {

--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -427,7 +427,7 @@ namespace kOS.Suffixed
             //// Although there is an implementation of lat/long/alt in Orbitible,
             //// it's better to use the methods for vessels that are faster if they're
             //// available:
-            AddSuffix("LATITUDE", new Suffix<float>(() => VesselUtils.GetVesselLattitude(Vessel)));
+            AddSuffix("LATITUDE", new Suffix<float>(() => VesselUtils.GetVesselLatitude(Vessel)));
             AddSuffix("LONGITUDE", new Suffix<double>(() => VesselUtils.GetVesselLongitude(Vessel)));
             AddSuffix("ALTITUDE", new Suffix<double>(() => Vessel.altitude));
        }

--- a/src/kOS/Utilities/VesselUtils.cs
+++ b/src/kOS/Utilities/VesselUtils.cs
@@ -365,7 +365,7 @@ namespace kOS.Utilities
                           vessel.GetTotalMass() / (GetMassDrag(vessel) * FlightGlobals.DragMultiplier * densityOfAir));
         }
 
-        public static float GetVesselLattitude(Vessel vessel)
+        public static float GetVesselLatitude(Vessel vessel)
         {
             var retVal = (float)vessel.latitude;
 


### PR DESCRIPTION
Fixes the case when longitude is reported wrapped around
the world several times, but Latitude can still be
wonky and record things on the
wrong side of the world i.e. report 60 north as
instead 120 north from a longitude on the other
side of the world, with a latitude so big that it
is wrapping up and over the north pole to the
other side.  That's a nontrivial fix so it's still
being left that way so at least kOS won't report
false data - just ... report true data in a stupid
way like the main game does.