### PR TITLE
Forbid interpreter func ( Resolves #886 )

### DIFF
--- a/kerboscript_tests/user_functions/functest7.ks
+++ b/kerboscript_tests/user_functions/functest7.ks
@@ -1,9 +1,8 @@
 // One test of the nolazyglobal keyword.
-// This should work correctly.
 
 @lazyglobal off. // at the top - should be okay.
 
-declare x to 1. // this should be fine.
+local x is 1. // this should be fine.
 set x to 2. // this should be fine because x exists now.
 print "Should bomb out with error because there was no 'declare y' statement and lazyglobals disabled.".
 set y to 1.

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -1944,7 +1944,7 @@ namespace kOS.Safe.Compilation.KS
                 // methods and functions, and always has exactly one copy in memory whether there are
                 // one, many, or zero "instances" of it present in scope at the moment.
                 AddOpcode(new OpcodePush(func.ScopelessPointerIdentifier));
-                AddOpcode(new OpcodePushRelocateLater(null), func.GetFuncLabel());
+                AddOpcode(new OpcodePushDelegateRelocateLater(null,false), func.GetFuncLabel());
                 if (node == null) // global scope, so unconditionally use a normal Store:
                     AddOpcode(new OpcodeStore()); //
                 else
@@ -1971,7 +1971,7 @@ namespace kOS.Safe.Compilation.KS
             string functionLabel = lockObject.GetUserFunctionLabel(expressionHash);
             // lock variable
             AddOpcode(new OpcodePush(lockObject.ScopelessPointerIdentifier));
-            AddOpcode(new OpcodePushDelegateRelocateLater(null), functionLabel);
+            AddOpcode(new OpcodePushDelegateRelocateLater(null,true), functionLabel);
             AddOpcode(CreateAppropriateStoreCode(whereToStore, allowLazyGlobal));
 
             if (lockObject.IsSystemLock())

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -1231,6 +1231,7 @@ namespace kOS.Safe.Compilation
                 cpu.PushAboveStack(contextRecord);
                 if (userDelegate != null)
                 {
+                    cpu.AssertValidDelegateCall(userDelegate);
                     // Reverse-push the closure's scope record, just after the function return context got put on the stack.
                     for (int i = userDelegate.Closure.Count - 1 ; i >= 0 ; --i)
                         cpu.PushAboveStack(userDelegate.Closure[i]);
@@ -1739,13 +1740,16 @@ namespace kOS.Safe.Compilation
     {
         [MLField(1,false)]
         private int EntryPoint { get; set; }
+        [MLField(2,false)]
+        private bool WithClosure { get; set; }
 
         protected override string Name { get { return "pushdelegate"; } }
         public override ByteCode Code { get { return ByteCode.PUSHDELEGATE; } }
 
-        public OpcodePushDelegate(int entryPoint)
+        public OpcodePushDelegate(int entryPoint, bool withClosure)
         {
             EntryPoint = entryPoint;
+            WithClosure = withClosure;
         }
 
         /// <summary>
@@ -1756,14 +1760,15 @@ namespace kOS.Safe.Compilation
         public override void PopulateFromMLFields(List<object> fields)
         {
             // Expect fields in the same order as the [MLField] properties of this class:
-            if (fields == null || fields.Count<1)
-                throw new Exception("Saved field in ML file for OpcodePush seems to be missing.  Version mismatch?");
+            if (fields == null || fields.Count<2)
+                throw new Exception("Saved field in ML file for OpcodePushDelegate seems to be missing.  Version mismatch?");
             EntryPoint = (int)fields[0];
+            WithClosure = (bool)fields[1];
         }
 
         public override void Execute(ICpu cpu)
         {
-            IUserDelegate pushMe = cpu.MakeUserDelegate(EntryPoint);
+            IUserDelegate pushMe = cpu.MakeUserDelegate(EntryPoint, WithClosure);
             cpu.PushStack(pushMe);
         }
 
@@ -1779,17 +1784,29 @@ namespace kOS.Safe.Compilation
     /// </summary>
     public class OpcodePushDelegateRelocateLater : OpcodePushRelocateLater
     {
+        [MLField(1,false)]
+        public bool WithClosure { get; set; }
+
         protected override string Name { get { return "PushDelegateRelocateLater"; } }
         public override ByteCode Code { get { return ByteCode.PUSHDELEGATERELOCATELATER; } }
 
-        public OpcodePushDelegateRelocateLater(string destLabel) : base(destLabel)
+        public OpcodePushDelegateRelocateLater(string destLabel, bool withClosure) : base(destLabel)
         {
+            WithClosure = withClosure;
         }
 
         /// <summary>
         /// This variant of the constructor is just for ML file save/load to use.
         /// </summary>
-        protected OpcodePushDelegateRelocateLater() : base() { }
+        protected OpcodePushDelegateRelocateLater() : base() {}
+        
+        public override void PopulateFromMLFields(List<object> fields)
+        {
+            // Expect fields in the same order as the [MLField] properties of this class:
+            if (fields == null || fields.Count<1)
+                throw new Exception("Saved field in ML file for OpcodePushDelegateRelocatelater seems to be missing.  Version mismatch?");
+            WithClosure = (bool)fields[0];
+        }
     }
     
     #endregion

--- a/src/kOS.Safe/Compilation/ProgramBuilder.cs
+++ b/src/kOS.Safe/Compilation/ProgramBuilder.cs
@@ -132,7 +132,9 @@ namespace kOS.Safe.Compilation
                     // Replace the OpcodePushRelocateLater with the proper OpcodePush:
                     Opcode newOp;
                     if (opcode is OpcodePushDelegateRelocateLater)
-                        newOp = new OpcodePushDelegate(destinationIndex);
+                    {
+                        newOp = new OpcodePushDelegate(destinationIndex, ((OpcodePushDelegateRelocateLater)opcode).WithClosure);
+                    }
                     else
                         newOp = new OpcodePush(destinationIndex);
                     newOp.SourceName = opcode.SourceName;

--- a/src/kOS.Safe/Exceptions/KOSInvalidDelegateContext.cs
+++ b/src/kOS.Safe/Exceptions/KOSInvalidDelegateContext.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace kOS.Safe.Exceptions
+{
+    /// <summary>
+    /// Thrown when you attempt to call a user delegate from an invalid context
+    /// where it cannot access the delegate from.
+    /// </summary>
+    public class KOSInvalidDelegateContext : KOSException
+    {
+        private const string TERSE_MSG_FMT = "Cannot call this lock or function from {0} when it was declared in {1}.";
+        private const string HELP_URL = "http://ksp-kos.github.io/KOS_DOC/language/user_functions.html#functions-and-the-terminal-interpreter";
+        
+        public KOSInvalidDelegateContext(string currentContextName, string intendedContextName) :
+            base(String.Format(TERSE_MSG_FMT, currentContextName, intendedContextName))
+        {
+        }
+
+        public virtual string VerboseMessage
+        {
+            get { return base.Message; }
+        }
+
+        public virtual string HelpURL
+        {
+            get { return HELP_URL; }
+        }
+    }
+}

--- a/src/kOS.Safe/Execution/ICpu.cs
+++ b/src/kOS.Safe/Execution/ICpu.cs
@@ -11,7 +11,8 @@ namespace kOS.Safe.Execution
         void PushAboveStack(object thing);
         object PopAboveStack(int howMany);
         List<VariableScope> GetCurrentClosure();
-        IUserDelegate MakeUserDelegate(int entryPoint);
+        IUserDelegate MakeUserDelegate(int entryPoint, bool withClosure);
+        void AssertValidDelegateCall(IUserDelegate userDelegate);
         object GetValue(object testValue, bool barewordOkay = false);
         object PopValue(bool barewordOkay = false);
         object PeekValue(int digDepth, bool barewordOkay = false);        

--- a/src/kOS.Safe/Execution/IProgramContext.cs
+++ b/src/kOS.Safe/Execution/IProgramContext.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using kOS.Safe.Compilation;
+using kOS.Safe.Execution;
+
+namespace kOS.Safe.Execution
+{
+    public interface IProgramContext
+    {
+        void AddParts(IEnumerable<CodePart> parts);
+        int AddObjectParts(IEnumerable<CodePart> parts);
+        void ToggleFlyByWire(string paramName, bool enabled);
+        List<string> GetCodeFragment(int contextLines);
+        List<string> GetCodeFragment(int start, int stop);
+        List<Opcode> Program { get; set; }
+        int InstructionPointer { get; set; }
+        List<int> Triggers { get; set; }
+        bool Silent { get; set; }
+    }
+}

--- a/src/kOS.Safe/Execution/IUserDelegate.cs
+++ b/src/kOS.Safe/Execution/IUserDelegate.cs
@@ -9,6 +9,7 @@ namespace kOS.Safe.Execution
     /// </summary>
     public interface IUserDelegate
     {
+        IProgramContext ProgContext {get;}
         int EntryPoint {get;}
         List<VariableScope> Closure {get;}
     }

--- a/src/kOS.Safe/Execution/UserDelegate.cs
+++ b/src/kOS.Safe/Execution/UserDelegate.cs
@@ -9,6 +9,7 @@ namespace kOS.Safe.Execution
     /// </summary>
     public class UserDelegate : IUserDelegate
     {
+        public IProgramContext ProgContext {get; private set;}
         public int EntryPoint {get; private set;}
         private readonly ICpu cpu;
         public List<VariableScope> Closure {get; private set;}
@@ -18,13 +19,15 @@ namespace kOS.Safe.Execution
         /// the entry point location of the function to call.
         /// </summary>
         /// <param name="cpu">the CPU on which this program is running.</param>
+        /// <param name="context">The IProgramContext in which the entryPoint is stored.  Entry point 27 in the interpreter is not the same as entrypoint 27 in program context.</param>
         /// <param name="entryPoint">instruction address where OpcodeCall should jump to to call the function.</param>
         /// <param name="useClosure">If true, then a snapshot of the current scoping stack, and thus a persistent ref to its variables,
         ///   will be kept in the delegate so it can be called later as a callback with closure.  Set to false if the
         ///   function is only getting called instantly using whatever the scope is at the time of the call.</param>
-        public UserDelegate(ICpu cpu, int entryPoint, bool useClosure)
+        public UserDelegate(ICpu cpu, IProgramContext context, int entryPoint, bool useClosure)
         {
             this.cpu = cpu;
+            ProgContext = context;
             EntryPoint = entryPoint;
             if (useClosure)
                 CaptureClosure();

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Exceptions\KOSBreakInvalidHereException.cs" />
     <Compile Include="Exceptions\KOSInvalidArgumentException.cs" />
     <Compile Include="Exceptions\KOSIdentifierClashException.cs" />
+    <Compile Include="Exceptions\KOSInvalidDelegateContext.cs" />
     <Compile Include="Exceptions\KOSLowTechException.cs" />
     <Compile Include="Exceptions\KOSCastException.cs" />
     <Compile Include="Exceptions\KOSCommandInvalidHere.cs" />
@@ -117,6 +118,7 @@
     <Compile Include="Exceptions\KOSUnaryOperandTypeException.cs" />
     <Compile Include="Execution\IKOSScopeObserver.cs" />
     <Compile Include="Execution\ICpu.cs" />
+    <Compile Include="Execution\IProgramContext.cs" />
     <Compile Include="Execution\IStack.cs" />
     <Compile Include="Execution\IUserDelegate.cs" />
     <Compile Include="Execution\SurboutineContext.cs" />

--- a/src/kOS/Execution/CPU.cs
+++ b/src/kOS/Execution/CPU.cs
@@ -226,19 +226,21 @@ namespace kOS.Execution
         /// Build a delegate call for the given function entry point, in which it will capture a closure of the current
         /// runtime scoping state to be used when that function gets called later by OpcodeCall:
         /// </summary>
+        /// <param name="entryPoint">Integer location in memory to jump to to start the call</param>
+        /// <param name="withClosure">Should the closure be captured for this delegate or ignored</param></param>
         /// <returns>The delegate object you can store in a variable.</returns>
-        public IUserDelegate MakeUserDelegate(int entryPoint)
+        public IUserDelegate MakeUserDelegate(int entryPoint, bool withClosure)
         {
-            return new UserDelegate(this, entryPoint, true);
+            return new UserDelegate(this, currentContext, entryPoint, withClosure);
         }
 
         // only two contexts exist now, one for the interpreter and one for the programs
-        public ProgramContext GetInterpreterContext()
+        public IProgramContext GetInterpreterContext()
         {
             return contexts[0];
         }
         
-        public ProgramContext SwitchToProgramContext()
+        public IProgramContext SwitchToProgramContext()
         {
             if (contexts.Count == 1)
             {
@@ -374,6 +376,19 @@ namespace kOS.Execution
         public void MoveStackPointer(int delta)
         {
             stack.MoveStackPointer(delta);
+        }
+        
+        /// <summary>Throw exception if the user delegate is not one the CPU can call right now.</summary>
+        /// <param name="userDelegate">The userdelegate being checked</param>
+        /// <exception cref="KOSInvalidDelegate">thrown if the cpu is in a state where it can't call this delegate.</exception>
+        public void AssertValidDelegateCall(IUserDelegate userDelegate)
+        {
+            if (userDelegate.ProgContext != currentContext) {
+                throw new KOSInvalidDelegateContext(
+                    (currentContext == contexts[0] ? "the interpreter" : "a program" ),
+                    (currentContext == contexts[0] ? "a program" : "the interpreter" )
+                    );
+            }
         }
         
         /// <summary>
@@ -995,7 +1010,7 @@ namespace kOS.Execution
                 SafeHouse.Logger.Log(executeLog.ToString());
         }
 
-        private bool ExecuteInstruction(ProgramContext context)
+        private bool ExecuteInstruction(IProgramContext context)
         {
             bool DEBUG_EACH_OPCODE = false;
             

--- a/src/kOS/Execution/ProgramContext.cs
+++ b/src/kOS/Execution/ProgramContext.cs
@@ -2,10 +2,11 @@
 using System.Collections.Generic;
 using kOS.Binding;
 using kOS.Safe.Compilation;
+using kOS.Safe.Execution;
 
 namespace kOS.Execution
 {
-    public class ProgramContext
+    public class ProgramContext : IProgramContext
     {
         private readonly Dictionary<string, bool> flyByWire;
         private readonly ProgramBuilder builder;
@@ -13,8 +14,8 @@ namespace kOS.Execution
         public List<Opcode> Program { get; set; }
         public int InstructionPointer { get; set; }
         public List<int> Triggers { get; set; }
-        public bool Silent { get; set; } 
-        
+        public bool Silent { get; set; }
+
         public ProgramContext(bool interpreterContext)
         {
             Program = new List<Opcode>();
@@ -24,8 +25,7 @@ namespace kOS.Execution
             flyByWire = new Dictionary<string, bool>();
         }
 
-        public ProgramContext(bool interpreterContext, List<Opcode> program)
-            : this(interpreterContext)
+        public ProgramContext(bool interpreterContext, List<Opcode> program) : this(interpreterContext)
         {
             Program = program;
         }
@@ -45,38 +45,31 @@ namespace kOS.Execution
             UpdateProgram(newProgram);
             return entryPointAddress;
         }
-        
+
         private void UpdateProgram(List<Opcode> newProgram)
         {
-            if (Program != null)
-            {
+            if (Program != null) {
                 List<Opcode> oldProgram = Program;
                 Program = newProgram;
                 UpdateInstructionPointer(oldProgram);
-            }
-            else
-            {
+            } else {
                 Program = newProgram;
             }
         }
 
         private void UpdateInstructionPointer(List<Opcode> oldProgram)
         {
-            if (oldProgram.Count > 1)
-            {
+            if (oldProgram.Count > 1) {
                 int delta = 0;
 
-                if (InstructionPointer == (oldProgram.Count - 1))
-                {
+                if (InstructionPointer == (oldProgram.Count - 1)) {
                     delta = 1;
                 }
 
                 int currentInstructionId = oldProgram[InstructionPointer - delta].Id;
 
-                for (int index = 0; index < Program.Count; index++)
-                {
-                    if (Program[index].Id == currentInstructionId)
-                    {
+                for (int index = 0; index < Program.Count; index++) {
+                    if (Program[index].Id == currentInstructionId) {
                         InstructionPointer = index + delta;
                         break;
                     }
@@ -86,22 +79,17 @@ namespace kOS.Execution
 
         public void ToggleFlyByWire(string paramName, bool enabled)
         {
-            if (!flyByWire.ContainsKey(paramName))
-            {
+            if (!flyByWire.ContainsKey(paramName)) {
                 flyByWire.Add(paramName, enabled);
-            }
-            else
-            {
+            } else {
                 flyByWire[paramName] = enabled;
             }
         }
 
         public void DisableActiveFlyByWire(BindingManager manager)
         {
-            foreach (KeyValuePair<string, bool> kvp in flyByWire)
-            {
-                if (kvp.Value)
-                {
+            foreach (KeyValuePair<string, bool> kvp in flyByWire) {
+                if (kvp.Value) {
                     manager.ToggleFlyByWire(kvp.Key, false);
                 }
             }
@@ -109,36 +97,27 @@ namespace kOS.Execution
 
         public void EnableActiveFlyByWire(BindingManager manager)
         {
-            foreach (KeyValuePair<string, bool> kvp in flyByWire)
-            {
+            foreach (KeyValuePair<string, bool> kvp in flyByWire) {
                 manager.ToggleFlyByWire(kvp.Key, kvp.Value);
             }
         }
-        
+
         public List<string> GetCodeFragment(int contextLines)
         {
-            return GetCodeFragment( InstructionPointer - contextLines, InstructionPointer + contextLines );
+            return GetCodeFragment(InstructionPointer - contextLines, InstructionPointer + contextLines);
         }
-        
+
         public List<string> GetCodeFragment(int start, int stop)
         {
             var codeFragment = new List<string>();
-            
-            const string FORMAT_STR = "{0,-20} {1,4}:{2,-3} {3:0000} {4} {5}";
-            codeFragment.Add(string.Format(FORMAT_STR, "File", "Line", "Col", "IP  ", "opcode", "operand" ));
-            codeFragment.Add(string.Format(FORMAT_STR, "----", "----", "---", "----", "---------------------", "" ));
 
-            for (int index = start; index <= stop; index++)
-            {
-                if (index >= 0 && index < Program.Count)
-                {
-                    codeFragment.Add(string.Format(FORMAT_STR,
-                                                   Program[index].SourceName,
-                                                   Program[index].SourceLine,
-                                                   Program[index].SourceColumn,
-                                                   index,
-                                                   Program[index],
-                                                   (index == InstructionPointer ? "<<--INSTRUCTION POINTER--" : "")));
+            const string FORMAT_STR = "{0,-20} {1,4}:{2,-3} {3:0000} {4} {5}";
+            codeFragment.Add(string.Format(FORMAT_STR, "File", "Line", "Col", "IP  ", "opcode", "operand"));
+            codeFragment.Add(string.Format(FORMAT_STR, "----", "----", "---", "----", "---------------------", ""));
+
+            for (int index = start; index <= stop; index++) {
+                if (index >= 0 && index < Program.Count) {
+                    codeFragment.Add(string.Format(FORMAT_STR, Program[index].SourceName, Program[index].SourceLine, Program[index].SourceColumn, index, Program[index], (index == InstructionPointer ? "<<--INSTRUCTION POINTER--" : "")));
                 }
             }
 


### PR DESCRIPTION
Now all functions (lock, or declare function) are UserDelegates, and the UserDelegate will store what context the EntryPoint integer is referring to (i.e. is it instruction 54 of the interpreter context, or instruction 54 of a program context?)

For the moment, the only thing this really does is just enable the detection of the new error message.  But that idea can be expanded later to do more "interesting" things with the functions if we ever implement TSR.
