### PR TITLE
Fixes #923 by making return capable of popscope.

### DIFF
--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -1401,32 +1401,64 @@ namespace kOS.Safe.Compilation
         }
     }
     
+    /// <summary>
+    /// Returns from an OpcodeCall, popping a number of scope depths off
+    /// the stack as it does so.  It evals the topmost thing on the stack.
+    /// to remove any local variable references and replace them with their
+    /// current values, and then performs the equivalent of a popscope, then
+    /// jumps back to where the routine was called from.
+    /// It also checks to ensure that the argument stack contains the arg
+    /// bottom marker.  If it does not, that proves the number of parameters
+    /// consumed did not match the number of arguments passed and it throws
+    /// an exception (to avoid stack misalignment that would happen if it
+    /// tried to continue).
+    /// </summary>
     public class OpcodeReturn : Opcode
     {
         protected override string Name { get { return "return"; } }
         public override ByteCode Code { get { return ByteCode.RETURN; } }
+        
+        [MLField(0,true)]
+        public Int16 Depth { get; private set; } // Determines how many levels to popscope.
 
+        public override void PopulateFromMLFields(List<object> fields)
+        {
+            // Expect fields in the same order as the [MLField] properties of this class:
+            if (fields == null || fields.Count<1)
+                throw new Exception("Saved field in ML file for OpcodeCall seems to be missing.  Version mismatch?");
+            Depth = (Int16)fields[0];
+        }
+        
+        // Default constructor is needed for PopulateFromMLFields but shouldn't be used outside the KSM file handler:
+        private OpcodeReturn()
+        {
+        }
+        
+        /// <summary>
+        /// Make a return, telling it how many levels of the scope stack it should
+        /// be popping as it does so.  It compbines the behavior of a PopScope inside
+        /// itself, AFTER it reads and evaluates the thing atop the stack for return
+        /// purposes (that way it evals the top thing BEFORE it pops the scope and forgets
+        /// what variables exist).<br/
+        /// <br/>
+        /// Doing this:<br/>
+        ///   push $val<br/>
+        ///   return 2 deep<br/>
+        /// is the same as this:<br/>
+        ///   push $val<br/>
+        ///   eval<br/>
+        ///   popscope 2<br/>
+        ///   return 0 deep<br/>
+        /// <br/>
+        /// </summary>
+        /// <param name="popScopes"></param>
+        public OpcodeReturn(Int16 depth)
+        {
+            Depth = depth;
+        }
+        
         public override void Execute(ICpu cpu)
         {
-            // The only thing on the "above stack" now that is allowed to get in the way of
-            // finding the context record that tells us where to jump back to, are the potential
-            // closure scope frames that might have been pushed if this subroutine was
-            // called via a delegate reference.  Consume any of those that are in
-            // the way, then expect the context record.  Any other pattern encountered
-            // is proof the stack alignment got screwed up:
-            bool okay;
-            VariableScope peeked = cpu.PeekRaw(-1, out okay) as VariableScope;
-            while (okay && peeked != null && peeked.IsClosure)
-            {
-                cpu.PopAboveStack(1);
-                peeked = cpu.PeekRaw(-1, out okay) as VariableScope;
-            }
-            object shouldBeContextRecord = cpu.PopAboveStack(1);
-            if ( !(shouldBeContextRecord is SubroutineContext) )
-            {
-                // This should never happen with any user code:
-                throw new Exception( "kOS internal error: Stack misalignment detected when returning from routine.");
-            }
 
             // Return value should be atop the stack - we have to pop it so that
             // we can reach the arg start marker under it:
@@ -1449,14 +1481,42 @@ namespace kOS.Safe.Compilation
             // back, where it belongs, now that the arg start marker was popped off:
             cpu.PushStack(returnVal);
             
+            // Now, after the eval was done, NOW finally pop the scope, after we don't need local vars anymore:
+            if( Depth > 0 )
+                OpcodePopScope.DoPopScope(cpu, Depth);
+
+            // The only thing on the "above stack" now that is allowed to get in the way of
+            // finding the context record that tells us where to jump back to, are the potential
+            // closure scope frames that might have been pushed if this subroutine was
+            // called via a delegate reference.  Consume any of those that are in
+            // the way, then expect the context record.  Any other pattern encountered
+            // is proof the stack alignment got screwed up:
+            bool okay;
+            VariableScope peeked = cpu.PeekRaw(-1, out okay) as VariableScope;
+            while (okay && peeked != null && peeked.IsClosure)
+            {
+                cpu.PopAboveStack(1);
+                peeked = cpu.PeekRaw(-1, out okay) as VariableScope;
+            }
+            object shouldBeContextRecord = cpu.PopAboveStack(1);
+            if ( !(shouldBeContextRecord is SubroutineContext) )
+            {
+                // This should never happen with any user code:
+                throw new Exception( "kOS internal error: Stack misalignment detected when returning from routine.");
+            }
+            
             var contextRecord = shouldBeContextRecord as SubroutineContext;
             
             int destinationPointer = contextRecord.CameFromInstPtr;
             int currentPointer = cpu.InstructionPointer;
             DeltaInstructionPointer = destinationPointer - currentPointer;
         }
-    }
 
+        public override string ToString()
+        {
+            return String.Format("{0} {1} deep", Name, Depth);
+        }
+    }
     #endregion
 
     #region Stack
@@ -1726,7 +1786,21 @@ namespace kOS.Safe.Compilation
 
         public override void Execute(ICpu cpu)
         {
-            cpu.PopAboveStack(NumLevels);
+            DoPopScope(cpu, NumLevels);
+        }
+        
+        /// <summary>
+        /// Do the actual work of the Execute() method.  This was pulled out
+        /// to a separate static method so that others can call it without needing
+        /// an actual popscope object.  Everything OpcodePopScope.Execute() does
+        /// should actually be done here, so as to ensure that external callers of
+        /// this get exactly the same behaviour as a full popstack opcode.
+        /// </summary>
+        /// <param name="cpuObj">the shared.cpu to operate on.</param>
+        /// <param name="levels">number of levels to popscope.</param>
+        public static void DoPopScope(ICpu cpuObj, Int16 levels)
+        {
+            cpuObj.PopAboveStack(levels);
         }
 
         public override string ToString()

--- a/src/kOS.Safe/Compilation/ProgramBuilder.cs
+++ b/src/kOS.Safe/Compilation/ProgramBuilder.cs
@@ -99,7 +99,7 @@ namespace kOS.Safe.Compilation
             else
             {
                 linkedObject.MainCode.Add(new OpcodePush(0)); // all Returns now need a dummy return value on them.
-                linkedObject.MainCode.Add(new OpcodeReturn());
+                linkedObject.MainCode.Add(new OpcodeReturn(0));
             }
         }
 


### PR DESCRIPTION
Now it is possible to have an OpcodeReturn that does its own
popscope, AFTER it evals the thing atop the stack.  This is
now used in:

   returning from locks.
   explicit return statements from user functions like so:
```
    function foo {
      local val is 3.
      if true {
        return val.
      }
      return 0.
    }
```

When you call that, now, the return val will perform its own internal
popscope 2 (because it's jumping outside of both the if and the
function's braces), and the return 0 will perform its own internal
popscope 1 (because its outside the if but still inside the function's
braces).

This is as opposed to before, where it would do it in two separate
steps, first doing a popscope, and then doing a return.

So for example, the above code's return val will now do this:

```
    push $val
    return 2 depth
```

Where what it used to do was this:
```
    push $val
    popscope 2
    return
```

When looking at an opcode dump, the format for the new return statement
in the "assembly language" will be:
``return`` number ``depth``.

Under the hood, that means it was called with constructor:

  new OpcodeReturn(number).