### PR TITLE
Fix for #934 empty return crashes

### DIFF
--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -2561,11 +2561,9 @@ namespace kOS.Safe.Compilation.KS
 
             // Push the return expression onto the stack, or if it was a naked RETURN
             // keyword with no expression, then push a secret dummy return value of zero:
-            if (node.Nodes.Count > 1)
+            if (node.Nodes.Count > 2)
             {
                 VisitNode(node.Nodes[1]);
-                AddOpcode(new OpcodeEval()); // vital because we can't return a local var to the caller,
-                                             // we must return the value it contained instead.
             }
             else
             {


### PR DESCRIPTION
Increased the node count required to add the dummy return value of 0.
Remove eval opcode that is no longer needed.