### PR TITLE
[breaking] Fix thrust calculation for 1.0 (ready)

### DIFF
--- a/doc/source/structures/vessels/engine.rst
+++ b/doc/source/structures/vessels/engine.rst
@@ -118,7 +118,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
     :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
     :type: scalar (kN)
 
-    How much thrust would this engine give if the throttle was max at the current velocity, and at the given atmospheric pressure.
+    How much thrust would this engine give if the throttle was max at the current velocity, and at the given atmospheric pressure.  Use a pressure of 0 for vacuum, and 1 for sea level (on Kerbin).
 
 .. attribute:: Engine:THRUST
 
@@ -139,7 +139,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
     :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
     :type: scalar (kN)
 
-    How much thrust would this engine give if the throttle was max at the current thrust limit and velocity, and at the given atmospheric pressure.
+    How much thrust would this engine give if the throttle was max at the current thrust limit and velocity, and at the given atmospheric pressure.  Use a pressure of 0 for vacuum, and 1 for sea level (on Kerbin).
 
 .. attribute:: Engine:FUELFLOW
 
@@ -160,7 +160,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
     :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
     :type: scalar
 
-    `Specific impulse <isp>`_ at the given atmospheric pressure.
+    `Specific impulse <isp>`_ at the given atmospheric pressure.  Use a pressure of 0 for vacuum, and 1 for sea level (on Kerbin).
 
 .. attribute:: Engine:VACUUMISP
 

--- a/doc/source/structures/vessels/engine.rst
+++ b/doc/source/structures/vessels/engine.rst
@@ -35,15 +35,27 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
         * - :attr:`MAXTHRUST`
           - scalar (kN)
           - Untweaked thrust limit
+        * - :meth:`MAXTHRUSTAT(pressure)`
+          - scalar (kN)
+          - Max thrust at the specified pressure (in standard Kerbin atmospheres).
         * - :attr:`THRUST`
           - scalar (kN)
           - Current thrust
+        * - :attr:`AVAILABLETHRUST`
+          - scalar (kN)
+          - Available thrust at full throttle accounting for thrust limit
+        * - :meth:`AVAILABLETHRUSTAT(pressure)`
+          - scalar (kN)
+          - Available thrust at the specified pressure (in standard Kerbin atmospheres).
         * - :attr:`FUELFLOW`
           - scalar (l/s maybe)
           - Rate of fuel burn
         * - :attr:`ISP`
           - scalar
           - `Specific impulse <isp>`_
+        * - :meth:`ISPAT(pressure)`
+          - scalar
+          - `Specific impulse <isp>`_ at the given pressure (in standard Kerbin atmospheres).
         * - :attr:`VACUUMISP`
           - scalar
           - `Vacuum Specific impulse <isp>`_
@@ -99,7 +111,14 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
     :access: Get only
     :type: scalar (kN)
 
-    How much thrust would this engine give if the throttle was max and conditions were ideal.
+    How much thrust would this engine give if the throttle was max at current conditions.
+
+.. method:: Engine:MAXTHRUSTAT(pressure)
+
+    :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
+    :type: scalar (kN)
+
+    How much thrust would this engine give if the throttle was max at the current velocity, and at the given atmospheric pressure.
 
 .. attribute:: Engine:THRUST
 
@@ -107,6 +126,20 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
     :type: scalar (kN)
 
     How much thrust is this engine giving at this very moment.
+
+.. attribute:: Engine:AVAILABLETHRUST
+
+    :access: Get only
+    :type: scalar (kN)
+
+    How much thrust would this engine give if the throttle was max at current thrust limit and conditions.
+
+.. method:: Engine:AVAILABLETHRUSTAT(pressure)
+
+    :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
+    :type: scalar (kN)
+
+    How much thrust would this engine give if the throttle was max at the current thrust limit and velocity, and at the given atmospheric pressure.
 
 .. attribute:: Engine:FUELFLOW
 
@@ -121,6 +154,13 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
     :type: scalar
 
     `Specific impulse <isp>`_
+
+.. method:: Engine:ISPAT(pressure)
+
+    :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
+    :type: scalar
+
+    `Specific impulse <isp>`_ at the given atmospheric pressure.
 
 .. attribute:: Engine:VACUUMISP
 

--- a/doc/source/structures/vessels/vessel.rst
+++ b/doc/source/structures/vessels/vessel.rst
@@ -35,7 +35,9 @@ All vessels share a structure. To get a variable referring to any vessel you can
      :attr:`BEARING`                       scalar (deg)              relative heading to this vessel
      :attr:`HEADING`                       scalar (deg)              Absolute heading to this vessel
      :attr:`MAXTHRUST`                     scalar                    Sum of active maximum thrusts
+     :meth:`MAXTHRUSTAT(pressure)`         scalar                    Sum of active maximum thrusts at the given atmospheric pressure
      :attr:`AVAILABLETHRUST`               scalar                    Sum of active limited maximum thrusts 
+     :meth:`AVAILABLETHRUSTAT(pressure)`   scalar                    Sum of active limited maximum thrusts at the given atmospheric pressure
      :attr:`FACING`                        :struct:`Direction`       The way the vessel is pointed
      :attr:`MASS`                          scalar (metric tons)      Mass of the ship
      :attr:`WETMASS`                       scalar (metric tons)      Mass of the ship fully fuelled
@@ -97,12 +99,26 @@ All vessels share a structure. To get a variable referring to any vessel you can
 
     Sum of all the Max thrust of all the currently active engines In Kilonewtons.
     
+.. method:: Engine:MAXTHRUSTAT(pressure)
+
+    :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
+    :type: scalar (kN)
+
+    Sum of all the Max thrust of all the currently active engines In Kilonewtons at the given atmospheric pressure.
+
 .. attribute:: vessel:AVAILABLETHRUST
 
     :type: scalar
     :access: Get only
     
     Sum of all the Max thrust of all the currently active engines taking into acount their throttlelimits. Result is in Kilonewtons.
+
+.. method:: Engine:AVAILABLETHRUSTAT(pressure)
+
+    :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
+    :type: scalar (kN)
+
+    Sum of all the Max thrust of all the currently active engines taking into acount their throttlelimits at the given atmospheric pressure. Result is in Kilonewtons.
 
 .. attribute:: Vessel:FACING
 

--- a/doc/source/structures/vessels/vessel.rst
+++ b/doc/source/structures/vessels/vessel.rst
@@ -104,7 +104,7 @@ All vessels share a structure. To get a variable referring to any vessel you can
     :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
     :type: scalar (kN)
 
-    Sum of all the Max thrust of all the currently active engines In Kilonewtons at the given atmospheric pressure.
+    Sum of all the Max thrust of all the currently active engines In Kilonewtons at the given atmospheric pressure.  Use a pressure of 0 for vacuum, and 1 for sea level (on Kerbin).
 
 .. attribute:: vessel:AVAILABLETHRUST
 
@@ -118,7 +118,7 @@ All vessels share a structure. To get a variable referring to any vessel you can
     :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
     :type: scalar (kN)
 
-    Sum of all the Max thrust of all the currently active engines taking into acount their throttlelimits at the given atmospheric pressure. Result is in Kilonewtons.
+    Sum of all the Max thrust of all the currently active engines taking into acount their throttlelimits at the given atmospheric pressure. Result is in Kilonewtons.  Use a pressure of 0 for vacuum, and 1 for sea level (on Kerbin).
 
 .. attribute:: Vessel:FACING
 

--- a/src/kOS.Safe/Encapsulation/Part/IModuleEngine.cs
+++ b/src/kOS.Safe/Encapsulation/Part/IModuleEngine.cs
@@ -6,6 +6,7 @@
         void Shutdown();
         float ThrustPercentage { get; set; }
         float MaxThrust { get; }
+        float AvailableThrust { get; }
         float FinalThrust { get; }
         float FuelFlow { get; }
         float SpecificImpulse { get; }
@@ -16,5 +17,8 @@
         bool AllowRestart { get; }
         bool AllowShutdown { get; }
         bool ThrottleLock { get; }
+        float IspAtAtm(double atmPressure);
+        float MaxThrustAtAtm(double atmPressure);
+        float AvailableThrustAtAtm(double atmPressure);
     }
 }

--- a/src/kOS/Suffixed/Part/EngineValue.cs
+++ b/src/kOS/Suffixed/Part/EngineValue.cs
@@ -1,7 +1,7 @@
 ﻿using kOS.Safe.Encapsulation;
-using System.Collections.Generic;
 using kOS.Safe.Encapsulation.Part;
 using kOS.Safe.Encapsulation.Suffixes;
+using System.Collections.Generic;
 
 namespace kOS.Suffixed.Part
 {
@@ -25,8 +25,8 @@ namespace kOS.Suffixed.Part
             AddSuffix("THRUST", new Suffix<float>(() => engine.FinalThrust));
             AddSuffix("FUELFLOW", new Suffix<float>(() => engine.FuelFlow));
             AddSuffix("ISP", new Suffix<float>(() => engine.SpecificImpulse));
-            AddSuffix(new[] {"VISP", "VACUUMISP"}, new Suffix<float>(() => engine.VacuumSpecificImpluse));
-            AddSuffix(new[] {"SLISP", "SEALEVELISP"}, new Suffix<float>(() => engine.SeaLevelSpecificImpulse));
+            AddSuffix(new[] { "VISP", "VACUUMISP" }, new Suffix<float>(() => engine.VacuumSpecificImpluse));
+            AddSuffix(new[] { "SLISP", "SEALEVELISP" }, new Suffix<float>(() => engine.SeaLevelSpecificImpulse));
             AddSuffix("FLAMEOUT", new Suffix<bool>(() => engine.Flameout));
             AddSuffix("IGNITION", new Suffix<bool>(() => engine.Ignition));
             AddSuffix("ALLOWRESTART", new Suffix<bool>(() => engine.AllowRestart));
@@ -59,14 +59,17 @@ namespace kOS.Suffixed.Part
             }
             return toReturn;
         }
+
         public float GetIspAtAtm(double atmPressure)
         {
             return engine.IspAtAtm(atmPressure);
         }
+
         public float GetMaxThrustAtAtm(double atmPressure)
         {
             return engine.MaxThrustAtAtm(atmPressure);
         }
+
         public float GetAvailableThrustAtAtm(double atmPressure)
         {
             return engine.AvailableThrustAtAtm(atmPressure);

--- a/src/kOS/Suffixed/Part/EngineValue.cs
+++ b/src/kOS/Suffixed/Part/EngineValue.cs
@@ -32,6 +32,10 @@ namespace kOS.Suffixed.Part
             AddSuffix("ALLOWRESTART", new Suffix<bool>(() => engine.AllowRestart));
             AddSuffix("ALLOWSHUTDOWN", new Suffix<bool>(() => engine.AllowShutdown));
             AddSuffix("THROTTLELOCK", new Suffix<bool>(() => engine.ThrottleLock));
+            AddSuffix("ISPAT", new OneArgsSuffix<float, double>(GetIspAtAtm));
+            AddSuffix("MAXTHRUSTAT", new OneArgsSuffix<float, double>(GetMaxThrustAtAtm));
+            AddSuffix("AVAILABLETHRUST", new Suffix<float>(() => engine.AvailableThrust));
+            AddSuffix("AVAILABLETHRUSTAT", new OneArgsSuffix<float, double>(GetAvailableThrustAtAtm));
         }
 
         public static ListValue PartsToList(IEnumerable<global::Part> parts, SharedObjects sharedObj)
@@ -54,6 +58,18 @@ namespace kOS.Suffixed.Part
                 }
             }
             return toReturn;
+        }
+        public float GetIspAtAtm(double atmPressure)
+        {
+            return engine.IspAtAtm(atmPressure);
+        }
+        public float GetMaxThrustAtAtm(double atmPressure)
+        {
+            return engine.MaxThrustAtAtm(atmPressure);
+        }
+        public float GetAvailableThrustAtAtm(double atmPressure)
+        {
+            return engine.AvailableThrustAtAtm(atmPressure);
         }
     }
 }

--- a/src/kOS/Suffixed/Part/ModuleEngineAdapter.cs
+++ b/src/kOS/Suffixed/Part/ModuleEngineAdapter.cs
@@ -150,11 +150,11 @@ namespace kOS.Suffixed.Part
             }
         }
 
-        public static double GetEngineThrust(ModuleEngines engine, float throttle = 1.0f, bool useThrustLimit = false, double atmPressure = -1.0)
+        public static float GetEngineThrust(ModuleEngines engine, float throttle = 1.0f, bool useThrustLimit = false, double atmPressure = -1.0)
         {
             if (engine != null)
             {
-                if (!engine.isOperational) return 0.0;
+                if (!engine.isOperational) return 0.0f;
                 if (useThrustLimit) { throttle = throttle * engine.thrustPercentage / 100.0f; }
                 if (atmPressure < 0) { atmPressure = engine.part.staticPressureAtm; }
                 float flowMod = 1.0f;
@@ -165,7 +165,7 @@ namespace kOS.Suffixed.Part
                 }
                 if (engine.useAtmCurve && engine.atmCurve != null)
                 {
-                    flowMod = engine.atmCurve.Evaluate((float)flowMod);
+                    flowMod = engine.atmCurve.Evaluate(flowMod);
                 }
                 if (engine.useVelCurve && engine.velCurve != null)
                 {
@@ -174,14 +174,14 @@ namespace kOS.Suffixed.Part
                 // thrust is modified fuel flow rate times isp time g times the velocity modifier for jet engines (as of KSP 1.0)
                 return Mathf.Lerp(engine.minFuelFlow, engine.maxFuelFlow, throttle) * flowMod * GetEngineIsp(engine, atmPressure) * engine.g * velMod;
             }
-            else return 0.0;
+            else return 0.0f;
         }
 
         public static float GetEngineIsp(ModuleEngines engine)
         {
             if (engine != null)
             {
-                return GetEngineIsp(engine, (float)engine.part.staticPressureAtm);
+                return GetEngineIsp(engine, engine.part.staticPressureAtm);
             }
             else return 0.0f;
         }
@@ -377,10 +377,10 @@ namespace kOS.Suffixed.Part
             switch (engineType)
             {
                 case EngineType.Engine:
-                    return (float)ModuleEngineAdapter.GetEngineThrust(engineModule, atmPressure: atmPressure);
+                    return ModuleEngineAdapter.GetEngineThrust(engineModule, atmPressure: atmPressure);
 
                 case EngineType.EngineFx:
-                    return (float)ModuleEngineAdapter.GetEngineThrust(engineModuleFx, atmPressure: atmPressure);
+                    return ModuleEngineAdapter.GetEngineThrust(engineModuleFx, atmPressure: atmPressure);
 
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -392,10 +392,10 @@ namespace kOS.Suffixed.Part
             switch (engineType)
             {
                 case EngineType.Engine:
-                    return (float)ModuleEngineAdapter.GetEngineThrust(engineModule, useThrustLimit: true, atmPressure: atmPressure);
+                    return ModuleEngineAdapter.GetEngineThrust(engineModule, useThrustLimit: true, atmPressure: atmPressure);
 
                 case EngineType.EngineFx:
-                    return (float)ModuleEngineAdapter.GetEngineThrust(engineModuleFx, useThrustLimit: true, atmPressure: atmPressure);
+                    return ModuleEngineAdapter.GetEngineThrust(engineModuleFx, useThrustLimit: true, atmPressure: atmPressure);
 
                 default:
                     throw new ArgumentOutOfRangeException();

--- a/src/kOS/Suffixed/Part/ModuleEngineAdapter.cs
+++ b/src/kOS/Suffixed/Part/ModuleEngineAdapter.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using kOS.Safe.Utilities;
-using kOS.Safe.Encapsulation.Part;
+﻿using kOS.Safe.Encapsulation.Part;
+using System;
 using UnityEngine;
 
 namespace kOS.Suffixed.Part
@@ -36,9 +35,11 @@ namespace kOS.Suffixed.Part
                 case EngineType.Engine:
                     engineModule.Activate();
                     break;
+
                 case EngineType.EngineFx:
                     engineModuleFx.Activate();
                     break;
+
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -51,9 +52,11 @@ namespace kOS.Suffixed.Part
                 case EngineType.Engine:
                     engineModule.Shutdown();
                     break;
+
                 case EngineType.EngineFx:
                     engineModuleFx.Shutdown();
                     break;
+
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -101,8 +104,10 @@ namespace kOS.Suffixed.Part
                 {
                     case EngineType.Engine:
                         return (float)GetEngineThrust(engineModule);
+
                     case EngineType.EngineFx:
                         return (float)GetEngineThrust(engineModuleFx);
+
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
@@ -117,8 +122,10 @@ namespace kOS.Suffixed.Part
                 {
                     case EngineType.Engine:
                         return (float)GetEngineThrust(engineModule, useThrustLimit: true);
+
                     case EngineType.EngineFx:
                         return (float)GetEngineThrust(engineModuleFx, useThrustLimit: true);
+
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
@@ -178,6 +185,7 @@ namespace kOS.Suffixed.Part
             }
             else return 0.0f;
         }
+
         public static float GetEngineIsp(ModuleEngines engine, double staticPressureAtm)
         {
             if (engine != null)
@@ -222,6 +230,7 @@ namespace kOS.Suffixed.Part
                 }
             }
         }
+
         public float VacuumSpecificImpluse
         {
             get
@@ -239,6 +248,7 @@ namespace kOS.Suffixed.Part
                 }
             }
         }
+
         public float SeaLevelSpecificImpulse
         {
             get
@@ -346,38 +356,47 @@ namespace kOS.Suffixed.Part
                 }
             }
         }
+
         public float IspAtAtm(double atmPressure)
         {
             switch (engineType)
             {
                 case EngineType.Engine:
                     return ModuleEngineAdapter.GetEngineIsp(engineModule, atmPressure);
+
                 case EngineType.EngineFx:
                     return ModuleEngineAdapter.GetEngineIsp(engineModuleFx, atmPressure);
+
                 default:
                     throw new ArgumentOutOfRangeException();
             }
         }
+
         public float MaxThrustAtAtm(double atmPressure)
         {
             switch (engineType)
             {
                 case EngineType.Engine:
                     return (float)ModuleEngineAdapter.GetEngineThrust(engineModule, atmPressure: atmPressure);
+
                 case EngineType.EngineFx:
                     return (float)ModuleEngineAdapter.GetEngineThrust(engineModuleFx, atmPressure: atmPressure);
+
                 default:
                     throw new ArgumentOutOfRangeException();
             }
         }
+
         public float AvailableThrustAtAtm(double atmPressure)
         {
             switch (engineType)
             {
                 case EngineType.Engine:
                     return (float)ModuleEngineAdapter.GetEngineThrust(engineModule, useThrustLimit: true, atmPressure: atmPressure);
+
                 case EngineType.EngineFx:
                     return (float)ModuleEngineAdapter.GetEngineThrust(engineModuleFx, useThrustLimit: true, atmPressure: atmPressure);
+
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -403,7 +403,9 @@ namespace kOS.Suffixed
             AddSuffix("BEARING", new Suffix<float>(() => VesselUtils.GetTargetBearing(CurrentVessel, Vessel)));
             AddSuffix("HEADING", new Suffix<float>(() => VesselUtils.GetTargetHeading(CurrentVessel, Vessel)));
             AddSuffix("AVAILABLETHRUST", new Suffix<double>(() => VesselUtils.GetAvailableThrust(Vessel)));
+            AddSuffix("AVAILABLETHRUSTAT", new OneArgsSuffix<double, double>(GetAvailableThrustAt));
             AddSuffix("MAXTHRUST", new Suffix<double>(() => VesselUtils.GetMaxThrust(Vessel)));
+            AddSuffix("MAXTHRUSTAT", new OneArgsSuffix<double, double>(GetMaxThrustAt));
             AddSuffix("FACING", new Suffix<Direction>(() => VesselUtils.GetFacing(Vessel)));
             AddSuffix("ANGULARMOMENTUM", new Suffix<Vector>(() => new Vector(Vessel.angularMomentum)));
             AddSuffix("ANGULARVEL", new Suffix<Vector>(() => RawAngularVelFromRelative(Vessel.angularVelocity)));
@@ -443,6 +445,15 @@ namespace kOS.Suffixed
 
        }
 
+        public double GetAvailableThrustAt(double atmPressure)
+        {
+            return VesselUtils.GetAvailableThrust(Vessel, atmPressure);
+        }
+
+        public double GetMaxThrustAt(double atmPressure)
+        {
+            return VesselUtils.GetMaxThrust(Vessel, atmPressure);
+        }
 
         private void RetypeVessel(string value)
         {

--- a/src/kOS/Utilities/VesselUtils.cs
+++ b/src/kOS/Utilities/VesselUtils.cs
@@ -365,7 +365,7 @@ namespace kOS.Utilities
                 {
                     if (pm.isEnabled && pm is ModuleEngines)
                     {
-                        thrust += ModuleEngineAdapter.GetEngineThrust((ModuleEngines)pm);
+                        thrust += ModuleEngineAdapter.GetEngineAvailableThrust((ModuleEngines)pm);
                     }
                 }
             }

--- a/src/kOS/Utilities/VesselUtils.cs
+++ b/src/kOS/Utilities/VesselUtils.cs
@@ -113,43 +113,9 @@ namespace kOS.Utilities
                 foreach (PartModule pm in p.Modules)
                 {
                     if (!pm.isEnabled) continue;
-                    if (!(pm is ModuleEngines || pm is ModuleEnginesFX)) continue;
-
-                    var engine = pm as ModuleEngines;
-                    var enginefx = pm as ModuleEnginesFX;
-
-                    if (enginefx != null)
+                    if (pm is ModuleEngines)
                     {
-                        if (!enginefx.isOperational) continue;
-                        float flowMod = (float)(engine.part.atmDensity / 1.225f);
-                        float velMod = 1.0f;
-                        if (enginefx.atmChangeFlow && enginefx.atmCurve != null)
-                        {
-                            flowMod = enginefx.atmCurve.Evaluate((float)(enginefx.part.atmDensity / 1.225));
-                        }
-                        if (enginefx.velCurve != null)
-                        {
-                            velMod = velMod * enginefx.velCurve.Evaluate((float)vessel.mach);
-                        }
-                        // thrust is fuel flow rate times isp time g times the velocity modifier for jet engines (as of KSP 1.0)
-                        thrust += enginefx.maxFuelFlow * flowMod * enginefx.atmosphereCurve.Evaluate((float)enginefx.part.staticPressureAtm) * enginefx.g * velMod;
-                    }
-                    else if (engine != null)
-                    {
-                        if (!engine.isOperational) continue;
-                        float flowMod = (float)(engine.part.atmDensity / 1.225f);
-                        float velMod = 1.0f;
-                        if (engine.atmChangeFlow && engine.atmCurve != null)
-                        {
-                            flowMod = engine.atmCurve.Evaluate((float)(engine.part.atmDensity / 1.225));
-                        }
-                        if (engine.velCurve != null)
-                        {
-                            velMod = velMod * engine.velCurve.Evaluate((float)vessel.mach);
-                        }
-                        // thrust is modified fuel flow rate times isp time g times the velocity modifier for jet engines (as of KSP 1.0)
-                        thrust += engine.maxFuelFlow * flowMod * engine.atmosphereCurve.Evaluate((float)engine.part.staticPressureAtm) * engine.g * velMod;
-                        //thrust += engine.GetCurrentThrust();
+                        thrust += ModuleEngineAdapter.GetEngineMaxThrust((ModuleEngines)pm);
                     }
                 }
             }
@@ -397,22 +363,9 @@ namespace kOS.Utilities
             {
                 foreach (PartModule pm in p.Modules)
                 {
-                    if (!pm.isEnabled) continue;
-                    if (!(pm is ModuleEngines || pm is ModuleEnginesFX)) continue;
-
-                    var engine = pm as ModuleEngines;
-                    var enginefx = pm as ModuleEnginesFX;
-
-                    if (enginefx != null)
+                    if (pm.isEnabled && pm is ModuleEngines)
                     {
-                        if (!enginefx.isOperational) continue;
-                        thrust += enginefx.maxThrust * enginefx.thrustPercentage / 100;
-                    }
-
-                    if (engine != null)
-                    {
-                        if (!engine.isOperational) continue;
-                        thrust += engine.maxThrust * engine.thrustPercentage / 100;
+                        thrust += ModuleEngineAdapter.GetEngineThrust((ModuleEngines)pm);
                     }
                 }
             }

--- a/src/kOS/Utilities/VesselUtils.cs
+++ b/src/kOS/Utilities/VesselUtils.cs
@@ -104,7 +104,7 @@ namespace kOS.Utilities
             return list;
         }
 
-        public static double GetMaxThrust(Vessel vessel)
+        public static double GetMaxThrust(Vessel vessel, double atmPressure = -1.0)
         {
             var thrust = 0.0;
 
@@ -115,7 +115,7 @@ namespace kOS.Utilities
                     if (!pm.isEnabled) continue;
                     if (pm is ModuleEngines)
                     {
-                        thrust += ModuleEngineAdapter.GetEngineMaxThrust((ModuleEngines)pm);
+                        thrust += ModuleEngineAdapter.GetEngineThrust((ModuleEngines)pm, atmPressure: atmPressure);
                     }
                 }
             }
@@ -355,7 +355,7 @@ namespace kOS.Utilities
             FlightGlobals.fetch.SetVesselTarget(null);
         }
 
-        public static double GetAvailableThrust(Vessel vessel)
+        public static double GetAvailableThrust(Vessel vessel, double atmPressure = -1.0)
         {
             var thrust = 0.0;
 
@@ -365,7 +365,7 @@ namespace kOS.Utilities
                 {
                     if (pm.isEnabled && pm is ModuleEngines)
                     {
-                        thrust += ModuleEngineAdapter.GetEngineAvailableThrust((ModuleEngines)pm);
+                        thrust += ModuleEngineAdapter.GetEngineThrust((ModuleEngines)pm, useThrustLimit: true, atmPressure: atmPressure);
                     }
                 }
             }

--- a/src/kOS/Utilities/VesselUtils.cs
+++ b/src/kOS/Utilities/VesselUtils.cs
@@ -121,13 +121,35 @@ namespace kOS.Utilities
                     if (enginefx != null)
                     {
                         if (!enginefx.isOperational) continue;
-                        thrust += enginefx.maxThrust;
+                        float flowMod = (float)(engine.part.atmDensity / 1.225f);
+                        float velMod = 1.0f;
+                        if (enginefx.atmChangeFlow && enginefx.atmCurve != null)
+                        {
+                            flowMod = enginefx.atmCurve.Evaluate((float)(enginefx.part.atmDensity / 1.225));
+                        }
+                        if (enginefx.velCurve != null)
+                        {
+                            velMod = velMod * enginefx.velCurve.Evaluate((float)vessel.mach);
+                        }
+                        // thrust is fuel flow rate times isp time g times the velocity modifier for jet engines (as of KSP 1.0)
+                        thrust += enginefx.maxFuelFlow * flowMod * enginefx.atmosphereCurve.Evaluate((float)enginefx.part.staticPressureAtm) * enginefx.g * velMod;
                     }
-
-                    if (engine != null)
+                    else if (engine != null)
                     {
                         if (!engine.isOperational) continue;
-                        thrust += engine.maxThrust;
+                        float flowMod = (float)(engine.part.atmDensity / 1.225f);
+                        float velMod = 1.0f;
+                        if (engine.atmChangeFlow && engine.atmCurve != null)
+                        {
+                            flowMod = engine.atmCurve.Evaluate((float)(engine.part.atmDensity / 1.225));
+                        }
+                        if (engine.velCurve != null)
+                        {
+                            velMod = velMod * engine.velCurve.Evaluate((float)vessel.mach);
+                        }
+                        // thrust is modified fuel flow rate times isp time g times the velocity modifier for jet engines (as of KSP 1.0)
+                        thrust += engine.maxFuelFlow * flowMod * engine.atmosphereCurve.Evaluate((float)engine.part.staticPressureAtm) * engine.g * velMod;
+                        //thrust += engine.GetCurrentThrust();
                     }
                 }
             }


### PR DESCRIPTION
When complete, this will fix #940.

I have updated the VesselUtils to calculate maxthrust based on isp, atmospheric density, and velocity.  This works for traditional rocket engines and jet engines alike.

TODO:
- [x] Move calculation to within EngineModuleAdapter
- [x] Port to individual engine calculations
- [x] Port to availablethrust
- [x] Test against all stock engines
- [x] Test against non-stock if possible
- [x] Create "at pressure" variants
- [x] Implement available thrust on EngineValue
- [x] Documentation