### PR TITLE
PartModule suffixes 

### DIFF
--- a/doc/source/structures/vessels/partmodule.rst
+++ b/doc/source/structures/vessels/partmodule.rst
@@ -29,12 +29,21 @@ Once you have a :struct:`PartModule`, you can use it to invoke the behaviors tha
         * - :attr:`ALLFIELDS`
           - :struct:`List` of strings
           - Accessible fields
+        * - :attr:`ALLFIELDNAMES`
+          - :struct:`List` of strings
+          - Accessible fields (name only)
         * - :attr:`ALLEVENTS`
           - :struct:`List` of strings
           - Triggerable events
+        * - :attr:`ALLEVENTNAMES`
+          - :struct:`List` of strings
+          - Triggerable event names
         * - :attr:`ALLACTIONS`
           - :struct:`List` of strings
           - Triggerable actions
+        * - :attr:`ALLACTIONNAMES`
+          - :struct:`List` of strings
+          - Triggerable event names
         * - :meth:`GETFIELD(name)`
           -
           - Get value of a field by name
@@ -81,6 +90,13 @@ Once you have a :struct:`PartModule`, you can use it to invoke the behaviors tha
 
     Get a list of all the names of KSPFields on this PartModule that the kos script is CURRENTLY allowed to get or set with :GETFIELD or :SETFIELD. Note the Security access comments below. This list can become obsolete as the game continues running depending on what the PartModule chooses to do.
 
+.. attribute:: PartModule:ALLFIELDNAMES
+
+     :access: Get only
+     :test: :struct:`List` of strings
+     
+     Similar to :ALLFIELDS except that it returns the string without the formatting to make it easier to use in a script. This list can become obsolete as the game continues running depending on what the PartModule chooses to do.
+     
 .. attribute:: PartModule:ALLEVENTS
 
     :access: Get only
@@ -88,6 +104,13 @@ Once you have a :struct:`PartModule`, you can use it to invoke the behaviors tha
 
     Get a list of all the names of KSPEvents on this PartModule that the kos script is CURRENTLY allowed to trigger with :DOEVENT. Note the Security access comments below. This list can become obsolete as the game continues running depending on what the PartModule chooses to do.
 
+.. attribute:: PartModule:ALLEVENTNAMES
+
+     :access: Get only
+     :test: :struct:`List` of strings
+     
+     Similar to :ALLEVENTS except that it returns the string without the formatting to make it easier to use in a script. This list can become obsolete as the game continues running depending on what the PartModule chooses to do.
+     
 .. attribute:: PartModule:ALLACTIONS
 
     :access: Get only
@@ -95,6 +118,13 @@ Once you have a :struct:`PartModule`, you can use it to invoke the behaviors tha
 
     Get a list of all the names of KSPActions on this PartModule that the kos script is CURRENTLY allowed to trigger with :DOACTION. Note the Security access comments below.
 
+.. attribute:: PartModule:ALLACTIONNAMES
+
+     :access: Get only
+     :test: :struct:`List` of strings
+     
+     Similar to :ALLACTIONS except that it returns the string without the formatting to make it easier to use in a script. This list can become obsolete as the game continues running depending on what the PartModule chooses to do.
+     
 .. method:: PartModule:GETFIELD(name)
 
     :parameter name: (string) Name of the field

--- a/src/kOS/Suffixed/PartModuleField/PartModuleFields.cs
+++ b/src/kOS/Suffixed/PartModuleField/PartModuleFields.cs
@@ -192,22 +192,22 @@ namespace kOS.Suffixed.PartModuleField
         }
         
         /// <summary>
-		/// Return a list of all the strings of all KSPfields registered to this PartModule
-		/// which are currently showing on the part's RMB menu, without formating.
-		/// </summary>
-		/// <returns>List of all the strings field names.</returns>
-		private ListValue AllFieldNames()
-		{            
-			var returnValue = new ListValue();
+        /// Return a list of all the strings of all KSPfields registered to this PartModule
+        /// which are currently showing on the part's RMB menu, without formating.
+        /// </summary>
+        /// <returns>List of all the strings field names.</returns>
+        private ListValue AllFieldNames()
+        {            
+            var returnValue = new ListValue();
 
-			IEnumerable<BaseField> visibleFields = partModule.Fields.Cast<BaseField>().Where(FieldIsVisible);
+            IEnumerable<BaseField> visibleFields = partModule.Fields.Cast<BaseField>().Where(FieldIsVisible);
 
-			foreach (BaseField field in visibleFields)
-			{
-				returnValue.Add(field.guiName.ToLower());
-			}
-			return returnValue;
-		}
+            foreach (BaseField field in visibleFields)
+            {
+                returnValue.Add(field.guiName.ToLower());
+            }
+            return returnValue;
+        }
         
         /// <summary>
         /// Determine if the Partmodule has this KSPField on it, which is publicly
@@ -253,22 +253,22 @@ namespace kOS.Suffixed.PartModuleField
         }
         
         /// <summary>
-		/// Return a list of all the KSPEvents the module has in it which are currently
-		/// visible on the RMB menu, without formatting.
-		/// </summary>
-		/// <returns>List of Event Names</returns>
-		private ListValue AllEventNames()
-		{            
-			var returnValue = new ListValue();
+        /// Return a list of all the KSPEvents the module has in it which are currently
+        /// visible on the RMB menu, without formatting.
+        /// </summary>
+        /// <returns>List of Event Names</returns>
+        private ListValue AllEventNames()
+        {            
+            var returnValue = new ListValue();
 
-			IEnumerable<BaseEvent> visibleEvents = partModule.Events.Where( EventIsVisible );
+            IEnumerable<BaseEvent> visibleEvents = partModule.Events.Where( EventIsVisible );
 
-			foreach (BaseEvent kspEvent in visibleEvents)
-			{
-				returnValue.Add(kspEvent.guiName.ToLower());
-			}
-			return returnValue;
-		}
+            foreach (BaseEvent kspEvent in visibleEvents)
+            {
+                returnValue.Add(kspEvent.guiName.ToLower());
+            }
+            return returnValue;
+        }
         
         /// <summary>
         /// Determine if the Partmodule has this KSPEvent on it, which is publicly
@@ -310,20 +310,20 @@ namespace kOS.Suffixed.PartModuleField
             return returnValue;
         }
         
-		/// <summary>
-		/// Return a list of all the KSPActions the module has in it, without formatting.
-		/// </summary>
-		/// <returns>List of Action Names</returns>
-		private ListValue AllActionNames()
-		{            
-			var returnValue = new ListValue();
+        /// <summary>
+        /// Return a list of all the KSPActions the module has in it, without formatting.
+        /// </summary>
+        /// <returns>List of Action Names</returns>
+        private ListValue AllActionNames()
+        {            
+            var returnValue = new ListValue();
 
-			foreach (BaseAction kspAction  in partModule.Actions)
-			{
-				returnValue.Add(kspAction.guiName.ToLower());
-			}
-			return returnValue;
-		}
+            foreach (BaseAction kspAction  in partModule.Actions)
+            {
+                returnValue.Add(kspAction.guiName.ToLower());
+            }
+            return returnValue;
+        }
 
         /// <summary>
         /// Determine if the Partmodule has this KSPAction on it, which is publicly
@@ -381,13 +381,13 @@ namespace kOS.Suffixed.PartModuleField
             AddSuffix("NAME",       new Suffix<string>(() => partModule.moduleName));
             AddSuffix("PART",       new Suffix<PartValue>(() => PartValueFactory.Construct(partModule.part,shared)));
             AddSuffix("ALLFIELDS",  new Suffix<ListValue>(() => AllFields("({0}) {1}, is {2}")));
-			AddSuffix("ALLFIELDNAMES", new Suffix<ListValue> (AllFieldNames));
+            AddSuffix("ALLFIELDNAMES", new Suffix<ListValue> (AllFieldNames));
             AddSuffix("HASFIELD",   new OneArgsSuffix<bool, string>(HasField));
             AddSuffix("ALLEVENTS",  new Suffix<ListValue>(() => AllEvents("({0}) {1}, is {2}")));
-			AddSuffix("AllEVENTNAMES", new Suffix<ListValue> (AllEventNames));
+            AddSuffix("AllEVENTNAMES", new Suffix<ListValue> (AllEventNames));
             AddSuffix("HASEVENT",   new OneArgsSuffix<bool, string>(HasEvent));
             AddSuffix("ALLACTIONS", new Suffix<ListValue>(() => AllActions("({0}) {1}, is {2}")));
-			AddSuffix("ALLACTIONNAMES", new Suffix<ListValue> (AllActionNames));
+            AddSuffix("ALLACTIONNAMES", new Suffix<ListValue> (AllActionNames));
             AddSuffix("HASACTION",  new OneArgsSuffix<bool, string>(HasAction));
             AddSuffix("GETFIELD",   new OneArgsSuffix<object, string>(GetKSPFieldValue));
             AddSuffix("SETFIELD",   new TwoArgsSuffix<string, object>(SetKSPFieldValue));

--- a/src/kOS/Suffixed/PartModuleField/PartModuleFields.cs
+++ b/src/kOS/Suffixed/PartModuleField/PartModuleFields.cs
@@ -192,6 +192,24 @@ namespace kOS.Suffixed.PartModuleField
         }
         
         /// <summary>
+		/// Return a list of all the strings of all KSPfields registered to this PartModule
+		/// which are currently showing on the part's RMB menu, without formating.
+		/// </summary>
+		/// <returns>List of all the strings field names.</returns>
+		private ListValue AllFieldNames()
+		{            
+			var returnValue = new ListValue();
+
+			IEnumerable<BaseField> visibleFields = partModule.Fields.Cast<BaseField>().Where(FieldIsVisible);
+
+			foreach (BaseField field in visibleFields)
+			{
+				returnValue.Add(field.guiName.ToLower());
+			}
+			return returnValue;
+		}
+        
+        /// <summary>
         /// Determine if the Partmodule has this KSPField on it, which is publicly
         /// usable by a kOS script at the moment:
         /// </summary>
@@ -235,6 +253,24 @@ namespace kOS.Suffixed.PartModuleField
         }
         
         /// <summary>
+		/// Return a list of all the KSPEvents the module has in it which are currently
+		/// visible on the RMB menu, without formatting.
+		/// </summary>
+		/// <returns>List of Event Names</returns>
+		private ListValue AllEventNames()
+		{            
+			var returnValue = new ListValue();
+
+			IEnumerable<BaseEvent> visibleEvents = partModule.Events.Where( EventIsVisible );
+
+			foreach (BaseEvent kspEvent in visibleEvents)
+			{
+				returnValue.Add(kspEvent.guiName.ToLower());
+			}
+			return returnValue;
+		}
+        
+        /// <summary>
         /// Determine if the Partmodule has this KSPEvent on it, which is publicly
         /// usable by a kOS script:
         /// </summary>
@@ -273,6 +309,21 @@ namespace kOS.Suffixed.PartModuleField
             }
             return returnValue;
         }
+        
+		/// <summary>
+		/// Return a list of all the KSPActions the module has in it, without formatting.
+		/// </summary>
+		/// <returns>List of Action Names</returns>
+		private ListValue AllActionNames()
+		{            
+			var returnValue = new ListValue();
+
+			foreach (BaseAction kspAction  in partModule.Actions)
+			{
+				returnValue.Add(kspAction.guiName.ToLower());
+			}
+			return returnValue;
+		}
 
         /// <summary>
         /// Determine if the Partmodule has this KSPAction on it, which is publicly
@@ -330,10 +381,13 @@ namespace kOS.Suffixed.PartModuleField
             AddSuffix("NAME",       new Suffix<string>(() => partModule.moduleName));
             AddSuffix("PART",       new Suffix<PartValue>(() => PartValueFactory.Construct(partModule.part,shared)));
             AddSuffix("ALLFIELDS",  new Suffix<ListValue>(() => AllFields("({0}) {1}, is {2}")));
+			AddSuffix("ALLFIELDNAMES", new Suffix<ListValue> (AllFieldNames));
             AddSuffix("HASFIELD",   new OneArgsSuffix<bool, string>(HasField));
             AddSuffix("ALLEVENTS",  new Suffix<ListValue>(() => AllEvents("({0}) {1}, is {2}")));
+			AddSuffix("AllEVENTNAMES", new Suffix<ListValue> (AllEventNames));
             AddSuffix("HASEVENT",   new OneArgsSuffix<bool, string>(HasEvent));
             AddSuffix("ALLACTIONS", new Suffix<ListValue>(() => AllActions("({0}) {1}, is {2}")));
+			AddSuffix("ALLACTIONNAMES", new Suffix<ListValue> (AllActionNames));
             AddSuffix("HASACTION",  new OneArgsSuffix<bool, string>(HasAction));
             AddSuffix("GETFIELD",   new OneArgsSuffix<object, string>(GetKSPFieldValue));
             AddSuffix("SETFIELD",   new TwoArgsSuffix<string, object>(SetKSPFieldValue));


### PR DESCRIPTION
Quick fix for #947 - this was my quick fix for running script that didn't know what the event names were going to be for a part module. I have compiled and run it and it works. However you will probably want to change the suffix names or maybe implement this a different way (if at all).

If you use this I will add docs once the suffix names are decided upon.
Suffixes added:
`:ALLFIELDNAMES` - provides a list of just the field names
`:ALLEVENTNAMES` - returns a list of event names (not formated with `, is KSPEvent` )
`:ALLACTIONNAMES` - returns a list of action names
