### PR TITLE
Fixes #834. protect for null patchedConicSolver

### DIFF
--- a/doc/source/commands/prediction.rst
+++ b/doc/source/commands/prediction.rst
@@ -13,6 +13,23 @@ Predictions of Flight Path
 
     Using the Add and Remove commands as described on that page, you may alter the flight plan of the CPU\_vessel, however kOS does not automatically execute the nodes. You still have to write the code to decide how to successfully execute a planned maneuver node.
 
+.. warning::
+
+    Be aware that a limitation of KSP makes it so that some vessels'
+    manuever node systems cannot be accessed.  KSP appears to limit the
+    maneuver node system to only functioning on the current PLAYER
+    vessel, under the presumption that its the only vessel that needs
+    them, as ever other vessel cannot be manuevered. kOS can manuever a
+    vessel that is not the player vessel, but it cannot overcome this
+    limitation of the base game that unloads the maneuver node system
+    for other vessels. 
+
+    Be aware that the effect this has is that when you try to predict
+    another vessel's position, it will sometimes give you answers that
+    presume that other vessel will be purely drifting, and not following
+    its maneuver nodes.
+
+
 The following prediction functions do take into account the future maneuver nodes planned, and operate under the assumption that they will be executed as planned.
 
 These return predicted information about the future position and velocity of an object.

--- a/doc/source/structures/vessels/node.rst
+++ b/doc/source/structures/vessels/node.rst
@@ -13,6 +13,24 @@ Maneuver Node
 
 A planned velocity change along an orbit. These are the nodes that you can set in the KSP user interface. Setting one through kOS will make it appear on the in-game map view, and creating one manually on the in-game map view will cause it to be visible to kOS.
 
+.. warning::
+
+    Be aware that a limitation of KSP makes it so that some vessels'
+    manuever node systems cannot be accessed.  KSP appears to limit the
+    maneuver node system to only functioning on the current PLAYER
+    vessel, under the presumption that its the only vessel that needs
+    them, as ever other vessel cannot be manuevered. kOS can manuever a
+    vessel that is not the player vessel, but it cannot overcome this
+    limitation of the base game that unloads the maneuver node system
+    for other vessels. 
+
+    Be aware that the effect this has is that when you try to use some of
+    these commands on some vessels, they won't work because those vessels
+    do not have their manuever node system in play.  This is mostly only
+    going to happen when you try to run a script on a vessel that is not
+    the current player active vessel.
+
+
 Creation
 --------
 
@@ -46,11 +64,19 @@ Creation
 
     You should immediately see it appear on the map view when you do this. The :global:`ADD` command can add nodes anywhere within the flight plan. To insert a node earlier in the flight than an existing node, simply give it a smaller :attr:`ETA <ManeuverNode:ETA>` time and then :global:`ADD` it.
 
+.. warning::
+
+    As per the warning above at the top of the section, ADD won't work on vessels that are not the active vessel.
+
 .. global:: REMOVE
 
     To remove a maneuver node from the flight path of the cur:rent :ref:`CPU vessel <cpu vessel>` (i.e. ``SHIP``), just :global:`REMOVE` it like so::
 
         REMOVE myNode.
+`
+.. warning::
+
+    As per the warning above at the top of the section, REMOVE won't work on vessels that are not the active vessel.
 
 .. global:: NEXTNODE
 
@@ -61,6 +87,10 @@ Creation
         REMOVE :global:`NEXTNODE`.
 
     Currently, if you attempt to query :global:`NEXTNODE` and there is no node on your flight plan, it produces a run-time error. (This needs to be fixed in a future release so it is possible to query whether or not you have a next node).
+
+.. warning::
+
+    As per the warning above at the top of the section, NEXTNODE won't work on vessels that are not the active vessel.
 
     If you need to query whether or not you have a :global:`NEXTNODE`, the following has been suggested as a workaround in the meantime: Set a node really far into the future, beyond any reasonable amount of time. Add it to your flight plan. Then check :global:`NEXTNODE` to see if it returns THAT node, or an earlier one. If it returns an earlier one, then that earlier one was there all along and is the real :global:`NEXTNODE`. If it returns the fake far-future node you made instead, then there were no nodes before that point. In either case, remove the far-future node after you perform the test.
 

--- a/src/kOS.Safe/Exceptions/KOSSituationallyInvalidException.cs
+++ b/src/kOS.Safe/Exceptions/KOSSituationallyInvalidException.cs
@@ -1,0 +1,30 @@
+﻿namespace kOS.Safe.Exceptions
+{
+    /// <summary>
+    /// To be thrown whenever a command cannot be used or is going to
+    /// give bogus data due to the KSP GAME situation it's being called from
+    /// being invalid.<br/>
+    /// This is to be distinguished from various compile
+    /// exceptions about commands being disallowed in certain parts of the
+    /// code.<br/>
+    /// This is for runtime situations where it's not kOS that prevents
+    /// things from working, but KSP itself, according to the game
+    /// rules.<br/>
+    /// Examples of the sorts of things where it might be
+    /// appropriate to throw this include:<br/>
+    ///  - Trying to use time warp (not phys warp) when in atmosphere.<br/>
+    ///  - Trying to deploy a parachute that is broken.<br/>
+    ///  - Trying to see the manuever nodes of a vessel that is not the active vessel. (KSP only
+    /// attaches a patchedConicSolver to the current ActiveVessel.  It's null for all others.)
+    /// </summary>
+    public class KOSSituationallyInvalidException : KOSException
+    {
+
+        public override string VerboseMessage { get { return Message; } }
+
+        public KOSSituationallyInvalidException(string msg) :
+            base(msg)
+        {
+        }
+    }
+}

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Exceptions\KOSPersistenceException.cs" />
     <Compile Include="Exceptions\KOSPreserveInvalidHereException.cs" />
     <Compile Include="Exceptions\KOSReturnInvalidHereException.cs" />
+    <Compile Include="Exceptions\KOSSituationallyInvalidException.cs" />
     <Compile Include="Exceptions\KOSSuffixUseException.cs" />
     <Compile Include="Exceptions\KOSUnavailableAddonException.cs" />
     <Compile Include="Exceptions\KOSUndefinedIdentifierException.cs" />

--- a/src/kOS/Binding/FlightStats.cs
+++ b/src/kOS/Binding/FlightStats.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using kOS.Safe.Binding;
+using kOS.Safe.Exceptions;
 using kOS.Suffixed;
 using kOS.Utilities;
 using TimeSpan = kOS.Suffixed.TimeSpan;
@@ -30,10 +31,12 @@ namespace kOS.Binding
             shared.BindingMgr.AddGetter("NEXTNODE", () =>
             {
                 var vessel = shared.Vessel;
+                if (vessel.patchedConicSolver == null)
+                    throw new KOSSituationallyInvalidException(
+                        "A KSP limitation makes it impossible to access the manuever nodes of this vessel at this time. " +
+                        "(perhaps it's not the active vessel?)");
                 if (vessel.patchedConicSolver.maneuverNodes.Count == 0)
-                {
-                    throw new Exception("No maneuver nodes present!");
-                }
+                    throw new KOSSituationallyInvalidException("No maneuver nodes present!");
 
                 return Node.FromExisting(vessel, vessel.patchedConicSolver.maneuverNodes[0], shared);
             });

--- a/src/kOS/Suffixed/Node.cs
+++ b/src/kOS/Suffixed/Node.cs
@@ -125,6 +125,12 @@ namespace kOS.Suffixed
                 throw new KOSLowTechException("use maneuver nodes", careerReason);
 
             vesselRef = v;
+
+            if (v.patchedConicSolver == null)
+                throw new KOSSituationallyInvalidException(
+                    "A KSP limitation makes it impossible to access the manuever nodes of this vessel at this time. " +
+                    "(perhaps it's not the active vessel?)");
+
             nodeRef = v.patchedConicSolver.AddManeuverNode(time);
 
             UpdateNodeDeltaV();
@@ -151,6 +157,11 @@ namespace kOS.Suffixed
                 throw new KOSLowTechException("use maneuver nodes", careerReason);
 
             nodeLookup.Remove(nodeRef);
+
+            if (vesselRef.patchedConicSolver == null)
+                throw new KOSSituationallyInvalidException(
+                    "A KSP limitation makes it impossible to access the manuever nodes of this vessel at this time. " +
+                    "(perhaps it's not the active vessel?)");
 
             vesselRef.patchedConicSolver.RemoveManeuverNode(nodeRef);
 

--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -143,7 +143,7 @@ namespace kOS.Suffixed
             // After much trial and error this seems to be the only way to do this:
 
             // Find the lastmost maneuver node that occurs prior to timestamp:
-            List<ManeuverNode> nodes = Vessel.patchedConicSolver.maneuverNodes;
+            List<ManeuverNode> nodes = (Vessel.patchedConicSolver == null) ? new List<ManeuverNode>() : Vessel.patchedConicSolver.maneuverNodes;
             Orbit orbitPatch = Vessel.orbit;
             for (int nodeIndex = 0 ; nodeIndex < nodes.Count && nodes[nodeIndex].UT <= desiredUT ; ++nodeIndex)
             {

--- a/src/kOS/Utilities/VesselUtils.cs
+++ b/src/kOS/Utilities/VesselUtils.cs
@@ -227,6 +227,11 @@ namespace kOS.Utilities
 
         public static object TryGetEncounter(Vessel vessel, SharedObjects sharedObj)
         {
+            // If not the active vessel, it will be on rails, and therefore won't
+            // be able to have "encounters" via its patchedConicSolver.
+            if (vessel.patchedConicSolver == null)
+                return "None";
+
             foreach (var patch in vessel.patchedConicSolver.flightPlan)
             {
                 if (patch.patchStartTransition == Orbit.PatchTransitionType.ENCOUNTER)


### PR DESCRIPTION
vessel.patchedConicSolver appears to be null whenever the vessel in question is not the ActiveVessel.  There's a number of places in our code where we just presume it will exist for every vessel and blindly try to use it without checking if it's null.  This patch fixes that.
