### PR TITLE
Fixes #858 making empty programs have a NOP.

### DIFF
--- a/kerboscript_tests/compile/compiletest1.ks
+++ b/kerboscript_tests/compile/compiletest1.ks
@@ -1,0 +1,14 @@
+// compiletest1
+print "Tests the case where an empty script file is run".
+print "from another script.  It should do nothing, rather".
+print "than get stuck forever or error out.".
+print " ".
+print "You must 'set count to 0' before you run the test".
+set count to count + 1.
+if count > 1 { print 1/0. }. // force dump after a few runs
+print "program started".
+log "" to empty_file.
+delete empty_file.
+log "" to empty_file.
+run empty_file.
+print "If it got this far without complaint, then it passed the test.".

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -123,7 +123,7 @@ namespace kOS.Safe.Compilation.KS
             PushReversedParameters();
             VisitNode(tree.Nodes[0]);
             
-            if (addBranchDestination)
+            if (addBranchDestination || currentCodeSection.Count == 0)
             {
                 AddOpcode(new OpcodeNOP());
             }
@@ -663,7 +663,7 @@ namespace kOS.Safe.Compilation.KS
                         currentCodeSection = subprogramObject.FunctionCode;
                         // verify if the program has been loaded
                         Opcode functionStart = AddOpcode(new OpcodePush(subprogramObject.PointerIdentifier));
-                        AddOpcode(new OpcodePush(0));
+                        AddOpcode(new OpcodePush(-1));
                         AddOpcode(new OpcodeCompareEqual());
                         OpcodeBranchIfFalse branchOpcode = new OpcodeBranchIfFalse();
                         AddOpcode(branchOpcode);
@@ -700,7 +700,7 @@ namespace kOS.Safe.Compilation.KS
                         currentCodeSection = subprogramObject.InitializationCode;
                         // initialize the pointer to zero
                         AddOpcode(new OpcodePush(subprogramObject.PointerIdentifier));
-                        AddOpcode(new OpcodePush(0));
+                        AddOpcode(new OpcodePush(-1));
                         AddOpcode(new OpcodeStore());
                     }
                 }

--- a/src/kOS.Safe/Compilation/ProgramBuilder.cs
+++ b/src/kOS.Safe/Compilation/ProgramBuilder.cs
@@ -95,6 +95,7 @@ namespace kOS.Safe.Compilation
 
         protected virtual void AddEndOfProgram(CodePart linkedObject, bool isMainProgram)
         {
+            int nextIndex = linkedObject.MainCode.Count;
             if (isMainProgram)
             {
                 linkedObject.MainCode.Add(new OpcodeEOP());

--- a/src/kOS.Safe/Compilation/ProgramBuilder.cs
+++ b/src/kOS.Safe/Compilation/ProgramBuilder.cs
@@ -95,7 +95,6 @@ namespace kOS.Safe.Compilation
 
         protected virtual void AddEndOfProgram(CodePart linkedObject, bool isMainProgram)
         {
-            int nextIndex = linkedObject.MainCode.Count;
             if (isMainProgram)
             {
                 linkedObject.MainCode.Add(new OpcodeEOP());

--- a/src/kOS.Safe/Exceptions/KOSBadJumpException.cs
+++ b/src/kOS.Safe/Exceptions/KOSBadJumpException.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace kOS.Safe.Exceptions
+{
+    public class KOSBadJumpException : Exception
+    {
+        public KOSBadJumpException(int destination, string message):
+            base( String.Format("Can't jump to instruction {0}.  No opcode there: {1}: {2} ",
+                                destination,
+                                message,
+                                "If you see this message, something is broken about how this program got compiled."))
+        {
+        }
+
+        public virtual string VerboseMessage
+        {
+            get { return base.Message; }
+        }
+
+        public virtual string HelpURL
+        {
+            get { return string.Empty; }
+        }
+    }
+}

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Encapsulation\VersionInfo.cs" />
     <Compile Include="Exceptions\KOSArgumentMismatchException.cs" />
     <Compile Include="Exceptions\KOSAtmosphereDeprecationException.cs" />
+    <Compile Include="Exceptions\KOSBadJumpException.cs" />
     <Compile Include="Exceptions\KOSBreakInvalidHereException.cs" />
     <Compile Include="Exceptions\KOSInvalidArgumentException.cs" />
     <Compile Include="Exceptions\KOSIdentifierClashException.cs" />

--- a/src/kOS/Execution/CPU.cs
+++ b/src/kOS/Execution/CPU.cs
@@ -1013,7 +1013,6 @@ namespace kOS.Execution
         private bool ExecuteInstruction(IProgramContext context)
         {
             bool DEBUG_EACH_OPCODE = false;
-            DEBUG_EACH_OPCODE = true; // eraseme
             
             Opcode opcode = context.Program[context.InstructionPointer];
 

--- a/src/kOS/Execution/CPU.cs
+++ b/src/kOS/Execution/CPU.cs
@@ -1013,8 +1013,10 @@ namespace kOS.Execution
         private bool ExecuteInstruction(IProgramContext context)
         {
             bool DEBUG_EACH_OPCODE = false;
+            DEBUG_EACH_OPCODE = true; // eraseme
             
             Opcode opcode = context.Program[context.InstructionPointer];
+
             if (DEBUG_EACH_OPCODE)
             {
                 executeLog.Append(String.Format("Executing Opcode {0:0000}/{1:0000} {2} {3}\n",
@@ -1025,7 +1027,13 @@ namespace kOS.Execution
                 if (!(opcode is OpcodeEOF || opcode is OpcodeEOP))
                 {
                     opcode.Execute(this);
+                    int prevPointer = context.InstructionPointer;
                     context.InstructionPointer += opcode.DeltaInstructionPointer;
+                    if (context.InstructionPointer < 0 || context.InstructionPointer >= context.Program.Count())
+                    {
+                        throw new KOSBadJumpException(
+                            context.InstructionPointer, String.Format("after executing {0:0000} {1} {2}", prevPointer, opcode.Label, opcode.ToString()));
+                    }
                     return true;
                 }
                 if (opcode is OpcodeEOP)

--- a/src/kOS/Execution/ProgramContext.cs
+++ b/src/kOS/Execution/ProgramContext.cs
@@ -111,13 +111,21 @@ namespace kOS.Execution
         {
             var codeFragment = new List<string>();
 
-            const string FORMAT_STR = "{0,-20} {1,4}:{2,-3} {3:0000} {4} {5}";
-            codeFragment.Add(string.Format(FORMAT_STR, "File", "Line", "Col", "IP  ", "opcode", "operand"));
-            codeFragment.Add(string.Format(FORMAT_STR, "----", "----", "---", "----", "---------------------", ""));
+            const string FORMAT_STR = "{0,-20} {1,4}:{2,-3} {3:0000} {4} {5} {6}";
+            codeFragment.Add(string.Format(FORMAT_STR, "File", "Line", "Col", "IP  ", "label", "opcode", "operand"));
+            codeFragment.Add(string.Format(FORMAT_STR, "----", "----", "---", "----", "-------------------------------", "", ""));
 
             for (int index = start; index <= stop; index++) {
                 if (index >= 0 && index < Program.Count) {
-                    codeFragment.Add(string.Format(FORMAT_STR, Program[index].SourceName, Program[index].SourceLine, Program[index].SourceColumn, index, Program[index], (index == InstructionPointer ? "<<--INSTRUCTION POINTER--" : "")));
+                    codeFragment.Add(string.Format(
+                        FORMAT_STR,
+                        Program[index].SourceName,
+                        Program[index].SourceLine,
+                        Program[index].SourceColumn,
+                        index,
+                        Program[index].Label,
+                        Program[index],
+                        (index == InstructionPointer ? "<<--INSTRUCTION POINTER--" : "")));
                 }
             }
 


### PR DESCRIPTION
Now all empty program files will get at least 1 instruction
in them - a NOP, which (importantly) is labeled.  Empty programs
did have instructions before, but they didn't come from the
compiler.  The compiler made a zero-length program, and the
opcodes that existed were added afterward by
ProgramBuilder and they just consisted of a push 0, return.
The reason they didn't work is that since they were built outside
the compiler, they had no Label field filled in.  The jump for
a CALL is taken by reading the label of the entrypoint of
the program, which is its zeroth opcode.  When the zeroth
opcode had a missing .Label because it was added ad-hoc after
the compiler was done, the lookup system broke and the result was
returned as zero.

Now the compile simply performs a check.  If the list of opcodes
is length zero after the compile is done, then a dummy NOP is
added by the compiler before it finishes, so there's always at
least one opcode the compiler put there, with all its proper labelling
work that it knows how to do via AddOpcode().