### PR TITLE
Fixes #954 by making locks work in for loop.

### DIFF
--- a/kerboscript_tests/compile/compiletest2.ks
+++ b/kerboscript_tests/compile/compiletest2.ks
@@ -1,0 +1,5 @@
+print "this will test whether or not you can ".
+print "use lock inside for loop.".
+FOR p IN SHIP:PARTS {
+    LOCK THROTTLE TO 0.
+}

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -230,6 +230,7 @@ namespace kOS.Safe.Compilation.KS
                 case TokenType.instruction:
                 case TokenType.if_stmt:
                 case TokenType.until_stmt:
+                case TokenType.for_stmt:
                 case TokenType.on_stmt:
                 case TokenType.when_stmt:
                 case TokenType.declare_function_clause:


### PR DESCRIPTION
The problem was this:
There is a preprocessing step that scans ahead through all the
code looking for LOCK statements.  It needs to do some prep work
on them.  It is told which "parts of speech" are capable of
containing other statements inside them (until loops, functions,
naked brace sections, if statements, etc).  To compile faster,
if the statement isn't on the list, it doesn't recurse into them.

The for-statement was missing from that list, so the prep work
wasn't being done for locks that appear inside for loops.

This sort of check (see if this statement is the kind that can contain
other statements inside it or not (i.e. a control flow statement or
function declaration)) exists in a few places throughout the compiler.

It may be a good opportunity for a refactor later - a single unified way
to denote which kinds of statement can contain other statments.