### PR TITLE
Fixes #971 by making rename volume work right.

### DIFF
--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -2465,7 +2465,7 @@ namespace kOS.Safe.Compilation.KS
             }
             else
             {
-                AddOpcode(new OpcodePush(node.Nodes[2].Token.Type == TokenType.FROM ? "file" : "volume"));
+                AddOpcode(new OpcodePush(node.Nodes[1].Token.Type == TokenType.FILE ? "file" : "volume"));
             }
 
             VisitNode(node.Nodes[oldNameIndex]);


### PR DESCRIPTION
The problem was a quick one-liner.  It was using the wrong index
into the rename command, and comparing against the wrong token type,
in trying to detect if the command used FILE or VOLUME.