### PR TITLE
Fixes #1034 Boolean AND and OR operations now are short-circuiting.

### DIFF
--- a/src/kOS.Safe/Compilation/Calculator.cs
+++ b/src/kOS.Safe/Compilation/Calculator.cs
@@ -412,7 +412,7 @@ namespace kOS.Safe.Compilation
     {
         public override object Add(object argument1, object argument2)
         {
-            return Convert.ToBoolean(argument1) | Convert.ToBoolean(argument2);
+            throw new KOSBinaryOperandTypeException(argument2, "add", "to", argument1);
         }
 
         public override object Subtract(object argument1, object argument2)
@@ -422,7 +422,7 @@ namespace kOS.Safe.Compilation
 
         public override object Multiply(object argument1, object argument2)
         {
-            return Convert.ToBoolean(argument1) & Convert.ToBoolean(argument2);
+            throw new KOSBinaryOperandTypeException(argument2, "multiply", "by", argument1);
         }
 
         public override object Divide(object argument1, object argument2)
@@ -437,27 +437,22 @@ namespace kOS.Safe.Compilation
 
         public override object GreaterThan(object argument1, object argument2)
         {
-            // true > false
-            return Convert.ToBoolean(argument1) & !Convert.ToBoolean(argument2);
+            throw new KOSBinaryOperandTypeException(argument1, "ordinate", ">", argument2);
         }
 
         public override object LessThan(object argument1, object argument2)
         {
-            return !Convert.ToBoolean(argument1) & Convert.ToBoolean(argument2);
+            throw new KOSBinaryOperandTypeException(argument1, "ordinate", "<", argument2);
         }
 
         public override object GreaterThanEqual(object argument1, object argument2)
         {
-            bool arg1 = Convert.ToBoolean(argument1);
-            bool arg2 = Convert.ToBoolean(argument2);
-            return (arg1 & !arg2) | (arg1 == arg2);
+            throw new KOSBinaryOperandTypeException(argument1, "ordinate", ">=", argument2);
         }
 
         public override object LessThanEqual(object argument1, object argument2)
         {
-            bool arg1 = Convert.ToBoolean(argument1);
-            bool arg2 = Convert.ToBoolean(argument2);
-            return (!arg1 & arg2) | (arg1 == arg2);
+            throw new KOSBinaryOperandTypeException(argument1, "ordinate", "<=", argument2);
         }
 
         public override object NotEqual(object argument1, object argument2)
@@ -472,16 +467,12 @@ namespace kOS.Safe.Compilation
 
         public override object Min(object argument1, object argument2)
         {
-            bool arg1 = Convert.ToBoolean(argument1);
-            bool arg2 = Convert.ToBoolean(argument2);
-            return arg1 && arg2;
+            throw new KOSBinaryOperandTypeException(argument1, "get minimum of", "and", argument2);
         }
 
         public override object Max(object argument1, object argument2)
         {
-            bool arg1 = Convert.ToBoolean(argument1);
-            bool arg2 = Convert.ToBoolean(argument2);
-            return arg1 || arg2;
+            throw new KOSBinaryOperandTypeException(argument1, "get maximum of", "and", argument2);
         }
     }
 

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -79,6 +79,7 @@ namespace kOS.Safe.Compilation
         POPSCOPE       = 0x5b,
         STOREEXIST     = 0x5c,
         PUSHDELEGATE   = 0x5d,
+        BRANCHTRUE     = 0x5e,
 
         // Augmented bogus placeholder versions of the normal
         // opcodes: These only exist in the program temporarily
@@ -759,6 +760,18 @@ namespace kOS.Safe.Compilation
         {
             bool condition = Convert.ToBoolean(cpu.PopValue());
             DeltaInstructionPointer = !condition ? Distance : 1;
+        }
+    }
+    
+    public class OpcodeBranchIfTrue : BranchOpcode
+    {
+        protected override string Name { get { return "br.true"; } }
+        public override ByteCode Code { get { return ByteCode.BRANCHTRUE; } }
+
+        public override void Execute(ICpu cpu)
+        {
+            bool condition = Convert.ToBoolean(cpu.PopValue());
+            DeltaInstructionPointer = condition ? Distance : 1;
         }
     }
 


### PR DESCRIPTION
Breaking:  Not much.  Just if you used side-effects before, or were
near the upper limit of IPUS or KSM code size.

Note, this means the OpcodeOr and OpcodeAnd are in fact not being
used at all, but I didn't remove them.  I'm reluctant to cripple
the virtual machine's capacity for things just because kerboscript
doesn't use them.