### PR TITLE
Enable boot files on archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ kOS Mod Changelog
 
 ### BREAKING CHANGES
 * Deprecated INCOMMRANGE - now throws an exception with instructions to use the new addons:rt methods.
-* Updated maxtthrust and availablethrust calculations for KSP v1.0.x.  Due to the way KSP handles thrust, neither available thrust nor maxthrust values are constant at all altitudes around bodies with atmospheres.  
+* Updated maxtthrust and availablethrust calculations for KSP v1.0.x.  Due to the way KSP handles thrust, neither available thrust nor maxthrust values are constant at all altitudes around bodies with atmospheres.
+* Boot files are now stored on local hard drives with their original names.  You may get or set the boot file name using CORE:BOOTFILENAME suffix.
 
 ### New Hotness
 * New struct object CORE to interact with the currently running processor.

--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -13,129 +13,30 @@ of documentation again from scratch.
     :local:
     :depth: 3
 
-Changes in 0.17.0
+Changes in 0.17.3
 -----------------
 
-Variables can now be local
+Deprecated INCOMMRANGE
 ::::::::::::::::::::::::::
 
-Previously, the kOS runtime had a serious limitation in which
-it could only support one flat namespace of global-only variables.
-Considerable archetecture re-work has been done to now support
-:ref:`block-scoping <scope>` in the underlying runtime, which can
-be controlled through the use of :ref:`local declarations <declare syntax>`
-in your kerboscript files.
+Reading from the INCOMMRANGE suffix will now throw a deprecation exception with instructions to use the new Addons methods.
 
-Kerboscript has User Functions
+Updated boot file name handling
+::::::::::::::::::::::::::
+
+Boot files are now copied to the local hard disk using their original file name.  This allows for uniform file name access either on the archive or local drive and fixes boot files not working when kOS is configured to start on the Archive.  You can also get or set the boot file using the CORE:BOOTFILENAME suffix.
+
+Updated thrust calculations for 1.0.x
 ::::::::::::::::::::::::::::::
 
-The primary reason for the local scope variables rework was in
-support of the new :ref:`user functions feature <user_functions>`
-which has been a long-wished-for feature for kOS to support.
+We fixed the existing suffixes of MAXTHRUST and AVAILABLETHRUST for engines and vessels to account for the new changes in thrust based on ISP at different altitudes.  The AVAILABLETHRUST suffix is now implemented for engines (it was previously only available on vessels).  There are also new suffixes MAXTHRUSTAT (engines and vessels), AVAILABLETHRUSTAT (engines and vessels), and ISPAT (engines only) to read the applicable value at a given atmospheric pressure.
 
-Community Examples Library
-::::::::::::::::::::::::::
-
-There is now a :ref:`new fledgling repository of examples and library
-scripts<library>` that we hope to be something the user community
-contributes to.  Some of the examples shown in the kOS 0.17.0 release
-video are located there.  The addition of the ability to make user
-functions now makes the creation of such a library a viable option.
-
-Physics Ticks not Update Ticks
+New CORE struct
 ::::::::::::::::::::::::::::::
 
-The updates have been :ref:`moved to the physics update <physics tick>`
-portion of Unity, instead of the animation frame rate updates.
-This may affect your preferred CONFIG:IPU setting.  The new move
-creates a much more uniform performance across all users, without
-penalizing the users of faster computers anymore.  (Previously,
-if your computer was faster, you'd be charged more electricity as
-the updates came more often).
+The CORE struct can be used to access properties of the current processor, including it's associated part and vessel, as well as the currently selected volume.  Moving forward this will be the struct where we enable features that interact with the processor itself, like local configuration or current operational status.
 
-Ability to use SAS modes from KSP 0.90
-::::::::::::::::::::::::::::::::::::::
-
-Added a new :ref:`third way to control the ship <sasmode>`,
-by leaving SAS on, and just telling KSP which mode
-(prograde, retrograde, normal, etc) to put the SAS
-into.
-
-Blizzy ToolBar Support
-::::::::::::::::::::::
-
-If you have the Blizzy Toolbar mod installed, you should be able
-to put the kOS control panel window under its control.
-
-Ability to define colors using HSV
-::::::::::::::::::::::::::::::::::
-
-When a color is called for, such as with VECDRAW or HIGHLIGHT, you
-can now use the :ref:`HSV color system (hue, saturation, value)<hsv>`
-instead of RGB, if you prefer.
-
-Ability to highlight a part in color
-::::::::::::::::::::::::::::::::::::
-
-Any time your script needs to communicate something to the user about
-which part or parts it's dealing with, it can use KSP's :ref:`part
-highlighting feature <highlight>` to show a part.
-
-Better user interface for selecting boot scripts
-::::::::::::::::::::::::::::::::::::::::::::::::
-
-The selection of :ref:`boot scripts for your vessel <boot>` has been
-improved.
-
-Disks can be made bigger with tweakable slider
-::::::::::::::::::::::::::::::::::::::::::::::
-
-All parts that have disk space now have a slider you can use in the VAB
-or SPH editors to tweak the disk space to choose whether you want it to
-have 1x, 2x, or 4x as much as its default size.  Increasing the size
-increases its price and its weight cost.
-
-You Can Transfer Resources
+Docking port, element, and vessel references
 ::::::::::::::::::::::::::
 
-You can now use kOS scripts to :ref:`transfer resources between
-parts <resource transfer>` for things like fuel, in the same way
-that a manual user can do by using the right-click menus.
-
-Kerbal Alarm Clock support
-::::::::::::::::::::::::::
-
-If you have the Kerbal Alarm Clock Mod isntalled, you can now
-:ref:`query and manipulate its alarms <KAC>` from within your
-kOS scripts.
-
-Query the docked elements of a vessel
-:::::::::::::::::::::::::::::::::::::
-
-You can get the :ref:`docked components of a joined-together
-vessel <element>` as separate collections of parts now.
-
-Support for Action Groups Extended
-::::::::::::::::::::::::::::::::::
-
-While there was some support for the Action Groups Extended
-mod before, it has :ref:`been greatly improved <AGX>`.
-
-LIST constructor can now initialize lists
-:::::::::::::::::::::::::::::::::::::::::
-
-You can now do this::
-
-    set mylist to list(2,6,1,6,21).
-
-to initialize a :ref:`list of values <list>` from the start, so
-you no longer have to have a long list of list:ADD commands to
-populate it.
-
-ISDEAD suffix for Vessel
-::::::::::::::::::::::::
-
-Vessels now have an :ISDEAD suffix you can use to detect if the
-vessel has gone away since the last time you got the handle to it.
-(for example, you LIST TARGETS IN FOO, then the ship foo[3] blows
-up, then foo[3]:ISDEAD should become true to clue you in to this fact.)
+You can now get a list of docking ports on any element or vessel using the DOCKINGPORTS suffix.  Vessels also expose a list of their elements (the ELEMENTS suffix) and an element will refernce it's parent vessel (the VESSEL suffix).

--- a/doc/source/commands/files.rst
+++ b/doc/source/commands/files.rst
@@ -282,15 +282,18 @@ For users requiring even more automation, the feature of custom boot scripts was
  
 .. image:: http://i.imgur.com/05kp7Sy.jpg
 
-As soon as you vessel leaves VAB/SPH and is being initialised on the launchpad (e.g. its status is PRELAUNCH) the assigned script will be copied to CPU's local hard disk and named "boot.ks". This script will be run as soon as CPU boots, e.g. as soon as you bring your CPU in physics range or power on your CPU if it was turned off.
+As soon as you vessel leaves VAB/SPH and is being initialised on the launchpad (e.g. its status is PRELAUNCH) the assigned script will be copied to CPU's local hard disk with the same name.  If kOS is configured to start on the archive, the file will not be copied locally automatically. This script will be run as soon as CPU boots, e.g. as soon as you bring your CPU in physics range or power on your CPU if it was turned off.  You may get or set the name of the boot file using the :ref:`core:bootfilename<core>` suffix.
+
+.. warning::
+
+    .. versionchanged:: 0.18
+
+        **boot file name changed**
+
+        Previously boot files were copied to the local hard disk as "boot.ks".  This behaviour was changed so that boot files could be handled consistently if kOS is configured to start on the Archive.  Some scripts may have terminated with a generic "delete boot." line to clear the boot script.  Going forward you should use the new core:bootfilename suffix when dealing the boot file.
 
 Important things to consider:
 	* kOS CPU hard disk space is limited, avoid using complex boot scripts or increase disk space using MM config.
-	* If your kOS set to start from Archive, this feature may not work as intended. Possible workaround: disable starting from Archive and create simple default "boot.ks" file like this::
-		
-		//default boot script, just switches to Archive
-		switch to 0.
-		
 	* Boot script runs immediately on initialisation, it should avoid interaction with parts/modules until physics fully load. It is best to wait for couple seconds or until certain trigger.
 	
 	

--- a/doc/source/structures/core.rst
+++ b/doc/source/structures/core.rst
@@ -26,6 +26,10 @@ Core represents your ability to identify and interact directly with the running 
           - `Element`
         * - :attr:`VERSION`
           - `Version`
+        * - :attr:`BOOTFILENAME`
+          - `String`
+        * - :attr:`CURRENTVOLUME`
+          - `Volume`
 
 
 .. attribute:: CORE:PART
@@ -45,14 +49,28 @@ Core represents your ability to identify and interact directly with the running 
 
 .. attribute:: CORE:ELEMENT
 
-    :type: Element
+    :type: `Element`
     :access: Get only
 
-    The element object containing the current procesor.
+    The element object containing the current processor.
 
 .. attribute:: CORE:VERSION
 
-    :type: VersionInfo
+    :type: `VersionInfo`
     :access: Get only
 
     The kOS version currently running.
+
+.. attribute:: CORE:BOOTFILENAME
+
+    :type: `String`
+    :access: Get or Set
+
+    The filename for the boot file on the current processor.  This may be set to an empty string `""` or to `"None"` to disable the use of a boot file.
+
+.. attribute:: CORE:CURRENTVOLUME
+
+    :type: `Volume`
+    :access: Get only
+
+    The currently selected volume for the current processor.  This may be useful to prevent deleting files on the Archive, or for interacting with multiple local hard disks.

--- a/src/kOS.Safe/Module/IProcessor.cs
+++ b/src/kOS.Safe/Module/IProcessor.cs
@@ -3,6 +3,8 @@ namespace kOS.Safe.Module
     public interface IProcessor
     {
         void SetMode(ProcessorModes newProcessorMode);
+        string GetBootFileName();
+        void SetBootFileName(string name);
     }
     public enum ProcessorModes { READY, STARVED, OFF };
 }

--- a/src/kOS/Core.cs
+++ b/src/kOS/Core.cs
@@ -33,6 +33,8 @@ namespace kOS
             AddSuffix("VESSEL", new Suffix<VesselTarget>(() => new VesselTarget(shared.KSPPart.vessel, shared)));
             AddSuffix("ELEMENT", new Suffix<ElementValue>(GetEelement));
             AddSuffix("VOLUME", new Suffix<Volume>(() => { throw new NotImplementedException(); }));
+            AddSuffix("BOOTFILENAME", new SetSuffix<string>(GetBootFileName, SetBootFileName, "The name of the processor's boot file."));
+            AddSuffix("CURRENTVOLUME", new Suffix<Volume>(GetCurrentVolume));
         }
 
         private ElementValue GetEelement()
@@ -41,5 +43,10 @@ namespace kOS
             var part = new PartValue(shared.KSPPart, shared);
             return elList.Cast<ElementValue>().FirstOrDefault(el => el.Parts.Contains(part));
         }
+
+        private Volume GetCurrentVolume() { return shared.VolumeMgr.CurrentVolume; }
+
+        private string GetBootFileName() { return shared.Processor.GetBootFileName(); }
+        private void SetBootFileName(string name) { shared.Processor.SetBootFileName(name); }
     }
 }

--- a/src/kOS/Core.cs
+++ b/src/kOS/Core.cs
@@ -34,7 +34,7 @@ namespace kOS
             AddSuffix("ELEMENT", new Suffix<ElementValue>(GetEelement));
             AddSuffix("VOLUME", new Suffix<Volume>(() => { throw new NotImplementedException(); }));
             AddSuffix("BOOTFILENAME", new SetSuffix<string>(GetBootFileName, SetBootFileName, "The name of the processor's boot file."));
-            AddSuffix("CURRENTVOLUME", new Suffix<Volume>(GetCurrentVolume));
+            AddSuffix("CURRENTVOLUME", new Suffix<Volume>(GetCurrentVolume, "The currently selected volume"));
         }
 
         private ElementValue GetEelement()

--- a/src/kOS/Core.cs
+++ b/src/kOS/Core.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using kOS.Safe.Encapsulation;
+﻿using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Persistence;
-using kOS.Suffixed.Part;
 using kOS.Suffixed;
+using kOS.Suffixed.Part;
 using kOS.Utilities;
+using System;
 using System.Linq;
 
 namespace kOS
@@ -44,9 +44,19 @@ namespace kOS
             return elList.Cast<ElementValue>().FirstOrDefault(el => el.Parts.Contains(part));
         }
 
-        private Volume GetCurrentVolume() { return shared.VolumeMgr.CurrentVolume; }
+        private Volume GetCurrentVolume()
+        {
+            return shared.VolumeMgr.CurrentVolume;
+        }
 
-        private string GetBootFileName() { return shared.Processor.GetBootFileName(); }
-        private void SetBootFileName(string name) { shared.Processor.SetBootFileName(name); }
+        private string GetBootFileName()
+        {
+            return shared.Processor.GetBootFileName();
+        }
+
+        private void SetBootFileName(string name)
+        {
+            shared.Processor.SetBootFileName(name);
+        }
     }
 }

--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -1,26 +1,25 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using kOS.AddOns.RemoteTech;
+using kOS.Binding;
 using kOS.Execution;
 using kOS.Factories;
 using kOS.Function;
-using kOS.Safe.Persistence;
-using kOS.Safe.Utilities;
-using kOS.Utilities;
-using UnityEngine;
-using KSP.IO;
 using kOS.InterProcessor;
-using kOS.Binding;
 using kOS.Persistence;
 using kOS.Safe;
 using kOS.Safe.Compilation;
 using kOS.Safe.Compilation.KS;
 using kOS.Safe.Module;
+using kOS.Safe.Persistence;
 using kOS.Safe.Screen;
+using kOS.Safe.Utilities;
 using kOS.Suffixed;
-
+using kOS.Utilities;
+using KSP.IO;
 using KSPAPIExtensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
 using FileInfo = kOS.Safe.Encapsulation.FileInfo;
 
 namespace kOS.Module
@@ -30,6 +29,7 @@ namespace kOS.Module
         public ProcessorModes ProcessorMode = ProcessorModes.READY;
 
         public Harddisk HardDisk { get; private set; }
+
         private int vesselPartCount;
         private SharedObjects shared;
         private static readonly List<kOSProcessor> allMyInstances = new List<kOSProcessor>();
@@ -38,9 +38,9 @@ namespace kOS.Module
         //640K ought to be enough for anybody -sic
         private const int PROCESSOR_HARD_CAP = 655360;
 
-        [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "Boot File"), UI_ChooseOption(scene=UI_Scene.Editor)]
+        [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "Boot File"), UI_ChooseOption(scene = UI_Scene.Editor)]
         public string bootFile = "boot.ks";
-        
+
         [KSPField(isPersistant = true, guiName = "kOS Disk Space", guiActive = true)]
         public int diskSpace = 1024;
 
@@ -62,7 +62,8 @@ namespace kOS.Module
         [KSPField(isPersistant = false, guiName = "CPU/Disk Upgrade Mass", guiActive = false, guiActiveEditor = true)]
         public float additionalMass = 0F;
 
-        [KSPField(isPersistant = true, guiActive = false)] public int MaxPartId = 100;
+        [KSPField(isPersistant = true, guiActive = false)]
+        public int MaxPartId = 100;
 
         [KSPEvent(guiActive = true, guiName = "Open Terminal", category = "skip_delay;")]
         public void Activate()
@@ -71,7 +72,7 @@ namespace kOS.Module
             OpenWindow();
         }
 
-        [KSPField(isPersistant = true, guiName = "Required Power", guiActive = true)] 
+        [KSPField(isPersistant = true, guiName = "Required Power", guiActive = true)]
         public float RequiredPower;
 
         [KSPEvent(guiActive = true, guiName = "Toggle Power")]
@@ -81,7 +82,7 @@ namespace kOS.Module
             ProcessorModes newProcessorMode = (ProcessorMode != ProcessorModes.OFF) ? ProcessorModes.OFF : ProcessorModes.STARVED;
             SetMode(newProcessorMode);
         }
-        
+
         [KSPAction("Open Terminal", actionGroup = KSPActionGroup.None)]
         public void Activate(KSPActionParam param)
         {
@@ -109,7 +110,7 @@ namespace kOS.Module
             SafeHouse.Logger.Log("Toggle Power from ActionGroup");
             TogglePower();
         }
-        
+
         public void OpenWindow()
         {
             shared.Window.Open();
@@ -124,12 +125,12 @@ namespace kOS.Module
         {
             shared.Window.Toggle();
         }
-        
+
         public bool WindowIsOpen()
         {
             return shared.Window.IsOpen;
         }
-        
+
         public bool TelnetIsAttached()
         {
             return shared.Window.NumTelnets() > 0;
@@ -139,7 +140,7 @@ namespace kOS.Module
         {
             return shared.Screen;
         }
-        
+
         // TODO - later refactor making this kOS.Safer so it can work on ITermWindow, which also means moving all of UserIO's classes too.
         public Screen.TermWindow GetWindow()
         {
@@ -158,7 +159,7 @@ namespace kOS.Module
 
             if (additionalCost > 0)
             {
-                moduleInfo += "\nCost of probe CPU upgrade: " + System.Math.Round(additionalCost,0);
+                moduleInfo += "\nCost of probe CPU upgrade: " + System.Math.Round(additionalCost, 0);
             }
 
             return moduleInfo;
@@ -175,7 +176,7 @@ namespace kOS.Module
             const float DISK_SPACE_MASS_MULTIPLIER = 0.0000048829F; //implies approx 20kg for 4096bytes of diskSpace
             const float DISK_SPACE_COST_MULTIPLIER = 0.0244140625F; //implies approx 100funds for 4096bytes of diskSpace
 
-            additionalCost = baseModuleCost + (float)System.Math.Round((diskSpace - baseDiskSpace) * DISK_SPACE_COST_MULTIPLIER,0);
+            additionalCost = baseModuleCost + (float)System.Math.Round((diskSpace - baseDiskSpace) * DISK_SPACE_COST_MULTIPLIER, 0);
             additionalMass = (diskSpace - baseDiskSpace) * DISK_SPACE_MASS_MULTIPLIER;
 
             part.mass = basePartMass + additionalMass;
@@ -193,15 +194,15 @@ namespace kOS.Module
             //if in Editor, populate boot script selector, diskSpace selector and etc.
             if (state == StartState.Editor)
             {
-                if (baseDiskSpace == 0) 
+                if (baseDiskSpace == 0)
                     baseDiskSpace = diskSpace;
 
-                if (System.Math.Abs (baseModuleCost) < 0.000001F)
+                if (System.Math.Abs(baseModuleCost) < 0.000001F)
                     baseModuleCost = additionalCost;  //remember module cost before tweaks
                 else
                     additionalCost = baseModuleCost; //reset module cost and update later in UpdateCostAndMass()
 
-                if (System.Math.Abs (basePartMass) < 0.000001F)
+                if (System.Math.Abs(basePartMass) < 0.000001F)
                     basePartMass = part.mass;  //remember part mass before tweaks
                 else
                     part.mass = basePartMass; //reset part mass to original value and update later in UpdateCostAndMass()
@@ -209,7 +210,7 @@ namespace kOS.Module
                 InitUI();
             }
 
-            UpdateCostAndMass(); 
+            UpdateCostAndMass();
 
             //Do not start from editor and at KSP first loading
             if (state == StartState.Editor || state == StartState.None)
@@ -220,6 +221,7 @@ namespace kOS.Module
             SafeHouse.Logger.Log(string.Format("OnStart: {0} {1}", state, ProcessorMode));
             InitObjects();
         }
+
         private void InitUI()
         {
             //Populate selector for boot scripts
@@ -249,10 +251,9 @@ namespace kOS.Module
             options = (UI_ChooseOption)field.uiControlEditor;
             var sizeOptions = new string[3];
             sizeOptions[0] = baseDiskSpace.ToString();
-            sizeOptions[1] = (baseDiskSpace*2).ToString();
-            sizeOptions[2] = (baseDiskSpace*4).ToString();
+            sizeOptions[1] = (baseDiskSpace * 2).ToString();
+            sizeOptions[2] = (baseDiskSpace * 4).ToString();
             options.options = sizeOptions;
-        
         }
 
         public void InitObjects()
@@ -261,7 +262,7 @@ namespace kOS.Module
 
             shared = new SharedObjects();
             CreateFactory();
-                    
+
             shared.Vessel = vessel;
             shared.Processor = this;
             shared.KSPPart = part;
@@ -311,14 +312,14 @@ namespace kOS.Module
             {
                 shared.VolumeMgr.SwitchTo(HardDisk);
             }
-            
+
             InitProcessorTracking();
         }
 
         private void InitProcessorTracking()
         {
             // Track a list of all instances of me that exist:
-            if (! allMyInstances.Contains(this))
+            if (!allMyInstances.Contains(this))
             {
                 allMyInstances.Add(this);
                 allMyInstances.Sort(delegate(kOSProcessor a, kOSProcessor b)
@@ -347,11 +348,10 @@ namespace kOS.Module
                 return;
 
             GetWindow().DetachAllTelnets();
-            
-            allMyInstances.RemoveAll(m => m==this);
+
+            allMyInstances.RemoveAll(m => m == this);
         }
-        
-        
+
         /// <summary>
         /// Return a list of all existing runtime instances of this PartModule.
         /// The list is guaranteed to be ordered by the Vessel that it's on.
@@ -398,7 +398,7 @@ namespace kOS.Module
             //SafeHouse.Logger.Log("*** External Function Registration Succeeded");
             //cpu.RegisterkOSExternalFunction(parameters);
         }
-        
+
         public static int AssignNewId()
         {
             var config = PluginConfiguration.CreateForType<kOSProcessor>();
@@ -409,7 +409,7 @@ namespace kOS.Module
 
             return id;
         }
-        
+
         public void Update()
         {
             if (HighLogic.LoadedScene == GameScenes.EDITOR)
@@ -420,7 +420,6 @@ namespace kOS.Module
                     UpdateCostAndMass();
                     GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
                 }
-                
             }
             if (!IsAlive()) return;
             UpdateVessel();
@@ -588,7 +587,7 @@ namespace kOS.Module
                 SafeHouse.Logger.LogException(ex);
             }
         }
-        
+
         // This is what KSP calls during the initial loading screen (the screen
         // with the progress bar and all of the "Turning correct end toward space"
         // funny messages.)  This is where kOS *should* be putting all the
@@ -642,7 +641,7 @@ namespace kOS.Module
                     case ProcessorModes.STARVED:
                         if (shared.Interpreter != null) shared.Interpreter.SetInputLock(true);
                         if (shared.Window != null) shared.Window.IsPowered = false;
-                        if (shared.BindingMgr != null) shared.BindingMgr.UnBindAll(); 
+                        if (shared.BindingMgr != null) shared.BindingMgr.UnBindAll();
                         break;
                 }
 
@@ -668,6 +667,7 @@ namespace kOS.Module
         {
             return this.bootFile;
         }
+
         public void SetBootFileName(string name)
         {
             this.bootFile = name;

--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -293,13 +293,13 @@ namespace kOS.Module
             {
                 HardDisk = new Harddisk(Mathf.Min(diskSpace, PROCESSOR_HARD_CAP));
                 // populate it with the boot file, but only if using a new disk and in PRELAUNCH situation:
-                if (vessel.situation == Vessel.Situations.PRELAUNCH && bootFile != "None")
+                if (vessel.situation == Vessel.Situations.PRELAUNCH && bootFile != "None" && !Config.Instance.StartOnArchive)
                 {
                     var bootProgramFile = archive.GetByName(bootFile);
                     if (bootProgramFile != null)
                     {
                         // Copy to HardDisk as "boot".
-                        var boot = new ProgramFile(bootProgramFile) { Filename = "boot.ks" };
+                        var boot = new ProgramFile(bootProgramFile) { Filename = bootFile };
                         HardDisk.Add(boot);
                     }
                 }
@@ -426,12 +426,6 @@ namespace kOS.Module
                 
             }
             if (!IsAlive()) return;
-            if (firstUpdate)
-            {
-                SafeHouse.Logger.LogWarning("First Update()");
-                firstUpdate = false;
-                shared.Cpu.Boot();
-            }
             UpdateVessel();
             UpdateObservers();
         }
@@ -440,6 +434,12 @@ namespace kOS.Module
         {
             if (!IsAlive()) return;
 
+            if (firstUpdate)
+            {
+                SafeHouse.Logger.LogWarning("First Update()");
+                firstUpdate = false;
+                shared.Cpu.Boot();
+            }
             UpdateFixedObservers();
             ProcessElectricity(part, TimeWarp.fixedDeltaTime);
         }
@@ -665,6 +665,15 @@ namespace kOS.Module
         {
             RUIToggleButton[] modeButtons = FindObjectOfType<VesselAutopilotUI>().modeButtons;
             modeButtons.ElementAt(mode).SetTrue();
+        }
+
+        public string GetBootFileName()
+        {
+            return this.bootFile;
+        }
+        public void SetBootFileName(string name)
+        {
+            this.bootFile = name;
         }
     }
 }

--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -313,9 +313,6 @@ namespace kOS.Module
             }
             
             InitProcessorTracking();
-
-            // move Cpu.Boot() to within the first Update() to prevent boot script errors from killing OnStart
-            // shared.Cpu.Boot();
         }
 
         private void InitProcessorTracking()


### PR DESCRIPTION
Fixes #1046 
Update boot logic to maintain the original boot file name when copying to the local hard drive.  This allows for uniform file name access either on the archive or local drive.  At the same time I updated some of the underlying logic to make this easier to do, and to allow kOS scripts to be aware of the current volume (at least by name for now).

Todo:
- [x] Documentation