### PR TITLE
Support RemoteTech Local Control Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,13 @@ kOS Mod Changelog
 * Added availablethrust suffix to engines which mirrors the availablethrust suffix for vessels.
 * Added maxthrustat, availablethrustat, and ispat suffixes to engines to read the values at specified atmoshperic pressures.  See the documentation for details.
 * Added maxthrustat and availablethrustat suffixes to vessels to read the values at a specified atmoshperic pressures.  See the documentation for details.
+* Exposed RemoteTech's HasLocalControl method as a suffix.
 
 ### Old and busted
 * Fixed empty return statements crashing with an argument count exception.
 * Fix setting vector:mag to a new value actually setting the magnitude to 1.
 * Fix electricity being consumed while the game was paused.
+* Fix terminal lockout when RemoteTech has no connection to the KSC, but the ship has local control.
 
 # v0.17.2
 

--- a/doc/source/addons/RemoteTech.rst
+++ b/doc/source/addons/RemoteTech.rst
@@ -15,6 +15,8 @@ Interaction with kOS
 
 When you have RemoteTech installed you can only interact with the core's terminal when you have a connection to KSC on any unmanned craft. Scripts launched when you still had a connection will continue to execute even if your unmanned craft loses connection to KSC. But you should note, that when there is no connection to KSC the archive volume is inaccessible. This will require you to plan ahead and copy necessary scripts for your mission to probe hard disk, if your kerbals and/or other scripts need to use them while not connected.
 
+If you launch a manned craft while using RemoteTech, you are still able to input commands from the terminal even if you do not have a connection to the KSC.  The archive will still be inaccessible without a connection to the KSC.  Under the current implementation, there is no delay when accessing the archive with a local terminal.  This implementation may change in the future to account for delays in reading and writing data over the connection.
+
 Starting version 0.17 of kOS you can access structure RTAddon via `ADDONS:RT`.
 
 .. structure:: RTAddon
@@ -27,6 +29,7 @@ Starting version 0.17 of kOS you can access structure RTAddon via `ADDONS:RT`.
      :meth:`KSCDELAY(vessel)`              double                    Get delay from KSC to given :struct:`Vessel`
      :meth:`HASCONNECTION(vessel)`         bool                      True if given :struct:`Vessel` has any connection
      :meth:`HASKSCCONNECTION(vessel)`      bool                      True if given :struct:`Vessel` has connection to KSC
+     :meth:`HASLOCALCONTROL(vessel)`       bool                      True if given :struct:`Vessel` has local control
     ===================================== ========================= =============
 
 
@@ -65,3 +68,10 @@ Starting version 0.17 of kOS you can access structure RTAddon via `ADDONS:RT`.
     :return: bool
 
     Returns True if `vessel` has connection to KSC.
+
+.. method:: RTAddon:HASLOCALCONTROL(vessel)
+
+    :parameter vessel: :struct:`Vessel`
+    :return: bool
+
+    Returns True if `vessel` has local control (and thus not requiring a RemoteTech connection).

--- a/src/kOS/AddOns/RemoteTech/Addon.cs
+++ b/src/kOS/AddOns/RemoteTech/Addon.cs
@@ -20,7 +20,7 @@ namespace kOS.AddOns.RemoteTech
 
             AddSuffix("HASKSCCONNECTION", new OneArgsSuffix<bool, VesselTarget>(RTHasKSCConnection, "True if ship has connection to KSC"));
 
-            AddSuffix("HASLOCALCONTROL", new OneArgsSuffix<bool, VesselTarget>(RTHasLocalControl, "True if ship has connection to KSC"));
+            AddSuffix("HASLOCALCONTROL", new OneArgsSuffix<bool, VesselTarget>(RTHasLocalControl, "True if ship has locacl control (i.e. a pilot in a command module)"));
 
         }
 

--- a/src/kOS/AddOns/RemoteTech/Addon.cs
+++ b/src/kOS/AddOns/RemoteTech/Addon.cs
@@ -20,6 +20,8 @@ namespace kOS.AddOns.RemoteTech
 
             AddSuffix("HASKSCCONNECTION", new OneArgsSuffix<bool, VesselTarget>(RTHasKSCConnection, "True if ship has connection to KSC"));
 
+            AddSuffix("HASLOCALCONTROL", new OneArgsSuffix<bool, VesselTarget>(RTHasLocalControl, "True if ship has connection to KSC"));
+
         }
 
         private static double RTGetDelay(VesselTarget tgtVessel)
@@ -53,6 +55,18 @@ namespace kOS.AddOns.RemoteTech
             if (RemoteTechHook.IsAvailable(tgtVessel.Vessel.id))
             {
                 result = RemoteTechHook.Instance.HasAnyConnection(tgtVessel.Vessel.id);
+            }
+
+            return result;
+        }
+
+        private static bool RTHasLocalControl(VesselTarget tgtVessel)
+        {
+            bool result = false;
+
+            if (RemoteTechHook.IsAvailable(tgtVessel.Vessel.id))
+            {
+                result = RemoteTechHook.Instance.HasLocalControl(tgtVessel.Vessel.id);
             }
 
             return result;

--- a/src/kOS/AddOns/RemoteTech/IRemoteTechAPIv1.cs
+++ b/src/kOS/AddOns/RemoteTech/IRemoteTechAPIv1.cs
@@ -4,6 +4,7 @@ namespace kOS.AddOns.RemoteTech
 {
     public interface IRemoteTechAPIv1
     {
+        Func<Guid, bool> HasLocalControl { get; }
         Func<Guid, bool> HasFlightComputer { get; }
         Action<Guid, Action<FlightCtrlState>> AddSanctionedPilot { get; }
         Action<Guid, Action<FlightCtrlState>> RemoveSanctionedPilot { get; }

--- a/src/kOS/AddOns/RemoteTech/RemoteTechAPI.cs
+++ b/src/kOS/AddOns/RemoteTech/RemoteTechAPI.cs
@@ -4,6 +4,7 @@ namespace kOS.AddOns.RemoteTech
 {
     internal class RemoteTechAPI : IRemoteTechAPIv1
     {
+        public Func<Guid, bool> HasLocalControl { get; internal set; }
         public Func<Guid, bool> HasFlightComputer { get; internal set; }
         public Action<Guid, Action<FlightCtrlState>> AddSanctionedPilot { get; internal set; }
         public Action<Guid, Action<FlightCtrlState>> RemoveSanctionedPilot { get; internal set; }

--- a/src/kOS/AddOns/RemoteTech/RemoteTechInterpreter.cs
+++ b/src/kOS/AddOns/RemoteTech/RemoteTechInterpreter.cs
@@ -69,7 +69,7 @@ namespace kOS.AddOns.RemoteTech
             if (!BatchMode) throw new Exception("Batch mode is not active.");
             if (batchQueue.Count == 0) throw new Exception("There are no commands to deploy.");
 
-            waitTotal = RemoteTechUtility.GetTotalWaitTime(Shared.Vessel);
+            waitTotal = RemoteTechUtility.GetInputWaitTime(Shared.Vessel);
             if (double.IsPositiveInfinity(waitTotal)) throw new Exception("No connection available.");
                 
             Print("Deploying...");
@@ -97,7 +97,7 @@ namespace kOS.AddOns.RemoteTech
         {
             if (!deploymentInProgress && commandQueue.Count > 0 && !BatchMode)
             {
-                waitTotal = RemoteTechUtility.GetTotalWaitTime(Shared.Vessel);
+                waitTotal = RemoteTechUtility.GetInputWaitTime(Shared.Vessel);
                 StartDeployment();
                 deltaTime = 0; // so the elapsed time is zero in this update
             }
@@ -110,7 +110,7 @@ namespace kOS.AddOns.RemoteTech
 
         private void UpdateDeployment(double deltaTime)
         {
-            if (!RemoteTechHook.Instance.HasAnyConnection(Shared.Vessel.id))
+            if (!RemoteTechUtility.HasConnectionOrControl(Shared.Vessel))
             {
                 if (!signalLossWarning)
                 {

--- a/src/kOS/AddOns/RemoteTech/RemoteTechUtility.cs
+++ b/src/kOS/AddOns/RemoteTech/RemoteTechUtility.cs
@@ -13,5 +13,14 @@
 
             return waitTotal;
         }
+        public static double GetInputWaitTime(Vessel vessel)
+        {
+            if (RemoteTechHook.Instance.HasLocalControl(vessel.id)) return 0d;
+            else return GetTotalWaitTime(vessel);
+        }
+        public static bool HasConnectionOrControl(Vessel vessel)
+        {
+            return RemoteTechHook.Instance.HasAnyConnection(vessel.id) || RemoteTechHook.Instance.HasLocalControl(vessel.id);
+        }
     }
 }


### PR DESCRIPTION
Fixes #1005.

Enable terminal input when the vessel has local control.  The archive is still inaccessible without a connection to the KSC.  This does assume of course that Jeb is able to type commands into the terminal correctly.

Long term I would like to add a delay in program execution whenever the archive needs to be accessed.

TODO:
- [x] Documentation