### PR TITLE
Fix "controlfrom"

### DIFF
--- a/src/kOS/Suffixed/Part/PartValue.cs
+++ b/src/kOS/Suffixed/Part/PartValue.cs
@@ -117,8 +117,8 @@ namespace kOS.Suffixed.Part
 
         private void ControlFrom()
         {
-            var dockingModule = Part.Modules.OfType<ModuleDockingNode>().First();
-            var commandModule = Part.Modules.OfType<ModuleCommand>().First();
+            var dockingModule = Part.Modules.OfType<ModuleDockingNode>().FirstOrDefault();
+            var commandModule = Part.Modules.OfType<ModuleCommand>().FirstOrDefault();
 
             if (commandModule != null)
             {
@@ -130,7 +130,7 @@ namespace kOS.Suffixed.Part
             }
             else
             {
-                Part.vessel.SetReferenceTransform(Part);
+                throw new KOSCommandInvalidHere("CONTROLFROM", "a generic part value", "a docking port or command part");
             }
         }
 


### PR DESCRIPTION
Fixes #978
PartValue.cs
* fix the call to "controlfrom" giving an error using LINQ's First()
method by replacing it with FirstOrDefault()
* also now throws an exception if "controlfrom" is called from a part
other than a command module or docking port.