### PR TITLE
Cleaning up errors detected while generating docs.

### DIFF
--- a/doc/source/about.rst
+++ b/doc/source/about.rst
@@ -4,6 +4,6 @@ About **kOS** and **KerboScript**
 =================================
 
 kOS was originally created by Nivekk.
-It is under `active development`_ by the
+It is under active development by the
 `kOS Team <https://github.com/orgs/KSP-KOS/people>`_ and is licensed under terms of GNU General Public License Version 3, 29 June 2007, Copyright © 2007 `Free Software Foundation, Inc. <http://fsf.org/>`_
 

--- a/doc/source/addons/KAC.rst
+++ b/doc/source/addons/KAC.rst
@@ -193,7 +193,7 @@ Available Functions
 .. function:: LISTALARMS(alarmType)
 
     If `alarmType` equals "All", returns :struct:`List` of *all* :struct:`KACAlarm` objects attached to current vessel or have no vessel attached.
-    Otherwise returns :struct:`List` of all :struct:`KACAlarm` objects with `KACAlarm:TYPE` equeal to `alarmType' and attached to current vessel or have no vessel attached.::
+    Otherwise returns :struct:`List` of all :struct:`KACAlarm` objects with `KACAlarm:TYPE` equeal to `alarmType` and attached to current vessel or have no vessel attached.::
 
         set al to listAlarms("All").
         for i in al

--- a/doc/source/bindings.rst
+++ b/doc/source/bindings.rst
@@ -71,8 +71,33 @@ SRFPROGRADE      Same as SHIP:SRFPROGRADE
 SRFREROGRADE     Same as SHIP:SRFREROGRADE
 OBT              Same as SHIP:OBT
 STATUS           Same as SHIP:STATUS
-VESSELNAME       Same as SHIP:NAME
+SHIPNAME         Same as SHIP:NAME
 ================ ==============================================================================
+
+Terminal
+--------
+
+Get-only. ``terminal`` returns a :struct:`terminal` structure describing
+the attributes of the current terminal screen associated with the
+CPU this script is running on.
+
+Core
+----
+
+Get-only. ``core`` returns a :struct:`core` structure referring to the CPU you
+are running on.
+
+Stage
+-----
+
+Get-only. ``stage`` returns a :struct:`stage` structure used to count resources
+in the current stage.  Not to be confused with the COMMAND stage
+which triggers the next stage.
+
+NextNode
+--------
+
+Get-only. ``nextnode`` returns the next planned manuever :struct:`node` in the SHIP's flight plan.  Bombs out if no such node exists.
 
 Resource Types
 --------------
@@ -117,6 +142,8 @@ query-able this way, provided that you spell
 the term exactly as it appears in the resources window.
 
 You can also get a list of all resources, either in SHIP: or STAGE: with the :RESOURCES suffix. 
+
+.. |Resources| image:: /_images/reference/bindings/resources.png
 
 ALT ALIAS
 ---------
@@ -229,55 +256,10 @@ Controls that must be used with LOCK
     WHEELTHROTTLE       // Separate throttle for wheels
     WHEELSTEERING       // Separate steering system for wheels
 
-System Variables
-----------------
+Time
+----
 
-Returns values about kOS and hardware
-
-::
-
-    PRINT VERSION.            // Returns operating system version number. e.g. 0.8.6
-    PRINT VERSION:MAJOR.      // Returns major version number. e.g. 0
-    PRINT VERSION:MINOR.      // Returns minor version number. e.g. 8
-    PRINT VERSION:BUILD.      // Returns build version number. e.g. 6
-    PRINT SESSIONTIME.        // Returns amount of time, in seconds, from vessel load.
-
-NOTE the following important difference:
-
-SESSIONTIME is the time since the last time this vessel was loaded from
-on-rails into full physics.
-
-TIME is the time since the entire saved game campaign started, in the
-kerbal universe's time. i.e. TIME = 0 means a brand new campaign was
-just started.
-
-WARPING
-~~~~~~~
-
-Time warp can be controlled with WARP, and WARPMODE.  See
-:ref:`WARP <warp>`
-
-Config
-------
-
-CONFIG is a special variable name that refers to the configuration
-settings for
-the kOS mod, and can be used to set or get various options.
-
-`CONFIG has its own page <structures/misc/config.html>`__ for further
-details.
-
-Game State
-----------
-
-Variables that have something to do with the state of the universe.
-
-========= ====================================== ==============
-Variable  Type                                   Meaning
-========= ====================================== ==============
-TIME      `Time <structures/misc/time.html>`__   Simulated amount of time that passed since the beginning of the game's universe epoch. (A brand new campaign that just started begins at TIME zero.)
-MAPVIEW    boolean                               Both settable and gettable. If you query MAPVIEW, it's true if on the map screen, and false if on the flight view screen.  If you SET MAPVIEW, you can cause the game to switch between mapview and flight view or visa versa.
-========= ====================================== ==============
+`Time <structures/misc/time.html>`__ is the simulated amount of time that passed since the beginning of the game's universe epoch. (A brand new campaign that just started begins at TIME zero.)
 
 TIME is a useful system variable for calculating the passage of time
 between taking
@@ -301,4 +283,74 @@ It's important to be aware of the `frozen update
 nature <general/CPU_hardware.html#FROZEN>`__ of the kOS
 computer when reading TIME.
 
-.. |Resources| image:: /_images/reference/bindings/resources.png
+System Variables
+----------------
+
+This section is about variables that describe the things that are slightly
+outside the simulated universe of the game and are more about
+the game's user interface or the kOS mod itself.  They represent things
+that slightly "break the fourth wall" and let your script access
+something entirely outside the in-character experience.
+
+::
+
+    PRINT VERSION.            // Returns operating system version number. e.g. 0.8.6
+    PRINT VERSION:MAJOR.      // Returns major version number. e.g. 0
+    PRINT VERSION:MINOR.      // Returns minor version number. e.g. 8
+    PRINT VERSION:BUILD.      // Returns build version number. e.g. 6
+    PRINT SESSIONTIME.        // Returns amount of time, in seconds, from vessel load.
+
+NOTE the following important difference:
+
+SESSIONTIME is the time since the last time this vessel was loaded from
+on-rails into full physics.
+
+TIME is the time since the entire saved game campaign started, in the
+kerbal universe's time. i.e. TIME = 0 means a brand new campaign was
+just started.
+
+Config
+~~~~~~
+
+CONFIG is a special variable name that refers to the configuration
+settings for the kOS mod, and can be used to set or get various
+options.
+
+`CONFIG has its own page <structures/misc/config.html>`__ for further
+details.
+
+WARP and WARPMODE
+~~~~~~~~~~~~~~~~~
+
+Time warp can be controlled with the variables
+WARP and WARPMODE.  See :ref:`WARP <warp>`
+
+MAPVIEW
+~~~~~~~
+
+A boolean that is both gettable and settable.
+
+If you query MAPVIEW, it's true if on the map screen, and false if on the flight view screen.  If you SET MAPVIEW, you can cause the game to switch between mapview and flight view or visa versa.
+
+LOADDISTANCE
+~~~~~~~~~~~~
+
+LOADDISTANCE sets the distance from the active vessel at
+which vessels get removed from the full physics engine and put
+on-rails, or visa versa.  Note that as of KSP 1.0 the stock game
+supports multiple different load distance settings for different
+situations such that the value changes depending on where you are.
+But kOS does not support this at the moment so in kOS if you set
+the LOADDISTANCE, you are setting it to the same value
+universally for all situations.
+
+Addons
+------
+
+Get-only.  ``addons`` is a special variable used to access various extensions
+to kOS that are designed to support the features introduced by some other mods.  More info can be found on the :ref:`addons <addons>` page.
+
+Colors
+------
+
+There are several bound variables associated with :ref:`hardcoded colors <colors>` such as WHITE, BLACK, RED, etc.  See the linked page for the full list.

--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -16,6 +16,32 @@ of documentation again from scratch.
 Changes in 0.17.3
 -----------------
 
+New Looping control flow, the FROM loop
+:::::::::::::::::::::::::::::::::::::::
+
+There is now a new kind of loop, :ref:`the FROM loop <from>`,
+which is a bit like the typical 3-part for-loop seen in a
+lot of other languages with a separate init, check, and increment
+section.
+
+Short-Circuit Booleans
+::::::::::::::::::::::
+
+Previously, kerboscript's AND and OR operators were not 
+short-circuiting.  :ref:`Now they are <short_circuit>`.
+
+New Infernal Robotics interface
+:::::::::::::::::::::::::::::::
+
+There are a few new helper addon utilities for the Infernal
+Robotics mod, on the :ref:`IR addon page <IR>`.
+
+New RemoteTech interface
+::::::::::::::::::::::::
+
+There are a few new helper addon utilities for the RemoteTech
+mod, on the :ref:`RemoteTech addon page <remotetech>`.
+
 Deprecated INCOMMRANGE
 ::::::::::::::::::::::::::
 
@@ -47,7 +73,7 @@ read the applicable value at a given atmospheric pressure.
 New CORE struct
 :::::::::::::::
 
-The :struct:`CORE` bound variable gives you a structure you can use
+The :ref:`core <core>` bound variable gives you a structure you can use
 to access properties of the current in-game CPU the script is running on,
 including the vessel part it's inside of, and the vessel it's inside
 of, as well as the currently selected volume.  Moving forward this
@@ -71,6 +97,24 @@ You can now get a list of docking ports on any element or vessel using
 the DOCKINGPORTS suffix.  Vessels also expose a list of their elements
 (the ELEMENTS suffix) and an element will refernce it's parent vessel
 (the VESSEL suffix).
+
+New sounds and terminal features
+::::::::::::::::::::::::::::::::
+
+For purely cosmetic purpopses, there are new sound features and
+ a few terminal tweaks.
+
+- A terminal keyclick option for the in-game GUI terminal.
+- The ability to BEEP when printing ascii code 7 (BEL), although
+  the only way currently to achieve this is with the KSlib's spec_char.ksm
+  file, as kOS has no BEL char, but this will be addressed later.
+- A sound effect on exceptions, which can be turned off on the CONFIG panel.
+
+Clear vecdraws all at once
+::::::::::::::::::::::::::
+
+For convenience, you can clear all vecdraws off the screen at once
+now with the :ref:`clearvecdraws() <clearvecdraws>` function.
 
 ****
 

--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -19,24 +19,185 @@ Changes in 0.17.3
 Deprecated INCOMMRANGE
 ::::::::::::::::::::::::::
 
-Reading from the INCOMMRANGE suffix will now throw a deprecation exception with instructions to use the new Addons methods.
-
-Updated boot file name handling
-::::::::::::::::::::::::::
-
-Boot files are now copied to the local hard disk using their original file name.  This allows for uniform file name access either on the archive or local drive and fixes boot files not working when kOS is configured to start on the Archive.  You can also get or set the boot file using the CORE:BOOTFILENAME suffix.
+Reading from the INCOMMRANGE bound variable will now throw a
+deprecation exception with instructions to use the new
+:struct:`RTAddon` structure for the RT mod.
 
 Updated thrust calculations for 1.0.x
-::::::::::::::::::::::::::::::
+:::::::::::::::::::::::::::::::::::::
 
-We fixed the existing suffixes of MAXTHRUST and AVAILABLETHRUST for engines and vessels to account for the new changes in thrust based on ISP at different altitudes.  The AVAILABLETHRUST suffix is now implemented for engines (it was previously only available on vessels).  There are also new suffixes MAXTHRUSTAT (engines and vessels), AVAILABLETHRUSTAT (engines and vessels), and ISPAT (engines only) to read the applicable value at a given atmospheric pressure.
+KSP 1.0 caused the thrust calculations to become a LOT more
+complex than they used to be and kOS hadn't caught up yet.
+For a lot of scripts, trying to figure out a good throttle
+setting is no longer a matter of just taking a fraction of the
+engine's MAXTHRUST.
+
+We fixed the existing suffixes of MAXTHRUST and AVAILABLETHRUST for
+:struct:`engine` and :struct:`vessel` to account for the new changes
+in thrust based on
+ISP at different altitudes.  MAXTHRUST is now the max the engine can
+put out at the CURRENT atmospheric pressure and current velocity.
+It might not be the maximum it could put out under other conditions.
+The AVAILABLETHRUST suffix is now implemented for engines (it was
+previously only available on vessels).  There are also new
+suffixes MAXTHRUSTAT (engines and vessels), AVAILABLETHRUSTAT
+(engines and vessels), and ISPAT (engines only) to
+read the applicable value at a given atmospheric pressure.
 
 New CORE struct
-::::::::::::::::::::::::::::::
+:::::::::::::::
 
-The CORE struct can be used to access properties of the current processor, including it's associated part and vessel, as well as the currently selected volume.  Moving forward this will be the struct where we enable features that interact with the processor itself, like local configuration or current operational status.
+The :struct:`CORE` bound variable gives you a structure you can use
+to access properties of the current in-game CPU the script is running on,
+including the vessel part it's inside of, and the vessel it's inside
+of, as well as the currently selected volume.  Moving forward this
+will be the struct where we enable features that interact with
+the processor itself, like local configuration or current
+operational status.
+
+Updated boot file name handling
+:::::::::::::::::::::::::::::::
+
+Boot files are now copied to the local hard disk using their original
+file name.  This allows for uniform file name access either on the
+archive or local drive and fixes boot files not working when kOS is
+configured to start on the Archive.  You can also get or set the boot
+file using the BOOTFILENAME suffix of the :struct:`CORE` bound variable.
 
 Docking port, element, and vessel references
+::::::::::::::::::::::::::::::::::::::::::::
+
+You can now get a list of docking ports on any element or vessel using
+the DOCKINGPORTS suffix.  Vessels also expose a list of their elements
+(the ELEMENTS suffix) and an element will refernce it's parent vessel
+(the VESSEL suffix).
+
+****
+
+Changes in 0.17.0
+-----------------
+
+Variables can now be local
 ::::::::::::::::::::::::::
 
-You can now get a list of docking ports on any element or vessel using the DOCKINGPORTS suffix.  Vessels also expose a list of their elements (the ELEMENTS suffix) and an element will refernce it's parent vessel (the VESSEL suffix).
+Previously, the kOS runtime had a serious limitation in which
+it could only support one flat namespace of global-only variables.
+Considerable archetecture re-work has been done to now support
+:ref:`block-scoping <scope>` in the underlying runtime, which can
+be controlled through the use of :ref:`local declarations <declare syntax>`
+in your kerboscript files.
+
+Kerboscript has User Functions
+::::::::::::::::::::::::::::::
+
+The primary reason for the local scope variables rework was in
+support of the new :ref:`user functions feature <user_functions>`
+which has been a long-wished-for feature for kOS to support.
+
+Community Examples Library
+::::::::::::::::::::::::::
+
+There is now a :ref:`new fledgling repository of examples and library
+scripts<library>` that we hope to be something the user community
+contributes to.  Some of the examples shown in the kOS 0.17.0 release
+video are located there.  The addition of the ability to make user
+functions now makes the creation of such a library a viable option.
+
+Physics Ticks not Update Ticks
+::::::::::::::::::::::::::::::
+
+The updates have been :ref:`moved to the physics update <physics tick>`
+portion of Unity, instead of the animation frame rate updates.
+This may affect your preferred CONFIG:IPU setting.  The new move
+creates a much more uniform performance across all users, without
+penalizing the users of faster computers anymore.  (Previously,
+if your computer was faster, you'd be charged more electricity as
+the updates came more often).
+
+Ability to use SAS modes from KSP 0.90
+::::::::::::::::::::::::::::::::::::::
+
+Added a new :ref:`third way to control the ship <sasmode>`,
+by leaving SAS on, and just telling KSP which mode
+(prograde, retrograde, normal, etc) to put the SAS
+into.
+
+Blizzy ToolBar Support
+::::::::::::::::::::::
+
+If you have the Blizzy Toolbar mod installed, you should be able
+to put the kOS control panel window under its control.
+
+Ability to define colors using HSV
+::::::::::::::::::::::::::::::::::
+
+When a color is called for, such as with VECDRAW or HIGHLIGHT, you
+can now use the :ref:`HSV color system (hue, saturation, value)<hsv>`
+instead of RGB, if you prefer.
+
+Ability to highlight a part in color
+::::::::::::::::::::::::::::::::::::
+
+Any time your script needs to communicate something to the user about
+which part or parts it's dealing with, it can use KSP's :ref:`part
+highlighting feature <highlight>` to show a part.
+
+Better user interface for selecting boot scripts
+::::::::::::::::::::::::::::::::::::::::::::::::
+
+The selection of :ref:`boot scripts for your vessel <boot>` has been
+improved.
+
+Disks can be made bigger with tweakable slider
+::::::::::::::::::::::::::::::::::::::::::::::
+
+All parts that have disk space now have a slider you can use in the VAB
+or SPH editors to tweak the disk space to choose whether you want it to
+have 1x, 2x, or 4x as much as its default size.  Increasing the size
+increases its price and its weight cost.
+
+You Can Transfer Resources
+::::::::::::::::::::::::::
+
+You can now use kOS scripts to :ref:`transfer resources between
+parts <resource transfer>` for things like fuel, in the same way
+that a manual user can do by using the right-click menus.
+
+Kerbal Alarm Clock support
+::::::::::::::::::::::::::
+
+If you have the Kerbal Alarm Clock Mod isntalled, you can now
+:ref:`query and manipulate its alarms <KAC>` from within your
+kOS scripts.
+
+Query the docked elements of a vessel
+:::::::::::::::::::::::::::::::::::::
+
+You can get the :ref:`docked components of a joined-together
+vessel <element>` as separate collections of parts now.
+
+Support for Action Groups Extended
+::::::::::::::::::::::::::::::::::
+
+While there was some support for the Action Groups Extended
+mod before, it has :ref:`been greatly improved <AGX>`.
+
+LIST constructor can now initialize lists
+:::::::::::::::::::::::::::::::::::::::::
+
+You can now do this::
+
+    set mylist to list(2,6,1,6,21).
+
+to initialize a :ref:`list of values <list>` from the start, so
+you no longer have to have a long list of list:ADD commands to
+populate it.
+
+ISDEAD suffix for Vessel
+::::::::::::::::::::::::
+
+Vessels now have an :ISDEAD suffix you can use to detect if the
+vessel has gone away since the last time you got the handle to it.
+(for example, you LIST TARGETS IN FOO, then the ship foo[3] blows
+up, then foo[3]:ISDEAD should become true to clue you in to this fact.)
+

--- a/doc/source/commands/flight/systems.rst
+++ b/doc/source/commands/flight/systems.rst
@@ -31,15 +31,15 @@ Ship Systems
     :access: Get/Set
     :type: string
 
-        Getting this variable will return the currently selected mode.  Where ``value`` is one of the valid strings listed below, this will set the stock SAS mode for the cpu vessel::
+    Getting this variable will return the currently selected mode.  Where ``value`` is one of the valid strings listed below, this will set the stock SAS mode for the cpu vessel::
 
         SET SASMODE TO value.
 
-        It is the equivalent to clicking on the buttons next to the nav ball while manually piloting the craft, and will respect the current mode of the nav ball (orbital, surface, or target velocity).  Valid strings for ``value`` are ``"PROGRADE"``, ``"RETROGRADE"``, ``"NORMAL"``, ``"ANTINORMAL"``, ``"RADIALOUT"``, ``"RADIALIN"``, ``"TARGET"``, ``"ANTITARGET"``, ``MANEUVER``, ``"STABILITYASSIST"``, and ``"STABILITY"``.  A null or empty string will default to stability assist mode, however any other invalid string will throw an exception.  This feature will respect career mode limitations, and will throw an exception if the current vessel is not able to use the mode passed to the command.  An exception is also thrown if ``"TARGET"`` or ``"ANTITARGET"`` are used, but no target is selected.
+    It is the equivalent to clicking on the buttons next to the nav ball while manually piloting the craft, and will respect the current mode of the nav ball (orbital, surface, or target velocity).  Valid strings for ``value`` are ``"PROGRADE"``, ``"RETROGRADE"``, ``"NORMAL"``, ``"ANTINORMAL"``, ``"RADIALOUT"``, ``"RADIALIN"``, ``"TARGET"``, ``"ANTITARGET"``, ``MANEUVER``, ``"STABILITYASSIST"``, and ``"STABILITY"``.  A null or empty string will default to stability assist mode, however any other invalid string will throw an exception.  This feature will respect career mode limitations, and will throw an exception if the current vessel is not able to use the mode passed to the command.  An exception is also thrown if ``"TARGET"`` or ``"ANTITARGET"`` are used, but no target is selected.
 		
 .. warning:: SASMODE does not work with RemoteTech
 
-		Due to the way that RemoteTech disables flight control input, the built in SAS modes do not function properly when there is no connection to the KSC or a Command Center.  If you are writing scripts for use with RemoteTech, make sure to take this into account.
+    Due to the way that RemoteTech disables flight control input, the built in SAS modes do not function properly when there is no connection to the KSC or a Command Center.  If you are writing scripts for use with RemoteTech, make sure to take this into account.
 
 .. global:: LIGHTS
 

--- a/doc/source/commands/terminalgui.rst
+++ b/doc/source/commands/terminalgui.rst
@@ -1,4 +1,4 @@
-.. _terminal:
+.. _terminalgui:
 
 Terminal and game environment
 =============================

--- a/doc/source/language/features.rst
+++ b/doc/source/language/features.rst
@@ -79,6 +79,44 @@ Structures also often contain methods. A method is a suffix of a structure that 
 
 For more information, see the :ref:`Structures Section <language structures>`. A full list of structure types can be found on the :ref:`Structures <structures>` page. For a more detailed breakdown of the language, see the :ref:`Language Syntax Constructs <syntax>` page.
 
+
+.. _short_circuit:
+
+Short-curcuiting booleans
+-------------------------
+
+Further reading: https://en.wikipedia.org/wiki/Short-circuit_evaluation
+
+When performing any boolean operation involving the use of the AND or the OR
+operator, kerboscript will short-circuit the boolean check.  What this means
+is that if it gets to a point in the expression where it already knows the
+result is a forgone conclusion, it doesn't bother calculating the rest of
+the expression and just quits there.
+
+Example::
+
+    set x to true.
+    if x or y+2 > 10 {
+        print "yes".
+    } else {
+        print "no".
+    }.
+
+In this case, the fact that x is true means that when evaluating
+the boolean expression ``x or y+2 > 10`` it never even bothers trying
+to add y and 2 to find out if it's greater than 10.  It already knew
+as soon as it got to the ``x or whatever`` that given that x is true,
+the *whatever* doesn't matter one bit.  Once one side of an OR is true,
+the other side can either be true or false and it won't change the fact 
+that the whole expression will be true anyway.
+
+A similar short circuiting happens with AND.  Once the left side of the
+AND operator is false, then the entire AND expression is guaranteed
+to be false regardless of what's on the right side, so kerboscript 
+doesn't bother calculating the righthand side once the lefthand side is false.
+
+Read the link above for implications of why this matters in programming.
+
 Late Typing
 -----------
 

--- a/doc/source/language/flow.rst
+++ b/doc/source/language/flow.rst
@@ -204,6 +204,7 @@ What the parts mean
 ~~~~~~~~~~~~~~~~~~~
 
 - ``FROM`` { one or more statements }
+
   - Perform these statements at the beginning before starting the first
     pass through the loop.  They may contain local declarations of new
     variables.  If they do, then the variables will be local to the body
@@ -211,7 +212,9 @@ What the parts mean
     braces ``{`` and ``}`` are mandatory even when there is only one 
     statement present.  To create a a null FROM clause, give it an empty
     set of braces.
+
 - ``UNTIL`` expression
+
   - Exactly like the :ref:`UNTIL <until>` loop.  The loop will run this
     expression at the start of each pass through the loop body, and if
     it's true, it will abort and stop running the loop.  It checks before
@@ -220,14 +223,18 @@ What the parts mean
     ``{``..``}`` are not used here because this is not technically a 
     complete statement.  It is just an expression that evaluates to a
     value.
+
 - ``STEP`` { one or more statements }
+
   - Perform these statements at the bottom of each loop pass.  The purpose
     is typically to increment or decrement the variable you declared in
     your ``FROM`` clause to get it ready for the next loop pass.  In this
     case the braces ``{`` and ``}`` are mandatory even when there is
     only one statement present.  To create a null FROM clause, give
     it an empty set of braces.
+
 - ``DO`` one statement or a block of statements inside braxes ``{``..``}``:
+
   - This is where the loop body gets put.  Much like with the UNTIL and FOR
     loops, these braces are not mandatory when there is only exactly one
     statement in the body, but are a very good idea to have anyway.

--- a/doc/source/library.rst
+++ b/doc/source/library.rst
@@ -17,14 +17,17 @@ https://github.com/KSP-KOS/KSLib
 Some examples of useful things you can find there are:
 
 * A generic all-purpose **PID controller** function:
-  `library script <https://github.com/KSP-KOS/KSLib/blob/master/library/lib_pid.ks>`_,
-  `documentation <https://github.com/KSP-KOS/KSLib/blob/master/doc/lib_pid.md>`_, and
-  `example <https://github.com/KSP-KOS/KSLib/blob/master/examples/example_lib_pid.ks>`_
+
+  * library script: https://github.com/KSP-KOS/KSLib/blob/master/library/lib_pid.ks
+  * documentation: https://github.com/KSP-KOS/KSLib/blob/master/doc/lib_pid.md
+  * example https://github.com/KSP-KOS/KSLib/blob/master/examples/example_lib_pid.ks
 
 * A library for getting **navball orientation** information:
-  `library script <https://github.com/KSP-KOS/KSLib/blob/master/library/lib_navball.ks>`_,
-  `documentation <https://github.com/KSP-KOS/KSLib/blob/master/doc/lib_navball.md>`_, and
-  `example <https://github.com/KSP-KOS/KSLib/blob/master/examples/example_lib_navball.ks>`_
+
+  * library script https://github.com/KSP-KOS/KSLib/blob/master/library/lib_navball.ks
+  * documentation https://github.com/KSP-KOS/KSLib/blob/master/doc/lib_navball.md
+  * example https://github.com/KSP-KOS/KSLib/blob/master/examples/example_lib_navball.ks
 
 * An example of how to use the :ref:`sasmode <sasmode>` feature:
-  `example <https://github.com/KSP-KOS/KSLib/blob/master/examples/example_testsasmode.ks>`_
+  
+  * example https://github.com/KSP-KOS/KSLib/blob/master/examples/example_testsasmode.ks

--- a/doc/source/structures.rst
+++ b/doc/source/structures.rst
@@ -40,6 +40,7 @@ A general discussion of structures :ref:`can be found here <language structures>
     * :struct:`Highlight`
     * :struct:`Iterator`
     * :struct:`Terminal`
+    * :struct:`core`
     * :ref:`Colors <colors>`
     * :ref:`Time <time>`
     * :ref:`Drawing Vectors <vecdraw>`
@@ -52,3 +53,4 @@ A general discussion of structures :ref:`can be found here <language structures>
     Vessels & Parts  <structures/vessels>
     Waypoints        <structures/waypoint>
     Miscellaneous    <structures/misc>
+    Core             <structures/core>

--- a/doc/source/structures/core.rst
+++ b/doc/source/structures/core.rst
@@ -7,7 +7,7 @@ Core
     :local:
     :depth: 2
 
-Core represents your ability to identify and interact directly with the running kOS processor.  You can use it to access the parent vessel, or to perform operations on the processor's part.
+Core represents your ability to identify and interact directly with the running kOS processor.  You can use it to access the parent vessel, or to perform operations on the processor's part.  You obtain a CORE structure by using the bound variable ``core``.
 
 .. structure:: CORE
 

--- a/doc/source/structures/core.rst
+++ b/doc/source/structures/core.rst
@@ -1,7 +1,7 @@
 .. _core:
 
 Core
-=========
+====
 
 .. contents::
     :local:

--- a/doc/source/structures/misc/colors.rst
+++ b/doc/source/structures/misc/colors.rst
@@ -101,8 +101,8 @@ Examples::
     This global function creates a color from hue, saturation and value::
 
         SET myColor TO HSV(h,s,v).
-		
-	`More Information about HSV <http://en.wikipedia.org/wiki/HSL_and_HSV>`_,
+                
+        `More Information about HSV <http://en.wikipedia.org/wiki/HSL_and_HSV>`_,
 
     where:
 
@@ -126,7 +126,8 @@ Examples::
 
 .. structure:: HSVA
 
-	The HSVA structure contains all of the suffixes from the RGBA structure in addition to these
+    The HSVA structure contains all of the suffixes from the RGBA structure in addition to these
+
     .. list-table:: Members
         :header-rows: 1
         :widths: 2 1 4
@@ -144,7 +145,7 @@ Examples::
         * - :V or :VALUE
           - scalar
           - the value component of the color. It has a value from 0.0 to 1.0
-		  
+                  
 
 Examples::
 

--- a/doc/source/structures/misc/vecdraw.rst
+++ b/doc/source/structures/misc/vecdraw.rst
@@ -60,6 +60,8 @@ To make a :struct:`VecDraw` disappear, you can either set its :attr:`VecDraw:SHO
     become synonyms for the same thing, for backward compatibility.
     You can use them interchangably.
 
+.. _clearvecdraws:
+
 .. function:: CLEARVECDRAWS()
 
     Sets all visible vecdraws to invisible, everywhere in this kOS CPU.

--- a/doc/source/structures/vessels/element.rst
+++ b/doc/source/structures/vessels/element.rst
@@ -1,7 +1,7 @@
 .. _element:
 
 Element
-======
+=======
 
 An element is a *docked component* of a :struct:`Vessel`.  When you dock several
 vessels together to create one larger vessel, you can obtain the "chunks" of the

--- a/doc/source/structures/vessels/engine.rst
+++ b/doc/source/structures/vessels/engine.rst
@@ -43,7 +43,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
           - Current thrust
         * - :attr:`AVAILABLETHRUST`
           - scalar (kN)
-          - Available thrust at full throttle accounting for thrust limit
+          - Available thrust at full throttle accounting for thrust limiter
         * - :meth:`AVAILABLETHRUSTAT(pressure)`
           - scalar (kN)
           - Available thrust at the specified pressure (in standard Kerbin atmospheres).
@@ -61,13 +61,13 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
           - `Vacuum Specific impulse <isp>`_
         * - :attr:`VISP`
           - scalar
-          - `Synonym for VACUUMISP`_
+          - `Synonym for VACUUMISP <vacuumisp>`_
         * - :attr:`SEALEVELISP`
           - scalar
           - `Specific impulse at Kerbin sealevel <isp>`_
         * - :attr:`SLISP`
           - scalar
-          - `Synonym for SEALEVELISP`_
+          - `Synonym for SEALEVELISP <sealevelisp>`_
         * - :attr:`FLAMEOUT`
           - boolean
           - Check if no more fuel
@@ -106,19 +106,23 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
 
     If this an engine with a thrust limiter (tweakable) enabled, what percentage is it limited to?
 
+.. _engine_MAXTHRUST:
+
 .. attribute:: Engine:MAXTHRUST
 
     :access: Get only
     :type: scalar (kN)
 
-    How much thrust would this engine give if the throttle was max at current conditions.
+    How much thrust would this engine give at its current atmospheric pressure and velocity if the throttle was max at 1.0, and the thrust limiter was max at 100%.  Note this might not be the engine's actual max thrust it could have under other air pressure conditions.  Some engines have a very different value for MAXTHRUST in vacuum as opposed to at sea level pressure.  Also, some jet engines have a very different value for MAXTHRUST depending on how fast they are currently being rammed through the air.
+
+.. _engine_MAXTHRUSTAT:
 
 .. method:: Engine:MAXTHRUSTAT(pressure)
 
     :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
     :type: scalar (kN)
 
-    How much thrust would this engine give if the throttle was max at the current velocity, and at the given atmospheric pressure.  Use a pressure of 0 for vacuum, and 1 for sea level (on Kerbin).
+    How much thrust would this engine give if both the throttle and thrust limtier was max at the current velocity, and at the given atmospheric pressure.  Use a pressure of 0.0 for vacuum, and 1.0 for sea level (on Kerbin) (or more than 1 for thicker atmospheres like on Eve).
 
 .. attribute:: Engine:THRUST
 
@@ -127,19 +131,23 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
 
     How much thrust is this engine giving at this very moment.
 
+.. _engine_AVAILABLETHRUST:
+
 .. attribute:: Engine:AVAILABLETHRUST
 
     :access: Get only
     :type: scalar (kN)
 
-    How much thrust would this engine give if the throttle was max at current thrust limit and conditions.
+    Taking into account the thrust limiter tweakable setting, how much thrust would this engine give if the throttle was max at its current thrust limit setting and atmospheric pressure and velocity conditions.
+
+.. _engine_AVAILABLETHRUSTAT:
 
 .. method:: Engine:AVAILABLETHRUSTAT(pressure)
 
     :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
     :type: scalar (kN)
 
-    How much thrust would this engine give if the throttle was max at the current thrust limit and velocity, and at the given atmospheric pressure.  Use a pressure of 0 for vacuum, and 1 for sea level (on Kerbin).
+    Taking into account the thrust limiter tweakable setting, how much thrust would this engine give if the throttle was max at its current thrust limit setting and velocity, but at a different atmospheric pressure you pass into it.  The pressure is measured in ATM's, meaning 0.0 is a vacuum, 1.0 is seal level at Kerbin.
 
 .. attribute:: Engine:FUELFLOW
 
@@ -174,7 +182,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
     :access: Get only
     :type: scalar
 
-    `Synonym for :VACUUMISP`_
+    Synonym for :VACUUMISP
 
 .. attribute:: Engine:SEALEVELISP
 
@@ -188,7 +196,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
     :access: Get only
     :type: scalar
 
-    `Synonym for :SEALEVELISP`_
+    Synonym for :SEALEVELISP
 
 .. attribute:: Engine:FLAMEOUT
 

--- a/doc/source/structures/vessels/node.rst
+++ b/doc/source/structures/vessels/node.rst
@@ -73,7 +73,7 @@ Creation
     To remove a maneuver node from the flight path of the cur:rent :ref:`CPU vessel <cpu vessel>` (i.e. ``SHIP``), just :global:`REMOVE` it like so::
 
         REMOVE myNode.
-`
+
 .. warning::
 
     As per the warning above at the top of the section, REMOVE won't work on vessels that are not the active vessel.

--- a/doc/source/structures/vessels/vessel.rst
+++ b/doc/source/structures/vessels/vessel.rst
@@ -97,28 +97,28 @@ All vessels share a structure. To get a variable referring to any vessel you can
     :type: scalar
     :access: Get only
 
-    Sum of all the Max thrust of all the currently active engines In Kilonewtons.
+    Sum of all the :ref:`engines' MAXTHRUSTs <engine_MAXTHRUST>` of all the currently active engines In Kilonewtons.
     
-.. method:: Engine:MAXTHRUSTAT(pressure)
+.. method:: Vessel:MAXTHRUSTAT(pressure)
 
     :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
     :type: scalar (kN)
 
-    Sum of all the Max thrust of all the currently active engines In Kilonewtons at the given atmospheric pressure.  Use a pressure of 0 for vacuum, and 1 for sea level (on Kerbin).
+    Sum of all the :ref:`engines' MAXTHRUSTATs <engine_MAXTHRUSTAT>` of all the currently active engines In Kilonewtons at the given atmospheric pressure.  Use a pressure of 0 for vacuum, and 1 for sea level (on Kerbin).
 
-.. attribute:: vessel:AVAILABLETHRUST
+.. attribute:: Vessel:AVAILABLETHRUST
 
     :type: scalar
     :access: Get only
     
-    Sum of all the Max thrust of all the currently active engines taking into acount their throttlelimits. Result is in Kilonewtons.
+    Sum of all the :ref:`engines' AVAILABLETHRUSTs <engine_AVAILABLETHRUST>` of all the currently active engines taking into acount their throttlelimits. Result is in Kilonewtons.
 
-.. method:: Engine:AVAILABLETHRUSTAT(pressure)
+.. method:: Vessel:AVAILABLETHRUSTAT(pressure)
 
     :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
     :type: scalar (kN)
 
-    Sum of all the Max thrust of all the currently active engines taking into acount their throttlelimits at the given atmospheric pressure. Result is in Kilonewtons.  Use a pressure of 0 for vacuum, and 1 for sea level (on Kerbin).
+    Sum of all the :ref:`engines' AVAILABLETHRUSTATs <engine_AVAILABLETHRUSTAT>` of all the currently active engines taking into acount their throttlelimits at the given atmospheric pressure. Result is in Kilonewtons.  Use a pressure of 0 for vacuum, and 1 for sea level (on Kerbin).
 
 .. attribute:: Vessel:FACING
 

--- a/doc/source/tutorials/exenode.rst
+++ b/doc/source/tutorials/exenode.rst
@@ -5,7 +5,7 @@ Advanced Tutorial
 
 Let's try to automate one of the most common tasks in orbital maneuvering - execution of the maneuver node. In this tutorial I'll try to show you how to write a script for precise maneuver node execution.
 
-So to start our script we need to get the next available :ref:`maneuver node <_maneuver node>`::
+So to start our script we need to get the next available :ref:`maneuver node <maneuver node>`::
 
     set nd to nextnode().
 


### PR DESCRIPTION
Also, re-instituted the part of changes.rst that referred
to the prev version of kOS.  The intent I had for that page
was for it to have a table of contents for each version you
could click on, not to delete old versions from it.