### PR TITLE
Scriptable science

### DIFF
--- a/doc/source/structures/vessels/scienceexperiment.rst
+++ b/doc/source/structures/vessels/scienceexperiment.rst
@@ -1,0 +1,114 @@
+.. _scienceexperimentmodule:
+
+ScienceExperimentModule
+======
+
+The type of structures returned by kOS when querying a module that contains a science experiment.
+
+Some of the science-related tasks are normally not available to kOS scripts. It is for
+example possible to deploy a science experiment::
+
+    SET P TO SHIP:PARTSNAMED("GooExperiment")[1].
+    SET M TO P:GETMODULE("ModuleScienceExperiment").
+    M:DOEVENT("observe mystery goo").
+
+Hovewer, this results in a dialog being shown to the user. Only from that dialog it is possible
+to reset the experiment or transmit the experiment results back to Kerbin.
+:struct:`ScienceExperimentModule` structure introduces a few suffixes that allow the player
+to perform all science-related tasks without any manual intervention::
+
+    SET P TO SHIP:PARTSNAMED("GooExperiment")[0].
+    SET M TO P:GETMODULE("ModuleScienceExperiment").
+    M:DEPLOY.
+    WAIT UNTIL M:HASDATA.
+    M:TRANSMIT.
+
+
+.. structure:: ScienceExperimentModule
+
+    .. list-table::
+        :header-rows: 1
+        :widths: 2 1 4
+
+        * - Suffix
+          - Type
+          - Description
+
+        * - All suffixes of :struct:`PartModule`
+          -
+          - :struct:`ScienceExperimentModule` objects are a type of :struct:`PartModule`
+        * - :meth:`DEPLOY()`
+          -
+          - Deploy and run the science experiment
+        * - :meth:`RESET()`
+          -
+          - Reset this experiment if possible
+        * - :meth:`TRANSMIT()`
+          -
+          - Transmit the scientific data back to Kerbin
+        * - :meth:`DUMP()`
+          -
+          - Discard the data
+        * - :attr:`INOPERABLE`
+          - boolean
+          - Is this experiment inoperable
+        * - :attr:`RERUNNABLE`
+          - boolean
+          - Can this experiment be run multiple times
+        * - :attr:`DEPLOYED`
+          - boolean
+          - Is this experiment deployed
+        * - :attr:`HASDATA`
+          - boolean
+          - Does the experiment have scientific data
+
+.. note::
+
+    A :struct:`ScienceExperimentModule` is a type of :struct:`PartModule`, and therefore can use all the suffixes of :struct:`PartModule`.
+
+.. method:: ScienceExperimentModule:DEPLOY()
+
+    Call this method to deploy and run this science experiment. This method will fail if the experiment already contains scientific
+    data or is inoperable.
+
+.. method:: ScienceExperimentModule:RESET()
+
+    Call this method to reset this experiment. This method will fail if the experiment is inoperable.
+
+.. method:: ScienceExperimentModule:TRANSMIT()
+
+    Call this method to transmit the results of the experiment back to Kerbin. This will render the experiment
+    inoperable if it is not rerunnable. This method will fail if there is no data to send.
+
+.. method:: ScienceExperimentModule:DUMP()
+
+    Call this method to discard the data obtained as a result of running this experiment. This will render the experiment
+    inoperable if it is not rerunnable.
+
+.. attribute:: ScienceExperimentModule:INOPERABLE
+
+    :access: Get only
+    :type: boolean
+
+    True if this experiment is no longer operable.
+
+.. attribute:: ScienceExperimentModule:RERUNNABLE
+
+    :access: Get only
+    :type: boolean
+
+    True if this experiment can be run multiple times.
+
+.. attribute:: ScienceExperimentModule:DEPLOYED
+
+    :access: Get only
+    :type: boolean
+
+    True if this experiment is deployed.
+
+.. attribute:: ScienceExperimentModule:HASDATA
+
+    :access: Get only
+    :type: boolean
+
+    True if this experiment has scientific data stored.

--- a/src/kOS/Suffixed/PartModuleField/PartModuleFieldsFactory.cs
+++ b/src/kOS/Suffixed/PartModuleField/PartModuleFieldsFactory.cs
@@ -22,13 +22,16 @@ namespace kOS.Suffixed.PartModuleField
             if (moduleGimbal != null)
                 return new GimbalFields(moduleGimbal, shared);
 
+            var moduleScienceExperiment = mod as ModuleScienceExperiment;
+
+            if (moduleScienceExperiment != null) {
+                return new ScienceExperimentFields(moduleScienceExperiment, shared);
+            }
+
             if (mod.moduleName.Equals(RemoteTechAntennaModuleFields.RTAntennaModule)) {
                 return new RemoteTechAntennaModuleFields(mod, shared);
             }
 
-            // This seems pointlessly do-nothing for a special factory now,
-            // but it's here so that it can possibly become more
-            // sophisticated later if need be:
             return new PartModuleFields(mod, shared);
         }
     }

--- a/src/kOS/Suffixed/PartModuleField/ScienceExperimentFields.cs
+++ b/src/kOS/Suffixed/PartModuleField/ScienceExperimentFields.cs
@@ -1,0 +1,100 @@
+﻿using kOS.Safe.Encapsulation.Suffixes;
+using kOS.Safe.Exceptions;
+using kOS.Suffixed.Part;
+using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+using System.Collections.Generic;
+using kOS.Suffixed.PartModuleField;
+
+namespace kOS.Suffixed.PartModuleField
+{
+    public class ScienceExperimentFields : PartModuleFields
+    {
+
+        private readonly ModuleScienceExperiment module;
+        private readonly MethodInfo gatherDataMethod, resetExperimentMethod, sendDataToCommsMethod, dumpDataMethod;
+
+        public ScienceExperimentFields (ModuleScienceExperiment module, SharedObjects sharedObj) : base(module, sharedObj)
+        {
+            this.module = module;
+
+            gatherDataMethod = module.GetType().GetMethod("gatherData",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            resetExperimentMethod = module.GetType().GetMethod("resetExperiment",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            sendDataToCommsMethod = module.GetType().GetMethod("sendDataToComms",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            dumpDataMethod = module.GetType().GetMethod("dumpData",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+
+            InitializeSuffixes();
+        }
+
+        private void InitializeSuffixes()
+        {
+            AddSuffix("DEPLOY", new NoArgsSuffix(() => DeployExperiment(), "Deploy and run this experiment"));
+            AddSuffix("RESET", new NoArgsSuffix(() => ResetExperiment(), "Reset this experiment"));
+            AddSuffix("TRANSMIT", new NoArgsSuffix(() => TransmitData(), "Transmit experiment data back to Kerbin"));
+            AddSuffix("DUMP", new NoArgsSuffix(() => DumpData(), "Dump experiment data"));
+            AddSuffix("INOPERABLE", new Suffix<bool>(() => module.Inoperable, "Is this experiment inoperable"));
+            AddSuffix("DEPLOYED", new Suffix<bool>(() => module.Deployed, "Is this experiment deployed"));
+            AddSuffix("RERUNNABLE", new Suffix<bool>(() => module.rerunnable, "Is this experiment rerunnable"));
+            AddSuffix("HASDATA", new Suffix<bool>(() => module.GetData().Any(), "Does this experiment have any data stored"));
+        }
+
+        private void DeployExperiment()
+        {
+            if (module.GetData().Any()) {
+                throw new KOSException("Experiment already contains data");
+            }
+
+            if (module.Inoperable) {
+                throw new KOSException("Experiment is inoperable");
+            }
+
+            object result = gatherDataMethod.Invoke(module, new object[] { false });
+
+            IEnumerator e = result as IEnumerator;
+
+            module.StartCoroutine(e);
+        }
+
+        private void ResetExperiment()
+        {
+            if (module.Inoperable) {
+                throw new KOSException("Experiment is inoperable");
+            }
+
+            object result = resetExperimentMethod.Invoke(module, new object[] { });
+
+            IEnumerator e = result as IEnumerator;
+
+            module.StartCoroutine(e);
+        }
+
+        private void TransmitData()
+        {
+            if (!module.GetData().Any()) {
+                throw new KOSException("Experiment contains no data");
+            }
+
+            ScienceData[] dataArray = module.GetData();
+
+            foreach (ScienceData data in dataArray) {
+                sendDataToCommsMethod.Invoke(module, new object[] { data });
+            }
+        }
+
+        private void DumpData()
+        {
+            if (!module.rerunnable) {
+                module.SetInoperable();
+            }
+
+            dumpDataMethod.Invoke(module, new object[] { });
+        }
+    }
+}
+

--- a/src/kOS/kOS.csproj
+++ b/src/kOS/kOS.csproj
@@ -178,6 +178,7 @@
     <Compile Include="AddOns\InfernalRobotics\Addon.cs" />
     <Compile Include="Screen\RectExtensions.cs" />
     <Compile Include="AddOns\RemoteTech\RemoteTechAntennaModuleFields.cs" />
+    <Compile Include="Suffixed\PartModuleField\ScienceExperimentFields.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\kOS.Safe\kOS.Safe.csproj">


### PR DESCRIPTION
Fixes #1075.

Adds a couple of suffixes to ModuleScienceExperiment that allow to do science without clicking anything. I haven't had time to test it much, so any feedback would be appreciated.

Does not work with SCANsat as their scanners do not implement ModuleScienceExperiment. I imagine there are other mods out there that do this as well.
Does not implement science lab related stuff, but I don't think that's needed.