### PR TITLE
RemoteTech AntennaHasConnection API

### DIFF
--- a/doc/source/addons/RemoteTech.rst
+++ b/doc/source/addons/RemoteTech.rst
@@ -39,6 +39,7 @@ Starting version 0.17 of kOS you can access structure RTAddon via `ADDONS:RT`.
      :attr:`AVAILABLE`                     bool(readonly)            True if RT is installed and RT integration enabled.
      :meth:`DELAY(vessel)`                 double                    Get shortest possible delay to given :struct:`Vessel`
      :meth:`KSCDELAY(vessel)`              double                    Get delay from KSC to given :struct:`Vessel`
+     :meth:`ANTENNAHASCONNECTION(part)`    bool                      True if given :struct:`Part` has any connection
      :meth:`HASCONNECTION(vessel)`         bool                      True if given :struct:`Vessel` has any connection
      :meth:`HASKSCCONNECTION(vessel)`      bool                      True if given :struct:`Vessel` has connection to KSC
      :meth:`HASLOCALCONTROL(vessel)`       bool                      True if given :struct:`Vessel` has local control
@@ -66,6 +67,13 @@ Starting version 0.17 of kOS you can access structure RTAddon via `ADDONS:RT`.
     :return: (double) seconds
 
     Returns delay in seconds from KSC to `vessel`.
+
+.. method:: RTAddon:ANTENNAHASCONNECTION(part)
+
+    :parameter part: :struct:`Part`
+    :return: bool
+
+    Returns True if `part` has any connection (including to local command posts).
 
 .. method:: RTAddon:HASCONNECTION(vessel)
 

--- a/src/kOS/AddOns/RemoteTech/Addon.cs
+++ b/src/kOS/AddOns/RemoteTech/Addon.cs
@@ -1,5 +1,6 @@
 ﻿using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Suffixed;
+using kOS.Suffixed.Part;
 
 namespace kOS.AddOns.RemoteTech
 {
@@ -19,6 +20,8 @@ namespace kOS.AddOns.RemoteTech
             AddSuffix("HASCONNECTION", new OneArgsSuffix<bool, VesselTarget>(RTHasConnection, "True if ship has any connection"));
 
             AddSuffix("HASKSCCONNECTION", new OneArgsSuffix<bool, VesselTarget>(RTHasKSCConnection, "True if ship has connection to KSC"));
+
+            AddSuffix("ANTENNAHASCONNECTION", new OneArgsSuffix<bool, PartValue>(RTAntennaHasConnection, "True if antenna has any connection"));
 
             AddSuffix("HASLOCALCONTROL", new OneArgsSuffix<bool, VesselTarget>(RTHasLocalControl, "True if ship has locacl control (i.e. a pilot in a command module)"));
 
@@ -79,6 +82,18 @@ namespace kOS.AddOns.RemoteTech
             if (RemoteTechHook.IsAvailable(tgtVessel.Vessel.id))
             {
                 result = RemoteTechHook.Instance.HasConnectionToKSC(tgtVessel.Vessel.id);
+            }
+
+            return result;
+        }
+
+        private static bool RTAntennaHasConnection(PartValue part)
+        {
+            bool result = false;
+
+            if (RemoteTechHook.IsAvailable(part.Part.vessel.id))
+            {
+                result = RemoteTechHook.Instance.AntennaHasConnection(part.Part);
             }
 
             return result;

--- a/src/kOS/AddOns/RemoteTech/IRemoteTechAPIv1.cs
+++ b/src/kOS/AddOns/RemoteTech/IRemoteTechAPIv1.cs
@@ -10,6 +10,7 @@ namespace kOS.AddOns.RemoteTech
         Action<Guid, Action<FlightCtrlState>> RemoveSanctionedPilot { get; }
         Func<Guid, bool> HasAnyConnection { get; }
         Func<Guid, bool> HasConnectionToKSC { get; }
+        Func<Part, bool> AntennaHasConnection { get; }
         Func<Guid, double> GetShortestSignalDelay { get; }
         Func<Guid, double> GetSignalDelayToKSC { get; }
         Func<Guid, Guid, double> GetSignalDelayToSatellite { get; }

--- a/src/kOS/AddOns/RemoteTech/RemoteTechAPI.cs
+++ b/src/kOS/AddOns/RemoteTech/RemoteTechAPI.cs
@@ -10,6 +10,7 @@ namespace kOS.AddOns.RemoteTech
         public Action<Guid, Action<FlightCtrlState>> RemoveSanctionedPilot { get; internal set; }
         public Func<Guid, bool> HasAnyConnection { get; internal set; }
         public Func<Guid, bool> HasConnectionToKSC { get; internal set; }
+        public Func<Part, bool> AntennaHasConnection { get; internal set; }
         public Func<Guid, double> GetShortestSignalDelay { get; internal set; }
         public Func<Guid, double> GetSignalDelayToKSC { get; internal set; }
         public Func<Guid, Guid, double> GetSignalDelayToSatellite { get; internal set; }


### PR DESCRIPTION
Adds support for AntennaHasConnection that was added in RemoteTechnologiesGroup/RemoteTech#454.

There was no RT version released yet with that API, so I guess we need to wait a bit before we merge this.