### PR TITLE
Crew API

### DIFF
--- a/src/kOS/Suffixed/CrewMember.cs
+++ b/src/kOS/Suffixed/CrewMember.cs
@@ -1,0 +1,52 @@
+﻿using kOS.Safe.Encapsulation;
+using System;
+using kOS.Safe.Encapsulation.Suffixes;
+using kOS.Suffixed.Part;
+
+namespace kOS.Suffixed
+{
+    public class CrewMember : Structure
+    {
+        private ProtoCrewMember crewMember;
+        private SharedObjects shared;
+
+        public String Name {
+            get { return crewMember.name; }
+        }
+
+        public String Gender {
+            get { return crewMember.gender.ToString(); }
+        }
+
+        public int Experience {
+            get { return crewMember.experienceLevel; }
+        }
+
+        public String Trait {
+            get { return crewMember.experienceTrait.Title; }
+        }
+
+        public CrewMember(ProtoCrewMember crewMember, SharedObjects shared)
+        {
+            this.crewMember = crewMember;
+            this.shared = shared;
+            InitializeSuffixes();
+        }
+
+        private void InitializeSuffixes()
+        {
+            AddSuffix("NAME", new Suffix<String>(() => Name));
+            AddSuffix("TOURIST", new Suffix<bool>(() => crewMember.type == ProtoCrewMember.KerbalType.Tourist));
+            AddSuffix("GENDER", new Suffix<String>(() => Gender));
+            AddSuffix("TRAIT", new Suffix<String>(() => Trait));
+            AddSuffix("EXPERIENCE", new Suffix<int>(() => Experience));
+            AddSuffix("PART", new Suffix<PartValue>(() => PartValueFactory.Construct(crewMember.seat.part, shared)));
+        }
+
+        public override string ToString()
+        {
+            return Name + " " + Gender[0] + ", " + Trait + " " + new String('*', Experience);
+        }
+    }
+}
+

--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -448,6 +448,22 @@ namespace kOS.Suffixed
             AddSuffix("LATITUDE", new Suffix<float>(() => VesselUtils.GetVesselLatitude(Vessel)));
             AddSuffix("LONGITUDE", new Suffix<double>(() => VesselUtils.GetVesselLongitude(Vessel)));
             AddSuffix("ALTITUDE", new Suffix<double>(() => Vessel.altitude));
+            AddSuffix("CREW", new NoArgsSuffix<ListValue>(GetCrew));
+            AddSuffix("CREWCAPACITY", new NoArgsSuffix<int> (GetCrewCapacity));
+        }
+
+        public int GetCrewCapacity() {
+            return Vessel.GetCrewCapacity();
+        }
+
+        public ListValue GetCrew() {
+            ListValue crew = new ListValue();
+
+            foreach (ProtoCrewMember crewMember in Vessel.GetVesselCrew()) {
+                crew.Add(new CrewMember(crewMember, Shared));
+            }
+
+            return crew;
         }
 
         public double GetAvailableThrustAt(double atmPressure)

--- a/src/kOS/kOS.csproj
+++ b/src/kOS/kOS.csproj
@@ -178,6 +178,7 @@
     <Compile Include="AddOns\InfernalRobotics\Addon.cs" />
     <Compile Include="Screen\RectExtensions.cs" />
     <Compile Include="AddOns\RemoteTech\RemoteTechAntennaModuleFields.cs" />
+    <Compile Include="Suffixed\CrewMember.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\kOS.Safe\kOS.Safe.csproj">


### PR DESCRIPTION
This is a simple API that allows to retrieve information about vessel's crew. I use it to print the list of crew members or do some crew-related checks before major events. Let me know if this is something you'd like to merge, I can add documentation.

Example:

    function print_crew {
      print "(" + ship:crew:length + "/" + ship:crewcapacity + "):".
      for crew_member in ship:crew {
        print crew_member:name + " is in " + crew_member:part:name.
      }
    }
