### PR TITLE
Fixes #1141 allows wheelsteering by integer.

### DIFF
--- a/kerboscript_tests/cooked_steering/testwheelsteertypes1.ks
+++ b/kerboscript_tests/cooked_steering/testwheelsteertypes1.ks
@@ -1,0 +1,79 @@
+print "This needs to be run on a rover, on ground at KSC".
+print " ".
+print "-------------------------------------------------".
+
+brakes off.
+print "going north by integer compass heading 0".
+lock wheelsteering to 0.
+lock wheelthrottle to 1.0.
+wait 3.
+lock wheelthrottle to 0.5.
+wait 7.
+brakes on.
+print "stopping".
+wait 5.
+
+print "going westish by float compass heading 270.5".
+brakes off.
+lock wheelsteering to 270.5.
+lock wheelthrottle to 1.0.
+wait 3.
+lock wheelthrottle to 0.5.
+wait 7.
+lock wheelthrottle to 0.
+brakes on.
+print "stopping".
+wait 5.
+
+print "going south by integer compass heading 180".
+brakes off.
+lock wheelsteering to 180.
+lock wheelthrottle to 1.0.
+wait 3.
+lock wheelthrottle to 0.5.
+wait 7.
+lock wheelthrottle to 0.
+brakes on.
+print "stopping".
+wait 5.
+
+print "going east by integer compass heading 90".
+brakes off.
+lock wheelsteering to 90.
+lock wheelthrottle to 1.0.
+wait 3.
+lock wheelthrottle to 0.5.
+wait 7.
+lock wheelthrottle to 0.
+brakes on.
+print "stopping".
+wait 5.
+
+print "going south again, now by float compass heading 180.1".
+brakes off.
+lock wheelsteering to 180.1.
+lock wheelthrottle to 1.0.
+wait 3.
+lock wheelthrottle to 0.5.
+wait 7.
+lock wheelthrottle to 0.
+brakes on.
+print "stopping".
+wait 5.
+
+print "Going toward a LATLNG position that is southeast of here".
+set newlat to latitude + 1.
+set newlng to longitude + 1.
+brakes off.
+lock wheelsteering to LATLNG(newlat,newlng).
+lock wheelthrottle to 1.0.
+wait 3.
+lock wheelthrottle to 0.5.
+wait 7.
+lock wheelthrottle to 0.
+brakes on.
+print "stopping".
+wait 5.
+
+
+print "okay that's enough.  done testing".

--- a/src/kOS.Safe/Exceptions/KOSWrongControlValueType.cs
+++ b/src/kOS.Safe/Exceptions/KOSWrongControlValueType.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace kOS.Safe.Exceptions
+{
+    /// <summary>
+    /// To be thrown whenever the script attempted to perform a
+    /// cooked control "LOCK", or a raw control "SET", to a value<br/>
+    /// that's of an unusable type for that particular control bound variable.
+    /// <br/>
+    /// Examples:<br/>
+    /// - attempting to LOCK THROTTLE TO a string, or a LIST.<br/>
+    /// - attempting to SET SHIP:CONTROL:PITCH to a string, or a RGBA color.<br/>
+    /// </summary>
+    public class KOSWrongControlValueType : KOSException
+    {
+        public KOSWrongControlValueType(string controlType, string didUse, string shouldUse) :
+            base( string.Format("Cannot use a {0} as the value for the {1}.  Should use {2} instead.",
+                                didUse, controlType, shouldUse))
+        {
+        }
+
+        public virtual string VerboseMessage
+        {
+            get { return base.Message + "\n" +
+                         "When setting a special control variable\n" +
+                         "the type of the value has to match what\n" +
+                         "the kOS computer expects that value to be."; }
+        }
+
+        public virtual string HelpURL
+        {
+            get { return string.Empty; }
+        }
+    }
+}
+

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Exceptions\KOSUndefinedIdentifierException.cs" />
     <Compile Include="Exceptions\KOSWaitInValidHereException.cs" />
     <Compile Include="Exceptions\KOSUnaryOperandTypeException.cs" />
+    <Compile Include="Exceptions\KOSWrongControlValueType.cs" />
     <Compile Include="Execution\IKOSScopeObserver.cs" />
     <Compile Include="Execution\ICpu.cs" />
     <Compile Include="Execution\IProgramContext.cs" />
@@ -186,7 +187,7 @@
   <PropertyGroup>
     <PostBuildEvent Condition=" '$(OS)' == 'Unix' ">
       cp "$(TargetPath)" "$(SolutionDir)/../Resources/GameData/kOS/Plugins"
-      (test -h "$(SolutionDir)/../KSPdirlink" &#x26;&#x26; cp "$(TargetPath)" "$(SolutionDir)/../KSPdirlink/GameData/kOS/Plugins") || true
+      (test -h "$(SolutionDir)/../KSPdirlink" &amp;&amp; cp "$(TargetPath)" "$(SolutionDir)/../KSPdirlink/GameData/kOS/Plugins") || true
     </PostBuildEvent>
     <PostBuildEvent Condition=" '$(OS)' != 'Unix' ">
       xcopy "$(TargetPath)" "$(SolutionDir)\..\Resources\GameData\kOS\Plugins" /y

--- a/src/kOS/Binding/FlightControlManager.cs
+++ b/src/kOS/Binding/FlightControlManager.cs
@@ -1,6 +1,7 @@
 ﻿using kOS.AddOns.RemoteTech;
 using kOS.Safe.Binding;
 using kOS.Safe.Utilities;
+using kOS.Safe.Exceptions;
 using kOS.Suffixed;
 using kOS.Utilities;
 using System;
@@ -369,17 +370,39 @@ namespace kOS.Binding
             private void UpdateThrottle(FlightCtrlState c)
             {
                 if (!Enabled) return;
-                double doubleValue = Convert.ToDouble(value);
-                if (!double.IsNaN(doubleValue))
-                    c.mainThrottle = (float)Safe.Utilities.Math.Clamp(doubleValue, 0, 1);
+                try
+                {
+                    double doubleValue = Convert.ToDouble(value);
+                    if (!double.IsNaN(doubleValue))
+                        c.mainThrottle = (float)Safe.Utilities.Math.Clamp(doubleValue, 0, 1);
+                }
+                catch (InvalidCastException e) // Note, very few types actually fail Convert.ToDouble(), so it's hard to get this to occur.
+                {
+                    // perform the "unlock" so this message won't spew every FixedUpdate:
+                    Enabled = false;
+                    ClearValue();
+                    throw new KOSWrongControlValueType(
+                        "THROTTLE", value.GetType().Name, "Number in the range [0..1]");
+                }
             }
 
             private void UpdateWheelThrottle(FlightCtrlState c)
             {
                 if (!Enabled) return;
-                double doubleValue = Convert.ToDouble(value);
-                if (!double.IsNaN(doubleValue))
-                    c.wheelThrottle = (float)Safe.Utilities.Math.Clamp(doubleValue, -1, 1);
+                try
+                {
+                    double doubleValue = Convert.ToDouble(value);
+                    if (!double.IsNaN(doubleValue))
+                        c.wheelThrottle = (float)Safe.Utilities.Math.Clamp(doubleValue, -1, 1);
+                }
+                catch (InvalidCastException e) // Note, very few types actually fail Convert.ToDouble(), so it's hard to get this to occur.
+                {
+                    // perform the "unlock" so this message won't spew every FixedUpdate:
+                    Enabled = false;
+                    ClearValue();
+                    throw new KOSWrongControlValueType(
+                        "WHEELTHROTTLE", value.GetType().Name, "Number in the range [-1..1]");
+                }
             }
 
             private void SteerByWire(FlightCtrlState c)
@@ -401,6 +424,14 @@ namespace kOS.Binding
                 {
                     SteeringHelper.SteerShipToward(((Node)value).GetBurnVector().ToDirection(), c, control.Vessel);
                 }
+                else
+                {
+                    // perform the "unlock" so this message won't spew every FixedUpdate:
+                    Enabled = false;
+                    ClearValue();
+                    throw new KOSWrongControlValueType(
+                        "STEERING", value.GetType().Name, "Direction, Vector, Manuever Node, or special string \"KILL\"");
+                }
             }
 
             private void WheelSteer(FlightCtrlState c)
@@ -416,11 +447,28 @@ namespace kOS.Binding
                 {
                     bearing = (float) ((GeoCoordinates)value).GetBearing();
                 }
-                else if (value is double)
+                else
                 {
-                    double doubleValue = Convert.ToDouble(value);
-                    if (Utils.IsValidNumber(doubleValue))
-                        bearing = (float)(Math.Round(doubleValue) - Mathf.Round(FlightGlobals.ship_heading));
+                    try
+                    {
+                        double doubleValue = Convert.ToDouble(value);
+                        if (Utils.IsValidNumber(doubleValue))
+                        {
+                            bearing = (float)(Math.Round(doubleValue) - Mathf.Round(FlightGlobals.ship_heading));
+                            if (bearing < -180)
+                                bearing += 360; // i.e. 359 degrees to the left is really 1 degree to the right.
+                            else if (bearing > 180)
+                                bearing -= 360; // i.e. 359 degrees to the right is really 1 degree to the left
+                        }
+                    }
+                    catch (InvalidCastException e) // Note, very few types actually fail Convert.ToDouble(), so it's hard to get this to occur.
+                    {
+                        // perform the "unlock" so this message won't spew every FixedUpdate:
+                        Enabled = false;
+                        ClearValue();
+                        throw new KOSWrongControlValueType(
+                            "WHEELSTEER", value.GetType().Name, "Vessel, LATLNG, or Number (compass heading)");
+                    }
                 }
 
                 if (!(control.Vessel.horizontalSrfSpeed > 0.1f)) return;


### PR DESCRIPTION
Also fixed the "wraparound at north" bug when
doing LOCK WHEELSTEERING TO 0. (i.e. it would be
1 degree off to the left, and behave as if it was
359 degrees off to the right, and perform a full
loop all the way around, because it doesn't
realize a bearing of -359 really means +1.)

Also added a few more robust conditions for some of the
other steeering checks, although they are unlikely
to trigger.