### PR TITLE
Fixes 1117 lock throttle in from

### DIFF
--- a/kerboscript_tests/loop/fromthrottletest.ks
+++ b/kerboscript_tests/loop/fromthrottletest.ks
@@ -1,0 +1,14 @@
+print "This test from issue #1117 excercises the".
+print "bug with trying to LOCK THROTTLE inside".
+print "a FROM loop".
+print "It should move the throttle at T -3 seconds.".
+print "--------------------------------------------".
+print " ".
+FROM { LOCAL countdown IS 10. } UNTIL countdown = 0 STEP { SET countdown TO countdown - 1. } DO {
+    PRINT "T -" + countdown.
+    IF countdown = 3 {
+        print "Throttle should now become 1.".
+        LOCK THROTTLE TO 1.0.
+    }
+    WAIT 1.
+}

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -187,6 +187,7 @@ namespace kOS.Safe.Compilation.KS
             ParseNode rootNode = tree.Nodes[0];
             LowercaseConversions(rootNode);
             RearrangeParseNodes(rootNode);
+            Console.WriteLine("eraseme: dumping parse tree:\n" + tree.PrintTree());
             TraverseScopeBranch(rootNode);
             IterateUserFunctions(rootNode, IdentifyUserFunctions);
             PreProcessStatements(rootNode);
@@ -245,6 +246,7 @@ namespace kOS.Safe.Compilation.KS
                 case TokenType.instruction_block:
                 case TokenType.instruction:
                 case TokenType.if_stmt:
+                case TokenType.fromloop_stmt:
                 case TokenType.until_stmt:
                 case TokenType.for_stmt:
                 case TokenType.on_stmt:
@@ -361,9 +363,12 @@ namespace kOS.Safe.Compilation.KS
             initBlock.Nodes.Add(untilNode); // parent already assigned by initBlock.CreateNode() above.
             
             // The init block is now actually the entire loop, having been exploded and unrolled into its
-            // new form, make that be our only node node:
+            // new form, make that be our only node:
             node.Nodes.Clear();
             node.Nodes.Add(initBlock);  // initBlock's parent already points at node to begin with.
+            
+            // The FROM loop node is still in the parent's list, but it contains this new rearranged sub-tree
+            // instead of its original.
         }
         
         private void PreProcessStatements(ParseNode node)
@@ -380,6 +385,7 @@ namespace kOS.Safe.Compilation.KS
                 case TokenType.instruction_block:
                 case TokenType.instruction:
                 case TokenType.if_stmt:
+                case TokenType.fromloop_stmt:
                 case TokenType.until_stmt:
                 case TokenType.for_stmt:
                 case TokenType.declare_function_clause:

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -187,7 +187,6 @@ namespace kOS.Safe.Compilation.KS
             ParseNode rootNode = tree.Nodes[0];
             LowercaseConversions(rootNode);
             RearrangeParseNodes(rootNode);
-            Console.WriteLine("eraseme: dumping parse tree:\n" + tree.PrintTree());
             TraverseScopeBranch(rootNode);
             IterateUserFunctions(rootNode, IdentifyUserFunctions);
             PreProcessStatements(rootNode);

--- a/src/kOS.Safe/Compilation/ProgramBuilder.cs
+++ b/src/kOS.Safe/Compilation/ProgramBuilder.cs
@@ -108,6 +108,9 @@ namespace kOS.Safe.Compilation
 
         private void ReplaceLabels(List<Opcode> program)
         {
+            Console.WriteLine("eraseme: At the start of ReplaceLabels, the program looks like this:_______");
+            Console.WriteLine(kOS.Safe.Utilities.Debug.GetCodeFragment(program));//eraseme
+            
             var labels = new Dictionary<string, int>();
 
             // get the index of every label

--- a/src/kOS.Safe/Compilation/ProgramBuilder.cs
+++ b/src/kOS.Safe/Compilation/ProgramBuilder.cs
@@ -107,10 +107,7 @@ namespace kOS.Safe.Compilation
         }
 
         private void ReplaceLabels(List<Opcode> program)
-        {
-            Console.WriteLine("eraseme: At the start of ReplaceLabels, the program looks like this:_______");
-            Console.WriteLine(kOS.Safe.Utilities.Debug.GetCodeFragment(program));//eraseme
-            
+        {            
             var labels = new Dictionary<string, int>();
 
             // get the index of every label


### PR DESCRIPTION
The problem was that I thought I was replacing the fromloop_stmt entirely from the parse tree when I finished doing `RearrangeParseNodes()`, but I wasn't - I was rearranging its **innards** but leaving the outer node there as a wrapper around the new nodes.

That means all the places where the preprocessing methods descend down into things to parse whats inside them need to have fromloop_stmt added to their cases lists, as seen here in this PR.


