### PR TITLE
String manipulation suffixes (addresses #270)

### DIFF
--- a/doc/source/structures/misc/string.rst
+++ b/doc/source/structures/misc/string.rst
@@ -1,0 +1,311 @@
+.. _string:
+
+String
+====
+
+A :struct:`String` is an immutable sequence of characters in kOS.
+
+Creating strings
+-------------------
+
+Unlike other structures, strings are created with a special syntax::
+
+    // Create a new string
+    SET s TO "Hello, Strings!".
+    
+
+Strings are immutable. This means, once a string has been created, it 
+can not be directly modified. However, new strings can be created out
+of existing strings. For example::
+
+    // Create a new string with "Hello" replaced with "Goodbye"
+    SET s TO "Hello, Strings!".
+    SET t TO s:REPLACE("Hello", "Goodbye").
+
+Structure
+---------
+
+.. structure:: String
+
+    .. list-table:: Members
+        :header-rows: 1
+        :widths: 2 1 4
+
+        * - Suffix
+          - Type
+          - Description
+
+        * - :meth:`CONTAINS(string)`
+          - boolean
+          - True if the given string is contained within this string (case sensitive) 
+        * - :meth:`ENDSWITH(string)`
+          - boolean
+          - True if this string ends with the given string (case sensitive)
+        * - :meth:`FIND(string)`
+          - integer
+          - Returns the index of the first occurrence of the given string in this string (starting from 0)
+        * - :meth:`FINDAT(string, startAt)`
+          - integer
+          - Returns the index of the first occurrence of the given string in this string (starting from startAt)
+        * - :meth:`FINDLAST(string)`
+          - integer
+          - Returns the index of the last occurrence of the given string in this string (starting from 0)
+        * - :meth:`FINDLASTAT(string, startAt)`
+          - integer
+          - Returns the index of the last occurrence of the given string in this string (starting from startAt)
+        * - :meth:`INDEXOF(string)`
+          - integer
+          - Alias for FIND(string)
+        * - :meth:`INSERT(index, string)`
+          - :struct:`String`
+          - Returns a new string with the given string inserted at the given index into this string
+        * - :meth:`LASTINDEXOF(string)`
+          - integer
+          - Alias for FINDLAST(string)
+        * - :attr:`LENGTH`
+          - integer
+          - Number of characters in the string
+        * - :meth:`PADLEFT(width)`
+          - :struct:`String`
+          - Returns a new right-aligned version of this string padded to the given width by spaces
+        * - :meth:`PADRIGHT(width)`
+          - :struct:`String`
+          - Returns a new left-aligned version of this string padded to the given width by spaces
+        * - :meth:`REMOVE(index,count)`
+          - :struct:`String`
+          - Returns a new string out of this string with the given count of characters removed starting at the given index
+        * - :meth:`REPLACE(oldString, newString)`
+          - :struct:`String`
+          - Returns a new string out of this string with any occurrences of oldString replaced with newString
+        * - :meth:`SPLIT(separator)`
+          - :struct:`String`
+          - Breaks this string up into a list of smaller strings on each occurrence of the given separator
+        * - :meth:`STARTSWITH(string)`
+          - boolean
+          - True if this string starts with the given string (case sensitive)
+        * - :meth:`SUBSTRING(start, count)`
+          - :struct:`String`
+          - Returns a new string with the given count of characters from this string starting from the given start position
+        * - :attr:`TOLOWER`
+          - :struct:`String`
+          - Returns a new string with all characters in this string replaced with their lower case versions
+        * - :attr:`TOUPPER`
+          - :struct:`String`
+          - Returns a new string with all characters in this string replaced with their upper case versions
+        * - :attr:`TRIM`
+          - :struct:`String`
+          - returns a new string with no leading or trailing whitespace
+        * - :attr:`TRIMEND`
+          - :struct:`String`
+          - returns a new string with no trailing whitespace
+        * - :attr:`TRIMSTART`
+          - :struct:`String`
+          - returns a new string with no leading whitespace
+
+
+.. method:: String:CONTAINS(string)
+
+    :parameter string: :struct:`String` to look for
+    :type: boolean
+    
+    True if the given string is contained within this string. This is a case-sensitive search.
+
+.. method:: String:ENDSWITH(string)
+
+    :parameter string: :struct:`String` to look for
+    :type: boolean
+
+    True if this string ends with the given string. This is a case-sensitive search.
+
+.. method:: String:FIND(string)
+
+    :parameter string: :struct:`String` to look for
+    :type: :struct:`String`
+    
+    Returns the index of the first occurrence of the given string in this string (starting from 0).
+    
+.. method:: String:FINDAT(string, startAt)
+
+    :parameter string: :struct:`String` to look for
+    :parameter startAt: integer index to start searching at
+    :type: :struct:`String`
+    
+    Returns the index of the first occurrence of the given string in this string (starting from startAt).
+
+.. method:: String:FINDLAST(string)
+
+    :parameter string: :struct:`String` to look for
+    :type: :struct:`String`
+
+    Returns the index of the last occurrence of the given string in this string (starting from 0)
+
+.. method:: String:FINDLASTAT(string, startAt)
+
+    :parameter string: :struct:`String` to look for
+    :parameter startAt: integer index to start searching at
+    :type: :struct:`String`
+
+    Returns the index of the last occurrence of the given string in this string (starting from startAt)
+
+.. method:: String:INDEXOF(string)
+
+    Alias for FIND(string)
+
+.. method:: String:INSERT(index, string)
+
+    :parameter index: integer index to add the string at
+    :parameter string: :struct:`String` to insert
+    :type: :struct:`String`
+
+    Returns a new string with the given string inserted at the given index into this string
+
+.. method:: String:LASTINDEXOF(string)
+
+    Alias for FINDLAST(string)
+
+.. attribute:: String:LENGTH
+
+    :type: integer
+    :access: Get only
+
+    Number of characters in the string
+
+.. method:: String:PADLEFT(width)
+
+    :parameter width: integer number of characters the resulting string will contain
+    :type: :struct:`String`
+
+    Returns a new right-aligned version of this string padded to the given width by spaces.
+
+.. method:: String:PADRIGHT(width)
+
+    :parameter width: integer number of characters the resulting string will contain
+    :type: :struct:`String`
+
+    Returns a new left-aligned version of this string padded to the given width by spaces.
+
+.. method:: String:REMOVE(index,count)
+
+    :parameter index: integer position of the string from which characters will be removed from the resulting string
+    :parameter count: integer number of characters that will be removing from the resulting string
+    :type: :struct:`String`
+
+    Returns a new string out of this string with the given count of characters removed starting at the given index.
+
+.. method:: String:REPLACE(oldString,newString)
+
+    :parameter oldString: :struct:`String` to search for
+    :parameter newString: :struct:`String` that all occurances of oldString will be replaced with
+    :type: :struct:`String`
+
+    Returns a new string out of this string with any occurrences of oldString replaced with newString.
+
+.. method:: String:SPLIT(separator)
+
+    :parameter separator: :struct:`String` delimiter on which this string will be split
+    :return: :struct:`List`
+    
+    Breaks this string up into a list of smaller strings on each occurrence of the given separator. This will return a
+    list of strings, none of which will contain the separator character(s).
+
+.. method:: String:STARTSWITH(string)
+
+    :parameter string: :struct:`String` to look for
+    :type: boolean
+
+    True if this string starts with the given string (case sensitive).
+
+.. method:: String:SUBSTRING(start,count)
+
+    :parameter start: (integer) starting index (from zero)
+    :parameter count: (integer) resulting length of returned :struct:`String`
+    :return: :struct:`String`
+
+    Returns a new string with the given count of characters from this string starting from the given start position.
+
+.. attribute:: String:TOLOWER
+
+    :type: :struct:`String`
+    :access: Get only
+
+    Returns a new string with all characters in this string replaced with their lower case versions
+
+.. attribute:: String:TOUPPER
+
+    :type: :struct:`String`
+    :access: Get only
+
+    Returns a new string with all characters in this string replaced with their upper case versions
+
+.. attribute:: String:TRIM
+
+    :type: :struct:`String`
+    :access: Get only
+
+    returns a new string with no leading or trailing whitespace
+
+.. attribute:: String:TRIMEND
+
+    :type: :struct:`String`
+    :access: Get only
+
+    returns a new string with no trailing whitespace
+
+.. attribute:: String:TRIMSTART
+
+    :type: :struct:`String`
+    :access: Get only
+
+    returns a new string with no leading whitespace
+
+    
+Access to Individual Characters
+-----------------------------
+
+All string indexes start counting at zero. (The characters are numbered from 0 to N-1 rather than from 1 to N.)
+
+``string[expression]``
+    operator: access the character at position 'expression'. Any arbitrary complex expression may be used with this syntax, not just a number or variable name.
+``FOR VAR IN STRING { ... }.``
+    :ref:`A type of loop <flow>` in which var iterates over all the characters of the string from 0 to LENGTH-1.
+
+Examples::
+
+                                                                    // CORRECT OUTPUTS
+    SET s TO "Hello, Strings!".                                     // ---------------
+    PRINT "Original String:               " + s.                    // Hello, Strings!
+    PRINT "string[7]:                     " + s[7].                 // S
+    PRINT "LENGTH:                        " + s:LENGTH.             // 15
+    PRINT "SUBSTRING(7, 6):               " + s:SUBSTRING(7, 6).    // String
+    PRINT "CONTAINS(''ring''):            " + s:CONTAINS("ring").   // True
+    PRINT "CONTAINS(''bling''):           " + s:CONTAINS("bling").  // False
+    PRINT "ENDSWITH(''ings!''):           " + s:ENDSWITH("ings!").  // True
+    PRINT "ENDSWITH(''outs!''):           " + s:ENDSWITH("outs").   // False
+    PRINT "FIND(''l''):                   " + s:FIND("l").          // 2
+    PRINT "FINDLAST(''l''):               " + s:FINDLAST("l").      // 3
+    PRINT "FINDAT(''l'', 0):              " + s:FINDAT("l", 0).     // 2
+    PRINT "FINDAT(''l'', 3):              " + s:FINDAT("l", 3).     // 3
+    PRINT "FINDLASTAT(''l'', 9):          " + s:FINDLASTAT("l", 9). // 3
+    PRINT "FINDLASTAT(''l'', 2):          " + s:FINDLASTAT("l", 2). // 2
+    PRINT "INSERT(7, ''Big ''):           " + s:INSERT(7, "Big ").  // Hello, Big Strings!
+    
+    PRINT " ".
+    PRINT "                               |------ 18 ------|".
+    PRINT "PADLEFT(18):                   " + s:PADLEFT(18).        //    Hello, Strings!
+    PRINT "PADRIGHT(18):                  " + s:PADRIGHT(18).       // Hello, Strings!   
+    PRINT " ".
+    
+    PRINT "REMOVE(1, 3):                  " + s:REMOVE(1, 3).               // Ho, Strings!
+    PRINT "REPLACE(''Hell'', ''Heaven''): " + s:REPLACE("Hell", "Heaven").  // Heaveno, Strings!
+    PRINT "STARTSWITH(''Hell''):          " + s:STARTSWITH("Hell").         // True
+    PRINT "STARTSWITH(''Heaven''):        " + s:STARTSWITH("Heaven").       // False
+    PRINT "TOUPPER:                       " + s:TOUPPER().                  // HELLO, STRINGS!
+    PRINT "TOLOWER:                       " + s:TOLOWER().                  // hello, strings!
+    
+    PRINT " ".
+    PRINT "''  Hello!  '':TRIM():         " + "  Hello!  ":TRIM().          // Hello!
+    PRINT "''  Hello!  '':TRIMSTART():    " + "  Hello!  ":TRIMSTART().     // Hello!  
+    PRINT "''  Hello!  '':TRIMEND():      " + "  Hello!  ":TRIMEND().       //   Hello!
+
+    PRINT " ".
+    PRINT "Chained: " + "Hello!":SUBSTRING(0, 4):TOUPPER():REPLACE("ELL", "ELEPHANT").  // HELEPHANT

--- a/kerboscript_tests/string/stringtester.ks
+++ b/kerboscript_tests/string/stringtester.ks
@@ -1,36 +1,36 @@
-CLEARSCREEN.													// CORRECT OUTPUTS
-SET s TO "Hello, Strings!".										// ---------------
-PRINT "Original String:               " + s.					// Hello, Strings!
-PRINT "string[7]:                     " + s[7].					// S
-PRINT "LENGTH:                        " + s:LENGTH.				// 15
-PRINT "SUBSTRING(7, 6):               " + s:SUBSTRING(7, 6).	// String
-PRINT "CONTAINS(''ring''):            " + s:CONTAINS("ring").	// True
-PRINT "CONTAINS(''bling''):           " + s:CONTAINS("bling").	// False
-PRINT "ENDSWITH(''ings!''):           " + s:ENDSWITH("ings!").	// True
-PRINT "ENDSWITH(''outs!''):           " + s:ENDSWITH("outs").	// False
-PRINT "FIND(''l''):                   " + s:FIND("l").			// 2
-PRINT "FINDLAST(''l''):               " + s:FINDLAST("l").		// 3
-PRINT "FINDAT(''l'', 0):              " + s:FINDAT("l", 0).		// 2
-PRINT "FINDAT(''l'', 3):              " + s:FINDAT("l", 3).		// 3
-PRINT "FINDLASTAT(''l'', 9):          " + s:FINDLASTAT("l", 9).	// 3
-PRINT "FINDLASTAT(''l'', 2):          " + s:FINDLASTAT("l", 2).	// 2
-PRINT "INSERT(7, ''Big ''):           " + s:INSERT(7, "Big ").	// Hello, Big Strings!
+CLEARSCREEN.                                                    // CORRECT OUTPUTS
+SET s TO "Hello, Strings!".                                     // ---------------
+PRINT "Original String:               " + s.                    // Hello, Strings!
+PRINT "string[7]:                     " + s[7].                 // S
+PRINT "LENGTH:                        " + s:LENGTH.             // 15
+PRINT "SUBSTRING(7, 6):               " + s:SUBSTRING(7, 6).    // String
+PRINT "CONTAINS(''ring''):            " + s:CONTAINS("ring").   // True
+PRINT "CONTAINS(''bling''):           " + s:CONTAINS("bling").  // False
+PRINT "ENDSWITH(''ings!''):           " + s:ENDSWITH("ings!").  // True
+PRINT "ENDSWITH(''outs!''):           " + s:ENDSWITH("outs").   // False
+PRINT "FIND(''l''):                   " + s:FIND("l").          // 2
+PRINT "FINDLAST(''l''):               " + s:FINDLAST("l").      // 3
+PRINT "FINDAT(''l'', 0):              " + s:FINDAT("l", 0).     // 2
+PRINT "FINDAT(''l'', 3):              " + s:FINDAT("l", 3).     // 3
+PRINT "FINDLASTAT(''l'', 9):          " + s:FINDLASTAT("l", 9). // 3
+PRINT "FINDLASTAT(''l'', 2):          " + s:FINDLASTAT("l", 2). // 2
+PRINT "INSERT(7, ''Big ''):           " + s:INSERT(7, "Big ").  // Hello, Big Strings!
 
 PRINT " ".
 PRINT "                               |------ 18 ------|".
-PRINT "PADLEFT(18):                   " + s:PADLEFT(18).		//    Hello, Strings!
-PRINT "PADRIGHT(18):                  " + s:PADRIGHT(18).		// Hello, Strings!   
+PRINT "PADLEFT(18):                   " + s:PADLEFT(18).        //    Hello, Strings!
+PRINT "PADRIGHT(18):                  " + s:PADRIGHT(18).       // Hello, Strings!   
 PRINT " ".
 
-PRINT "REMOVE(1, 3):                  " + s:REMOVE(1, 3).				// Ho, Strings!
-PRINT "REPLACE(''Hell'', ''Heaven''): " + s:REPLACE("Hell", "Heaven").	// Heaveno, Strings!
-PRINT "STARTSWITH(''Hell''):          " + s:STARTSWITH("Hell").			// True
-PRINT "STARTSWITH(''Heaven''):        " + s:STARTSWITH("Heaven").		// False
-PRINT "TOUPPER:                       " + s:TOUPPER().					// HELLO, STRINGS!
-PRINT "TOLOWER:                       " + s:TOLOWER().					// hello, strings!
+PRINT "REMOVE(1, 3):                  " + s:REMOVE(1, 3).               // Ho, Strings!
+PRINT "REPLACE(''Hell'', ''Heaven''): " + s:REPLACE("Hell", "Heaven").  // Heaveno, Strings!
+PRINT "STARTSWITH(''Hell''):          " + s:STARTSWITH("Hell").         // True
+PRINT "STARTSWITH(''Heaven''):        " + s:STARTSWITH("Heaven").       // False
+PRINT "TOUPPER:                       " + s:TOUPPER().                  // HELLO, STRINGS!
+PRINT "TOLOWER:                       " + s:TOLOWER().                  // hello, strings!
 PRINT " ".
-PRINT "''  Hello!  '':TRIM():         " + "  Hello!  ":TRIM().			// Hello!
-PRINT "''  Hello!  '':TRIMSTART():    " + "  Hello!  ":TRIMSTART().		// Hello!  
-PRINT "''  Hello!  '':TRIMEND():      " + "  Hello!  ":TRIMEND().		//   Hello!
+PRINT "''  Hello!  '':TRIM():         " + "  Hello!  ":TRIM().          // Hello!
+PRINT "''  Hello!  '':TRIMSTART():    " + "  Hello!  ":TRIMSTART().     // Hello!  
+PRINT "''  Hello!  '':TRIMEND():      " + "  Hello!  ":TRIMEND().       //   Hello!
 PRINT " ".
-PRINT "Chained: " + "Hello!":SUBSTRING(0, 4):TOUPPER():REPLACE("ELL", "ELEPHANT").	// HELEPHANT
+PRINT "Chained: " + "Hello!":SUBSTRING(0, 4):TOUPPER():REPLACE("ELL", "ELEPHANT").  // HELEPHANT

--- a/kerboscript_tests/string/stringtester.ks
+++ b/kerboscript_tests/string/stringtester.ks
@@ -1,0 +1,36 @@
+CLEARSCREEN.													// CORRECT OUTPUTS
+SET s TO "Hello, Strings!".										// ---------------
+PRINT "Original String:               " + s.					// Hello, Strings!
+PRINT "string[7]:                     " + s[7].					// S
+PRINT "LENGTH:                        " + s:LENGTH.				// 15
+PRINT "SUBSTRING(7, 6):               " + s:SUBSTRING(7, 6).	// String
+PRINT "CONTAINS(''ring''):            " + s:CONTAINS("ring").	// True
+PRINT "CONTAINS(''bling''):           " + s:CONTAINS("bling").	// False
+PRINT "ENDSWITH(''ings!''):           " + s:ENDSWITH("ings!").	// True
+PRINT "ENDSWITH(''outs!''):           " + s:ENDSWITH("outs").	// False
+PRINT "FIND(''l''):                   " + s:FIND("l").			// 2
+PRINT "FINDLAST(''l''):               " + s:FINDLAST("l").		// 3
+PRINT "FINDAT(''l'', 0):              " + s:FINDAT("l", 0).		// 2
+PRINT "FINDAT(''l'', 3):              " + s:FINDAT("l", 3).		// 3
+PRINT "FINDLASTAT(''l'', 9):          " + s:FINDLASTAT("l", 9).	// 3
+PRINT "FINDLASTAT(''l'', 2):          " + s:FINDLASTAT("l", 2).	// 2
+PRINT "INSERT(7, ''Big ''):           " + s:INSERT(7, "Big ").	// Hello, Big Strings!
+
+PRINT " ".
+PRINT "                               |------ 18 ------|".
+PRINT "PADLEFT(18):                   " + s:PADLEFT(18).		//    Hello, Strings!
+PRINT "PADRIGHT(18):                  " + s:PADRIGHT(18).		// Hello, Strings!   
+PRINT " ".
+
+PRINT "REMOVE(1, 3):                  " + s:REMOVE(1, 3).				// Ho, Strings!
+PRINT "REPLACE(''Hell'', ''Heaven''): " + s:REPLACE("Hell", "Heaven").	// Heaveno, Strings!
+PRINT "STARTSWITH(''Hell''):          " + s:STARTSWITH("Hell").			// True
+PRINT "STARTSWITH(''Heaven''):        " + s:STARTSWITH("Heaven").		// False
+PRINT "TOUPPER:                       " + s:TOUPPER().					// HELLO, STRINGS!
+PRINT "TOLOWER:                       " + s:TOLOWER().					// hello, strings!
+PRINT " ".
+PRINT "''  Hello!  '':TRIM():         " + "  Hello!  ":TRIM().			// Hello!
+PRINT "''  Hello!  '':TRIMSTART():    " + "  Hello!  ":TRIMSTART().		// Hello!  
+PRINT "''  Hello!  '':TRIMEND():      " + "  Hello!  ":TRIMEND().		//   Hello!
+PRINT " ".
+PRINT "Chained: " + "Hello!":SUBSTRING(0, 4):TOUPPER():REPLACE("ELL", "ELEPHANT").	// HELEPHANT

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -577,9 +577,17 @@ namespace kOS.Safe.Compilation
             object popValue = cpu.PopValue();
 
             var specialValue = popValue as ISuffixed;
+            
             if (specialValue == null)
             {
-                throw new Exception(string.Format("Values of type {0} cannot have suffixes", popValue.GetType()));
+                if (popValue is String)
+                {
+                    specialValue = new StringValue((String)popValue);
+                }
+                else
+                {
+                    throw new Exception(string.Format("Values of type {0} cannot have suffixes", popValue.GetType()));
+                }
             }
 
             object value = specialValue.GetSuffix(suffixName);
@@ -631,7 +639,14 @@ namespace kOS.Safe.Compilation
             var specialValue = popValue as ISuffixed;
             if (specialValue == null)
             {
-                throw new Exception(string.Format("Values of type {0} cannot have suffixes", popValue.GetType()));
+                if (popValue is String)
+                {
+                    specialValue = new StringValue((String)popValue);
+                }
+                else
+                {
+                    throw new Exception(string.Format("Values of type {0} cannot have suffixes", popValue.GetType()));
+                }
             }
 
             if (!specialValue.SetSuffix(suffixName, value))
@@ -656,6 +671,11 @@ namespace kOS.Safe.Compilation
             }
             object list = cpu.PopValue();
 
+            if (list is String)
+            {
+                list = new StringValue((String)list);
+            }
+
             if (!(list is IIndexable)) throw new Exception(string.Format("Can't iterate on an object of type {0}", list.GetType()));
             if (!(index is int)) throw new Exception("The index must be an integer number");
 
@@ -679,7 +699,7 @@ namespace kOS.Safe.Compilation
             {
                 index = Convert.ToInt32(index);  // allow expressions like (1.0) to be indexes
             }
-            if (!(list is IIndexable)) throw new Exception(string.Format("Can't iterate on an object of type {0}", list.GetType()));
+            if (!(list is IIndexable)) throw new Exception(string.Format("Can't set indexed elements on an object of type {0}", list.GetType()));
             if (!(index is int)) throw new Exception("The index must be an integer number");
 
             if (value != null)

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -639,6 +639,7 @@ namespace kOS.Safe.Compilation
             var specialValue = popValue as ISuffixed;
             if (specialValue == null)
             {
+                // Box strings if necessary to allow suffixes
                 if (popValue is String)
                 {
                     specialValue = new StringValue((String)popValue);
@@ -671,6 +672,7 @@ namespace kOS.Safe.Compilation
             }
             object list = cpu.PopValue();
 
+            // Box strings if necessary to allow them to be indexed
             if (list is String)
             {
                 list = new StringValue((String)list);
@@ -699,6 +701,8 @@ namespace kOS.Safe.Compilation
             {
                 index = Convert.ToInt32(index);  // allow expressions like (1.0) to be indexes
             }
+
+            // Adjusted error message to reflect that there are now read-only indexable objects
             if (!(list is IIndexable)) throw new Exception(string.Format("Can't set indexed elements on an object of type {0}", list.GetType()));
             if (!(index is int)) throw new Exception("The index must be an integer number");
 

--- a/src/kOS.Safe/Encapsulation/StringValue.cs
+++ b/src/kOS.Safe/Encapsulation/StringValue.cs
@@ -63,7 +63,8 @@ namespace kOS.Safe.Encapsulation
             return internalString.IndexOf(s);
         }
 
-        // This was named FindAt because IndexOfAt made little sense
+        // IndexOf with a start position.
+        // This was named FindAt because IndexOfAt made little sense.
         public int FindAt(String s, int start)
         {
             return internalString.IndexOf(s, start);
@@ -144,11 +145,13 @@ namespace kOS.Safe.Encapsulation
             return internalString[index];
         }
 
+        // Required by the interface but unimplemented, because strings are immutable.
         public void SetIndex(int index, object value)
         {
             throw new KOSException("String are immutable; they can not be modified using the syntax \"SET string[1] TO 'a'\", etc.");
         }
 
+        // As the regular Split, except returning a ListValue rather than an array.
         public ListValue<String> SplitToList(String separator)
         {
             String[] split = internalString.Split(new string[] { separator }, StringSplitOptions.None);

--- a/src/kOS.Safe/Encapsulation/SuffixedString.cs
+++ b/src/kOS.Safe/Encapsulation/SuffixedString.cs
@@ -1,0 +1,191 @@
+﻿using kOS.Safe.Encapsulation.Suffixes;
+using kOS.Safe.Exceptions;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace kOS.Safe.Encapsulation
+{
+    /// <summary>
+    /// The class is a simple wrapper around the string class to 
+    /// implement the Structure and IIndexable interface on
+    /// strings. Currently, strings are only boxed with this
+    /// class temporarily when suffix/indexing support is
+    /// necessary.
+    /// 
+    /// </summary>
+    public class StringValue : Structure, IIndexable
+    {
+        private readonly string internalString;
+
+        public StringValue(): 
+            this ("")
+        {
+        }
+
+        public StringValue(string stringValue)
+        {
+            this.internalString = stringValue;
+            StringInitializeSuffixes();
+        }
+
+        public int Length
+        {
+            get { return internalString.Length; }
+        }
+
+        public String Substring(int start, int count)
+        {
+            return internalString.Substring(start, count);
+        }
+
+        public bool Contains(String s)
+        {
+            return internalString.Contains(s);
+        }
+
+        public bool EndsWith(String s)
+        {
+            return internalString.EndsWith(s);
+        }
+
+        // To match C# naming
+        public int IndexOf(String s)
+        {
+            return internalString.IndexOf(s);
+        }
+
+        // To be consistant with FindAt, below
+        public int Find(String s)
+        {
+            return internalString.IndexOf(s);
+        }
+
+        // This was named FindAt because IndexOfAt made little sense
+        public int FindAt(String s, int start)
+        {
+            return internalString.IndexOf(s, start);
+        }
+
+        public String Insert(int location, String s)
+        {
+            return internalString.Insert(location, s);
+        }
+
+        public int LastIndexOf(String s)
+        {
+            return internalString.LastIndexOf(s);
+        }
+
+        public int FindLast(String s)
+        {
+            return internalString.LastIndexOf(s);
+        }
+
+        public int FindLastAt(String s, int start)
+        {
+            return internalString.LastIndexOf(s, start);
+        }
+
+        public String PadLeft(int width)
+        {
+            return internalString.PadLeft(width);
+        }
+
+        public String PadRight(int width)
+        {
+            return internalString.PadRight(width);
+        }
+
+        public String Remove(int start, int count)
+        {
+            return internalString.Remove(start, count);
+        }
+
+        public String Replace(String oldString, String newString)
+        {
+            return internalString.Replace(oldString, newString);
+        }
+
+        public String ToLower()
+        {
+            return internalString.ToLower();
+        }
+
+        public String ToUpper()
+        {
+            return internalString.ToUpper();
+        }
+
+        public bool StartsWith(String s)
+        {
+            return internalString.StartsWith(s);
+        }
+
+        public String Trim()
+        {
+            return internalString.Trim();
+        }
+
+        public String TrimEnd()
+        {
+            return internalString.TrimEnd();
+        }
+
+        public String TrimStart()
+        {
+            return internalString.TrimStart();
+        }
+
+        public object GetIndex(int index)
+        {
+            return internalString[index];
+        }
+
+        public void SetIndex(int index, object value)
+        {
+            throw new KOSException("String are immutable; they can not be modified using the syntax \"SET string[1] TO 'a'\", etc.");
+        }
+
+        public ListValue<String> SplitToList(String separator)
+        {
+            String[] split = internalString.Split(new string[] { separator }, StringSplitOptions.None);
+            return new ListValue<String>(split);
+        }
+
+        private void StringInitializeSuffixes()
+        {
+            AddSuffix("LENGTH",     new NoArgsSuffix<int>                           (() => Length));
+            AddSuffix("SUBSTRING",  new TwoArgsSuffix<String, int, int>             (Substring));
+            AddSuffix("CONTAINS",   new OneArgsSuffix<bool, String>                 (Contains));
+            AddSuffix("ENDSWITH",   new OneArgsSuffix<bool, String>                 (EndsWith));
+            AddSuffix("FINDAT",     new TwoArgsSuffix<int, String, int>             (FindAt));
+            AddSuffix("INSERT",     new TwoArgsSuffix<String, int, String>          (Insert));
+            AddSuffix("FINDLASTAT", new TwoArgsSuffix<int, String, int>             (FindLastAt));
+            AddSuffix("PADLEFT",    new OneArgsSuffix<String, int>                  (PadLeft));
+            AddSuffix("PADRIGHT",   new OneArgsSuffix<String, int>                  (PadRight));
+            AddSuffix("REMOVE",     new TwoArgsSuffix<String, int, int>             (Remove));
+            AddSuffix("REPLACE",    new TwoArgsSuffix<String, String, String>       (Replace));
+            AddSuffix("SPLIT",      new OneArgsSuffix<ListValue<String>, String>    (SplitToList));
+            AddSuffix("STARTSWITH", new OneArgsSuffix<bool, String>                 (StartsWith));
+            AddSuffix("TOLOWER",    new NoArgsSuffix<String>                        (ToLower));
+            AddSuffix("TOUPPER",    new NoArgsSuffix<String>                        (ToUpper));
+            AddSuffix("TRIM",       new NoArgsSuffix<String>                        (Trim));
+            AddSuffix("TRIMEND",    new NoArgsSuffix<String>                        (TrimEnd));
+            AddSuffix("TRIMSTART",  new NoArgsSuffix<String>                        (TrimStart));
+
+            // Aliased "IndexOf" with "Find" to match "FindAt" (since IndexOfAt doesn't make sense, but I wanted to stick with common/C# names when possible)
+            AddSuffix(new string[] { "INDEXOF",     "FIND" },     new OneArgsSuffix<int, String>   (IndexOf));
+            AddSuffix(new string[] { "LASTINDEXOF", "FINDLAST" }, new OneArgsSuffix<int, String>   (LastIndexOf));
+
+        }
+
+        // Implicitly converts to a string (i.e., unboxes itself automatically)
+        public static implicit operator string(StringValue value)
+        {
+            return value.internalString;
+        }
+    }
+}

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Encapsulation\ListValue.cs" />
     <Compile Include="Encapsulation\Part\IModuleEngine.cs" />
     <Compile Include="Encapsulation\Structure.cs" />
+    <Compile Include="Encapsulation\StringValue.cs" />
     <Compile Include="Encapsulation\Suffixes\ClampSetSuffix.cs" />
     <Compile Include="Encapsulation\Suffixes\SuffixBase.cs" />
     <Compile Include="Encapsulation\Suffixes\GlobalSuffix.cs" />
@@ -179,14 +180,12 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Sound" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent Condition=" '$(OS)' == 'Unix' ">
       cp "$(TargetPath)" "$(SolutionDir)/../Resources/GameData/kOS/Plugins"
-      (test -h "$(SolutionDir)/../KSPdirlink" &#x26;&#x26; cp "$(TargetPath)" "$(SolutionDir)/../KSPdirlink/GameData/kOS/Plugins") || true
+      (test -h "$(SolutionDir)/../KSPdirlink" &amp;&amp; cp "$(TargetPath)" "$(SolutionDir)/../KSPdirlink/GameData/kOS/Plugins") || true
     </PostBuildEvent>
     <PostBuildEvent Condition=" '$(OS)' != 'Unix' ">
       xcopy "$(TargetPath)" "$(SolutionDir)\..\Resources\GameData\kOS\Plugins" /y


### PR DESCRIPTION
I added suffixes for basic string manipulation. As described in #270, I added a subclass of Structure to wrap C# strings which defines suffixes for most of the basic string operations in C#. I stuck with the C# function names in general. The wrapper class also adds indexing for individual character access.

The operations are as their C# equivalents for the most part, hence they are case sensitive, strings are immutable, etc. Of course, case insensitivity is easily obtained using ToUpper/ToLower.

The actual wrapping of the string is only done when suffixes are actually resolved; it doesn't keep the wrapped strings around permanently. I decided to do the wrapping here because it required the
simplest change and wouldn't break anything. Certainly may be a better place for it, or maybe there is some advantage to having the wrapped versions hang around on the stack. 

I mostly just needed string manipulation for what I was doing; if you'd rather do it a different way, feel free to ignore my PR, or let me know what you think.

Example code (with everything except Split):
```
                                                                // CORRECT OUTPUTS
SET s TO "Hello, Strings!".                                     // ---------------
PRINT "Original String:               " + s.                    // Hello, Strings!
PRINT "string[7]:                     " + s[7].                 // S
PRINT "LENGTH:                        " + s:LENGTH.             // 15
PRINT "SUBSTRING(7, 6):               " + s:SUBSTRING(7, 6).    // String
PRINT "CONTAINS(''ring''):            " + s:CONTAINS("ring").   // True
PRINT "CONTAINS(''bling''):           " + s:CONTAINS("bling").  // False
PRINT "ENDSWITH(''ings!''):           " + s:ENDSWITH("ings!").  // True
PRINT "ENDSWITH(''outs!''):           " + s:ENDSWITH("outs").   // False
PRINT "FIND(''l''):                   " + s:FIND("l").          // 2
PRINT "FINDLAST(''l''):               " + s:FINDLAST("l").      // 3
PRINT "FINDAT(''l'', 0):              " + s:FINDAT("l", 0).     // 2
PRINT "FINDAT(''l'', 3):              " + s:FINDAT("l", 3).     // 3
PRINT "FINDLASTAT(''l'', 9):          " + s:FINDLASTAT("l", 9). // 3
PRINT "FINDLASTAT(''l'', 2):          " + s:FINDLASTAT("l", 2). // 2
PRINT "INSERT(7, ''Big ''):           " + s:INSERT(7, "Big ").  // Hello, Big Strings!

PRINT " ".
PRINT "                               |------ 18 ------|".
PRINT "PADLEFT(18):                   " + s:PADLEFT(18).        //    Hello, Strings!
PRINT "PADRIGHT(18):                  " + s:PADRIGHT(18).       // Hello, Strings!   
PRINT " ".

PRINT "REMOVE(1, 3):                  " + s:REMOVE(1, 3).               // Ho, Strings!
PRINT "REPLACE(''Hell'', ''Heaven''): " + s:REPLACE("Hell", "Heaven").  // Heaveno, Strings!
PRINT "STARTSWITH(''Hell''):          " + s:STARTSWITH("Hell").         // True
PRINT "STARTSWITH(''Heaven''):        " + s:STARTSWITH("Heaven").       // False
PRINT "TOUPPER:                       " + s:TOUPPER().                  // HELLO, STRINGS!
PRINT "TOLOWER:                       " + s:TOLOWER().                  // hello, strings!

PRINT " ".
PRINT "''  Hello!  '':TRIM():         " + "  Hello!  ":TRIM().          // Hello!
PRINT "''  Hello!  '':TRIMSTART():    " + "  Hello!  ":TRIMSTART().     // Hello!  
PRINT "''  Hello!  '':TRIMEND():      " + "  Hello!  ":TRIMEND().       //   Hello!

PRINT " ".
PRINT "Chained: " + "Hello!":SUBSTRING(0, 4):TOUPPER():REPLACE("ELL", "ELEPHANT").  // HELEPHANT
```
The following operations were added:
[Character Indexing]
CONTAINS
ENDSWITH
FIND/INDEXOF
FINDAT
FINDLAST/LASTINDEXOF
FINDLASTAT
INSERT
LENGTH
PADLEFT
PADRIGHT
REMOVE
REPLACE
SPLIT (Returning a KOS List)
STARTSWITH
SUBSTRING
TOLOWER
TOUPPER
TRIM
TRIMEND
TRIMSTART

No attempt was made to tackle escape characters in strings, which was also briefly mentioned in #270.