### PR TITLE
Use the new RemoteTech SetAntennaTarget API

### DIFF
--- a/doc/source/addons/RemoteTech.rst
+++ b/doc/source/addons/RemoteTech.rst
@@ -19,15 +19,24 @@ If you launch a manned craft while using RemoteTech, you are still able to input
 
 It is possible to activate/deactivate RT antennas, as well as set their targets using kOS::
 
-  SET p TO SHIP:PARTSNAMED("mediumDishAntenna")[0].
-  SET m to p:GETMODULE("ModuleRTAntenna").
-  m:DOEVENT("activate").
-  m:SETFIELD("target", "mission-control").
-  // or
-  m:SETFIELD("target", mun).
-  m:SETFIELD("target", "minmus").
+  SET P TO SHIP:PARTSNAMED("mediumDishAntenna")[0].
+  SET M to p:GETMODULE("ModuleRTAntenna").
+  M:DOEVENT("activate").
+  M:SETFIELD("target", "Mission Control").
+  M:SETFIELD("target", mun).
+  M:SETFIELD("target", somevessel).
+  M:SETFIELD("target", "minmus").
 
-Acceptable values for `"target"` are: `"no-target"`, `"active-vessel"`, `"mission-control"`, a :struct:`Body`, a :struct:`Vessel`, or a string containing the name of a body or vessel.
+Acceptable values for `"target"` are:
+
+- `"no-target"`
+- `"active-vessel"`
+- a :struct:`Body`
+- a :struct:`Vessel`
+- a string containing the name of a body or vessel
+- a string containing the name of a ground station (case-sensitive)
+
+You can use :meth:`RTADDON:GROUNDSTATIONS` to get a list of all ground stations. The default ground station is called `"Mission Control"`.
 
 Starting version 0.17 of kOS you can access structure RTAddon via `ADDONS:RT`.
 
@@ -42,6 +51,7 @@ Starting version 0.17 of kOS you can access structure RTAddon via `ADDONS:RT`.
      :meth:`HASCONNECTION(vessel)`         bool                      True if given :struct:`Vessel` has any connection
      :meth:`HASKSCCONNECTION(vessel)`      bool                      True if given :struct:`Vessel` has connection to KSC
      :meth:`HASLOCALCONTROL(vessel)`       bool                      True if given :struct:`Vessel` has local control
+     :meth:`GROUNDSTATIONS()`              :struct:`List`            Get names of all ground stations
     ===================================== ========================= =============
 
 
@@ -87,3 +97,9 @@ Starting version 0.17 of kOS you can access structure RTAddon via `ADDONS:RT`.
     :return: bool
 
     Returns True if `vessel` has local control (and thus not requiring a RemoteTech connection).
+
+.. method:: RTAddon:GROUNDSTATIONS()
+
+    :return: :struct:`List`
+
+    Returns names of all RT ground stations

--- a/src/kOS/AddOns/RemoteTech/Addon.cs
+++ b/src/kOS/AddOns/RemoteTech/Addon.cs
@@ -1,5 +1,6 @@
 ﻿using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Suffixed;
+using kOS.Safe.Encapsulation;
 
 namespace kOS.AddOns.RemoteTech
 {
@@ -21,6 +22,8 @@ namespace kOS.AddOns.RemoteTech
             AddSuffix("HASKSCCONNECTION", new OneArgsSuffix<bool, VesselTarget>(RTHasKSCConnection, "True if ship has connection to KSC"));
 
             AddSuffix("HASLOCALCONTROL", new OneArgsSuffix<bool, VesselTarget>(RTHasLocalControl, "True if ship has locacl control (i.e. a pilot in a command module)"));
+
+            AddSuffix("GROUNDSTATIONS", new NoArgsSuffix<ListValue<string>>(RTGetGroundStations, "Get names of all ground stations"));
 
         }
 
@@ -82,6 +85,12 @@ namespace kOS.AddOns.RemoteTech
             }
 
             return result;
+        }
+
+        private static ListValue<string> RTGetGroundStations() {
+            var groundStations = RemoteTechHook.Instance.GetGroundStations();
+
+            return new ListValue<string>(groundStations);
         }
 
         public override bool Available()

--- a/src/kOS/AddOns/RemoteTech/IRemoteTechAPIv1.cs
+++ b/src/kOS/AddOns/RemoteTech/IRemoteTechAPIv1.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace kOS.AddOns.RemoteTech
 {
@@ -13,5 +14,12 @@ namespace kOS.AddOns.RemoteTech
         Func<Guid, double> GetShortestSignalDelay { get; }
         Func<Guid, double> GetSignalDelayToKSC { get; }
         Func<Guid, Guid, double> GetSignalDelayToSatellite { get; }
-    }
+        Func<IEnumerable<String>> GetGroundStations { get; }
+        Func<String, Guid> GetGroundStationGuid { get; }
+        Func<CelestialBody, Guid> GetCelestialBodyGuid { get; }
+        Func<Part, Guid> GetAntennaTarget { get; }
+        Action<Part, Guid> SetAntennaTarget { get; }
+        Func<Guid> GetNoTargetGuid { get; }
+        Func<Guid> GetActiveVesselGuid { get; }
+   }
 }

--- a/src/kOS/AddOns/RemoteTech/RemoteTechAPI.cs
+++ b/src/kOS/AddOns/RemoteTech/RemoteTechAPI.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace kOS.AddOns.RemoteTech
 {
@@ -13,5 +14,12 @@ namespace kOS.AddOns.RemoteTech
         public Func<Guid, double> GetShortestSignalDelay { get; internal set; }
         public Func<Guid, double> GetSignalDelayToKSC { get; internal set; }
         public Func<Guid, Guid, double> GetSignalDelayToSatellite { get; internal set; }
-    }
+        public Func<IEnumerable<String>> GetGroundStations { get; internal set; }
+        public Func<String, Guid> GetGroundStationGuid { get; internal set; }
+        public Func<CelestialBody, Guid> GetCelestialBodyGuid { get; internal set; }
+        public Func<Part, Guid> GetAntennaTarget { get; internal set; }
+        public Action<Part, Guid> SetAntennaTarget { get; internal set; }
+        public Func<Guid> GetNoTargetGuid { get; internal set; }
+        public Func<Guid> GetActiveVesselGuid { get; internal set; }
+   }
 }


### PR DESCRIPTION
Takes advantage of the new SetAntennaTarget API added in RemoteTechnologiesGroup/RemoteTech#493.

Uses the new API to set antenna target (instead of the old, hacky way). It now supports custom ground stations (previously only the default one was supported).

There is a one breaking change: `mission-control` is now not a valid value for the `target` field. The full name of a ground station must be used, in this case `Mission Control`.

The RT API is scheduled to be released with RT 1.7 (just as the other RT PR I've submitted), so we need to postpone merging this till the release.