### PR TITLE
Use RemoteTechFactory always when RemoteTech it is available

### DIFF
--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -374,7 +374,7 @@ namespace kOS.Module
             bool isAvailable;
             try
             {
-                isAvailable = RemoteTechHook.IsAvailable(vessel.id);
+                isAvailable = RemoteTechHook.IsAvailable();
             }
             catch
             {


### PR DESCRIPTION
Currently, when deciding whether to use RemoteTechFactory kOSProcessor checks if the vessel has a flight computer. If it does not, then RT-related features are not enabled. As a result it is possible to construct a vessel without a flight computer (command pod + kos processor + battery), place it in orbit of duna and happily explore the archive even though the vessel has no antenna and no one on board.

This commit disables the flight computer check. I'm not 100% sure if it does not create problems somewhere else. Any testing/feedback would be appreciated.

This might have been the cause of #1088.