### PR TITLE
Fixes #1116 with a reference direction.

### DIFF
--- a/doc/source/bindings.rst
+++ b/doc/source/bindings.rst
@@ -359,6 +359,37 @@ But kOS does not support this at the moment so in kOS if you set
 the LOADDISTANCE, you are setting it to the same value
 universally for all situations.
 
+.. _referencevector:
+
+REFERENCEVECTOR
+---------------
+
+Gives the Reference :struct:`Vector` for the Solar System itself, in
+current Ship-Raw XYZ coordinates.
+
+Both the :attr:`Orbit:LONGITUDEOFASCENDINGNODE` orbit suffix and the
+:attr:`Body:ROTATIONANGLE` body suffix are expressed in terms of
+degree offsets from this *Universal Reference Vector*.
+
+What is the Reference Vector?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The reference vector is an arbitrary vector in space used to measure
+some orbital parameters that are supposed to remain fixed to space
+regardless of how the planets underneath the orbit rotate, or where the
+Sun is.  In a sense it can be thought of as the celestial "prime
+meridian" of the entire solar system, rather than the "prime meridian" of
+any one particular rotating planet or moon.
+
+In a hypothetical Earthling's solar system our Kerbal scientists have
+hypothesized may exist in a galaxy far away, Earthbound astronomers use
+a reference they called the
+`First Point of Aries <https://en.wikipedia.org/wiki/First_Point_of_Aries>`__,
+as their reference vector.
+
+For Kerbals, it refers to a more arbitrary line in space, pointing at a fixed
+point in the firmament, also known as the "skybox".
+
 Addons
 ------
 

--- a/doc/source/bindings.rst
+++ b/doc/source/bindings.rst
@@ -359,22 +359,22 @@ But kOS does not support this at the moment so in kOS if you set
 the LOADDISTANCE, you are setting it to the same value
 universally for all situations.
 
-.. _referencevector:
+.. _solarprimevector:
 
-REFERENCEVECTOR
----------------
+SOLARPRIMEVECTOR
+----------------
 
-Gives the Reference :struct:`Vector` for the Solar System itself, in
+Gives the Prime Meridian :struct:`Vector` for the Solar System itself, in
 current Ship-Raw XYZ coordinates.
 
 Both the :attr:`Orbit:LONGITUDEOFASCENDINGNODE` orbit suffix and the
 :attr:`Body:ROTATIONANGLE` body suffix are expressed in terms of
-degree offsets from this *Universal Reference Vector*.
+degree offsets from this *Prime Meridian Reference Vector*.
 
-What is the Reference Vector?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+What is the Solar Prime Reference Vector?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The reference vector is an arbitrary vector in space used to measure
+The solar prime vector is an arbitrary vector in space used to measure
 some orbital parameters that are supposed to remain fixed to space
 regardless of how the planets underneath the orbit rotate, or where the
 Sun is.  In a sense it can be thought of as the celestial "prime
@@ -385,7 +385,7 @@ In a hypothetical Earthling's solar system our Kerbal scientists have
 hypothesized may exist in a galaxy far away, Earthbound astronomers use
 a reference they called the
 `First Point of Aries <https://en.wikipedia.org/wiki/First_Point_of_Aries>`__,
-as their reference vector.
+for this purpose.
 
 For Kerbals, it refers to a more arbitrary line in space, pointing at a fixed
 point in the firmament, also known as the "skybox".

--- a/doc/source/structures/celestial_bodies/body.rst
+++ b/doc/source/structures/celestial_bodies/body.rst
@@ -59,6 +59,7 @@ All of the main celestial bodies in the game are reserved variable names. The fo
     :attr:`GEOPOSITIONOF`            :struct:`GeoCoordinates` in :ref:`SHIP-RAW <ship-raw>`
     :attr:`ALTITUDEOF`               scalar (m)
     :attr:`SOIRADIUS`                scalar (m)
+    :attr:`ROTATIONANGLE`            scalar (deg)
     ================================ ============
 
 .. attribute:: Body:NAME
@@ -110,3 +111,14 @@ All of the main celestial bodies in the game are reserved variable names. The fo
 .. attribute:: Body:SOIRADIUS
 
     The radius of the body's sphere of influence. Measured from the body's center.
+
+.. attribute:: Body:ROTATIONANGLE
+
+    The rotation angle is the number of degrees between the 
+    :ref:`Universal Reference Vector <referencevector>` and the 
+    current positon of the body's prime meridian (body longitude
+    of zero).
+
+    The value is in constant motion, and once per body's day, its
+    ``:rotationangle`` will wrap around through a full 360 degrees.
+

--- a/doc/source/structures/celestial_bodies/body.rst
+++ b/doc/source/structures/celestial_bodies/body.rst
@@ -115,7 +115,7 @@ All of the main celestial bodies in the game are reserved variable names. The fo
 .. attribute:: Body:ROTATIONANGLE
 
     The rotation angle is the number of degrees between the 
-    :ref:`Universal Reference Vector <referencevector>` and the 
+    :ref:`Solar Prime Vector <solarprimevector>` and the 
     current positon of the body's prime meridian (body longitude
     of zero).
 

--- a/doc/source/structures/orbits/orbit.rst
+++ b/doc/source/structures/orbits/orbit.rst
@@ -163,7 +163,17 @@ Structure
     :type: scalar (deg)
     :access: Get only
 
-    Longitude of the ascending node. It's unclear what the basis line the game uses for this is, though. The real-world basis is the constellation Ares, which of course doesn't exist in the Kerbal universe.
+    The Longitude of the ascening node is the "celestial longitude" where
+    the orbit crosses the body's equator from its southern hemisphere to
+    its northern hemisphere
+
+    Note that the "celestial longitude" in this case is NOT the planetary
+    longitude of the orbit body.  "Celestial longitudes" are expressed
+    as the angle from the :ref:`universal reference vector <referencevector`,
+    not from the body's longitude.  In order to find out where it is
+    relative to the body's longitude, you will have to take into account
+    ``body:rotationangle``, and take into account that the body will
+    rotate by the time you get there.
 
 .. attribute:: Orbit:ARGUMENTOFPERIAPSIS
 

--- a/doc/source/structures/orbits/orbit.rst
+++ b/doc/source/structures/orbits/orbit.rst
@@ -169,7 +169,7 @@ Structure
 
     Note that the "celestial longitude" in this case is NOT the planetary
     longitude of the orbit body.  "Celestial longitudes" are expressed
-    as the angle from the :ref:`universal reference vector <referencevector`,
+    as the angle from the :ref:`Solar Prime Vector <solarprimevector`,
     not from the body's longitude.  In order to find out where it is
     relative to the body's longitude, you will have to take into account
     ``body:rotationangle``, and take into account that the body will

--- a/kerboscript_tests/demo/testrefvec.ks
+++ b/kerboscript_tests/demo/testrefvec.ks
@@ -1,0 +1,31 @@
+// A small sample script to demonstrate the reference vector
+// idea.
+
+clearscreen.
+print "Reference vector demo.".
+print " ".
+print "Use time-warp to watch things change.".
+print "press action group 1 to quit.".
+
+set refdraw to vecdraw().
+set refdraw:color to white.
+set refdraw:label to "ReferenceVector".
+set refdraw:show to true.
+set zerodraw to vecdraw().
+set zerodraw:color to yellow.
+set zerodraw:label to ship:body:name + "'s zero meridian".
+set zerodraw:show to true.
+
+until ag1 {
+  set refdraw:start  to ship:body:position.
+  set zerodraw:start to ship:body:position.
+  set refdraw:vec  to 2500000*ReferenceVector.
+  set zerodraw:vec to 4*(latlng(0,0):position - ship:body:position).
+  print ship:body:name + 
+        ":ROTATIONANGLE = " + 
+        round(ship:body:rotationangle,2) + " deg    " 
+          at (0,1).
+}.
+
+set refdraw to 0.
+set zerodraw to 0.

--- a/kerboscript_tests/demo/testrefvec.ks
+++ b/kerboscript_tests/demo/testrefvec.ks
@@ -2,14 +2,14 @@
 // idea.
 
 clearscreen.
-print "Reference vector demo.".
+print "Solar Prime Vector demo.".
 print " ".
 print "Use time-warp to watch things change.".
 print "press action group 1 to quit.".
 
 set refdraw to vecdraw().
 set refdraw:color to white.
-set refdraw:label to "ReferenceVector".
+set refdraw:label to "SolarPrimeVector".
 set refdraw:show to true.
 set zerodraw to vecdraw().
 set zerodraw:color to yellow.
@@ -19,7 +19,7 @@ set zerodraw:show to true.
 until ag1 {
   set refdraw:start  to ship:body:position.
   set zerodraw:start to ship:body:position.
-  set refdraw:vec  to 2500000*ReferenceVector.
+  set refdraw:vec  to 2500000*SOLARPRIMEVECTOR.
   set zerodraw:vec to 4*(latlng(0,0):position - ship:body:position).
   print ship:body:name + 
         ":ROTATIONANGLE = " + 

--- a/src/kOS/Binding/BindingsUniverse.cs
+++ b/src/kOS/Binding/BindingsUniverse.cs
@@ -152,7 +152,7 @@ namespace kOS.Binding
             }
 
             shared.BindingMgr.AddGetter("VERSION", () => Core.VersionInfo);
-            shared.BindingMgr.AddGetter("REFERENCEVECTOR", () => new Vector(Planetarium.right));
+            shared.BindingMgr.AddGetter("SOLARPRIMEVECTOR", () => new Vector(Planetarium.right));
         }
 
         private static void SetWarpRate(int newRate, int maxRate)

--- a/src/kOS/Binding/BindingsUniverse.cs
+++ b/src/kOS/Binding/BindingsUniverse.cs
@@ -152,6 +152,7 @@ namespace kOS.Binding
             }
 
             shared.BindingMgr.AddGetter("VERSION", () => Core.VersionInfo);
+            shared.BindingMgr.AddGetter("REFERENCEVECTOR", () => new Vector(Planetarium.right));
         }
 
         private static void SetWarpRate(int newRate, int maxRate)

--- a/src/kOS/Suffixed/BodyTarget.cs
+++ b/src/kOS/Suffixed/BodyTarget.cs
@@ -97,6 +97,7 @@ namespace kOS.Suffixed
             AddSuffix("ATM", new Suffix<BodyAtmosphere>(() => new BodyAtmosphere(Body)));
             AddSuffix("ANGULARVEL", new Suffix<Vector>(() => RawAngularVelFromRelative(Body.angularVelocity)));
             AddSuffix("SOIRADIUS", new Suffix<double>(() => Body.sphereOfInfluence));
+            AddSuffix("ROTATIONANGLE", new Suffix<double>(() => Body.rotationAngle));
             AddSuffix("GEOPOSITIONOF",
                       new OneArgsSuffix<GeoCoordinates, Vector>(
                               GeoCoordinatesFromPosition,


### PR DESCRIPTION
iI decided to drop the "give location of Ascending Node" part of the issue, as it's not quite the same remit, and it's possible for a user to calculate it now, as foillows:

```
set planetary_lan to ship:obt:lan - ship:body:rotationangle.
set an_position to latlng(0, planetary_lan):position.
```
