### PR TITLE
Implement KUniverse and revert

### DIFF
--- a/doc/source/structures/misc/kuniverse.rst
+++ b/doc/source/structures/misc/kuniverse.rst
@@ -1,0 +1,47 @@
+.. kuniverse:
+
+KUniverse 4th wall methods
+==========================
+
+
+.. structure:: KUniverse
+
+    :struct:`KUniverse` is a special structure that allows your kerboscript programs to access some of the functions that break the "4th Wall".  It serves as a place to access object directly connected to the KSP game itself, rather than the interaction with the KSP world (vessels, planets, orbits, etc.).
+
+    .. list-table:: Members (all Gettable and Settable)
+        :header-rows: 1
+        :widths: 3 1 1 4
+
+        * - Suffix
+          - Type
+          - Get/Set
+          - Description
+
+        * - :attr:`CANREVERT`
+          - boolean
+          - Get
+          - Is any revert possible?
+        * - :attr:`CANREVERTTOLAUNCH`
+          - boolean
+          - Get
+          - Is revert to launch possible?
+        * - :attr:`CANREVERTTOEDITOR`
+          - boolean
+          - Get
+          - Is revert to editor possible?
+        * - :attr:`REVERTTOLAUNCH`
+          - none
+          - Method
+          - Invoke revert to launch
+        * - :attr:`REVERTTOEDITOR`
+          - none
+          - Method
+          - Invoke revert to editor
+        * - :attr:`REVERTTO(name)`
+          - string
+          - Method
+          - Invoke revert to the named editor
+        * - :attr:`ORIGINEDITOR`
+          - string
+          - Get
+          - Returns the name of this vessel's editor.

--- a/doc/source/structures/misc/kuniverse.rst
+++ b/doc/source/structures/misc/kuniverse.rst
@@ -8,7 +8,7 @@ KUniverse 4th wall methods
 
     :struct:`KUniverse` is a special structure that allows your kerboscript programs to access some of the functions that break the "4th Wall".  It serves as a place to access object directly connected to the KSP game itself, rather than the interaction with the KSP world (vessels, planets, orbits, etc.).
 
-    .. list-table:: Members (all Gettable and Settable)
+    .. list-table:: Members and Methods
         :header-rows: 1
         :widths: 3 1 1 4
 
@@ -45,3 +45,52 @@ KUniverse 4th wall methods
           - string
           - Get
           - Returns the name of this vessel's editor.
+
+.. attribute:: Config:CANREVERT
+
+    :access: Get
+    :type: boolean.
+
+    Returns true if either revert to launch or revert to editor is available.  Note: either option may still be unavailable, use the specific methods below to check the exact option you are looking for.
+
+.. attribute:: Config:CANREVERTTOLAUNCH
+
+    :access: Get
+    :type: boolean.
+
+    Returns true if either revert to launch is available.
+
+.. attribute:: Config:CANREVERTTOEDITOR
+
+    :access: Get
+    :type: boolean.
+
+    Returns true if either revert to the editor is available.
+
+.. attribute:: Config:REVERTTOLAUNCH
+
+    :access: Method
+    :type: None.
+
+    Initiate the KSP game's revert to launch function.  All progress so far will be lost, and the vessel will be returned to the launch pad or runway at the time it was initially launched.
+
+.. attribute:: Config:REVERTTOEDITOR
+
+    :access: Method
+    :type: None.
+
+    Initiate the KSP game's revert to editor function.  The game will revert to the editor, as selected based on the vessel type.
+
+.. method:: Config:REVERTTO(editor)
+
+    :parameter editor: The editor identifier
+    :return: none
+
+    Revert to the provided editor.  Valid inputs are `"VAB"` and `"SPH"`.
+
+.. attribute:: Config:ORIGINEDITOR
+
+    :access: Get
+    :type: string.
+
+    Returns identifier of the orginating editor based on the vessel type.

--- a/src/kOS/Binding/BindingsUniverse.cs
+++ b/src/kOS/Binding/BindingsUniverse.cs
@@ -15,6 +15,7 @@ namespace kOS.Binding
 
         public override void AddTo(SharedObjects shared)
         {
+            shared.BindingMgr.AddGetter("KUNIVERSE", () => new KUniverseValue(shared));
             shared.BindingMgr.AddGetter("QUICKSAVE", () =>
             {
                 if (!HighLogic.CurrentGame.Parameters.Flight.CanQuickSave) return false;

--- a/src/kOS/Suffixed/KUniverseValue.cs
+++ b/src/kOS/Suffixed/KUniverseValue.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using kOS.Safe.Encapsulation;
+using kOS.Safe.Encapsulation.Suffixes;
+using kOS.Safe.Exceptions;
+
+namespace kOS.Suffixed
+{
+    public class KUniverseValue : Structure
+    {
+        private SharedObjects shared;
+        
+        public KUniverseValue(SharedObjects shared)
+        {
+            this.shared = shared;
+            InitializeSuffixes();
+        }
+        
+        public void InitializeSuffixes()
+        {
+            AddSuffix("CANREVERT", new Suffix<bool>(CanRevert));
+            AddSuffix("CANREVERTTOLAUNCH", new Suffix<bool>(CanRevertToLaunch));
+            AddSuffix("CANREVERTTOEDITOR", new Suffix<bool>(CanRevvertToEditor));
+            AddSuffix("REVERTTOLAUNCH", new NoArgsSuffix(RevertToLaunch));
+            AddSuffix("REVERTTOEDITOR", new NoArgsSuffix(RevertToEditor));
+            AddSuffix("REVERTTO", new OneArgsSuffix<string>(RevertTo));
+            AddSuffix("ORIGINEDITOR", new Suffix<string>(OriginatingEditor));
+        }
+
+        public void RevertToLaunch()
+        {
+            if (CanRevertToLaunch())
+            {
+                FlightDriver.RevertToLaunch();
+            }
+            else throw new KOSCommandInvalidHere("REVERTTOLAUNCH", "When revert is disabled", "When revert is enabled");
+        }
+
+        public void RevertToEditor()
+        {
+            if (CanRevvertToEditor())
+            {
+                EditorFacility fac = ShipConstruction.ShipType;
+                FlightDriver.RevertToPrelaunch(fac);
+            }
+            else throw new KOSCommandInvalidHere("REVERTTOEDITOR", "When revert is disabled", "When revert is enabled");
+        }
+
+        public void RevertTo(string editor)
+        {
+            if (CanRevvertToEditor())
+            {
+                EditorFacility fac;
+                switch (editor.ToUpper())
+                {
+                    case "VAB":
+                        fac = EditorFacility.VAB;
+                        break;
+                    case "SPH":
+                        fac = EditorFacility.SPH;
+                        break;
+                    default:
+                        fac = EditorFacility.None;
+                        break;
+                }
+                FlightDriver.RevertToPrelaunch(fac);
+            }
+            else throw new KOSCommandInvalidHere("REVERTTO", "When revert is disabled", "When revert is enabled");
+        }
+
+        public bool CanRevert()
+        {
+            return FlightDriver.CanRevert;
+        }
+
+        public bool CanRevertToLaunch()
+        {
+            return FlightDriver.CanRevertToPostInit && HighLogic.CurrentGame.Parameters.Flight.CanRestart;
+        }
+
+        public bool CanRevvertToEditor()
+        {
+            return FlightDriver.CanRevertToPrelaunch &&
+                HighLogic.CurrentGame.Parameters.Flight.CanLeaveToEditor &&
+                ShipConstruction.ShipConfig != null;
+        }
+
+        public string OriginatingEditor()
+        {
+            if (ShipConstruction.ShipConfig != null)
+            {
+                EditorFacility fac = ShipConstruction.ShipType;
+                return fac.ToString().ToUpper();
+            }
+            return "";
+        }
+    }
+}

--- a/src/kOS/Suffixed/KUniverseValue.cs
+++ b/src/kOS/Suffixed/KUniverseValue.cs
@@ -5,6 +5,7 @@ using System.Text;
 using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Exceptions;
+using kOS.Execution;
 
 namespace kOS.Suffixed
 {
@@ -34,6 +35,7 @@ namespace kOS.Suffixed
             if (CanRevertToLaunch())
             {
                 FlightDriver.RevertToLaunch();
+                ((CPU)shared.Cpu).GetCurrentOpcode().AbortProgram = true;
             }
             else throw new KOSCommandInvalidHereException("REVERTTOLAUNCH", "When revert is disabled", "When revert is enabled");
         }
@@ -44,6 +46,7 @@ namespace kOS.Suffixed
             {
                 EditorFacility fac = ShipConstruction.ShipType;
                 FlightDriver.RevertToPrelaunch(fac);
+                ((CPU)shared.Cpu).GetCurrentOpcode().AbortProgram = true;
             }
             else throw new KOSCommandInvalidHereException("REVERTTOEDITOR", "When revert is disabled", "When revert is enabled");
         }
@@ -66,6 +69,7 @@ namespace kOS.Suffixed
                         break;
                 }
                 FlightDriver.RevertToPrelaunch(fac);
+                ((CPU)shared.Cpu).GetCurrentOpcode().AbortProgram = true;
             }
             else throw new KOSCommandInvalidHereException("REVERTTO", "When revert is disabled", "When revert is enabled");
         }

--- a/src/kOS/Suffixed/KUniverseValue.cs
+++ b/src/kOS/Suffixed/KUniverseValue.cs
@@ -35,7 +35,7 @@ namespace kOS.Suffixed
             {
                 FlightDriver.RevertToLaunch();
             }
-            else throw new KOSCommandInvalidHere("REVERTTOLAUNCH", "When revert is disabled", "When revert is enabled");
+            else throw new KOSCommandInvalidHereException("REVERTTOLAUNCH", "When revert is disabled", "When revert is enabled");
         }
 
         public void RevertToEditor()
@@ -45,7 +45,7 @@ namespace kOS.Suffixed
                 EditorFacility fac = ShipConstruction.ShipType;
                 FlightDriver.RevertToPrelaunch(fac);
             }
-            else throw new KOSCommandInvalidHere("REVERTTOEDITOR", "When revert is disabled", "When revert is enabled");
+            else throw new KOSCommandInvalidHereException("REVERTTOEDITOR", "When revert is disabled", "When revert is enabled");
         }
 
         public void RevertTo(string editor)
@@ -67,7 +67,7 @@ namespace kOS.Suffixed
                 }
                 FlightDriver.RevertToPrelaunch(fac);
             }
-            else throw new KOSCommandInvalidHere("REVERTTO", "When revert is disabled", "When revert is enabled");
+            else throw new KOSCommandInvalidHereException("REVERTTO", "When revert is disabled", "When revert is enabled");
         }
 
         public bool CanRevert()

--- a/src/kOS/kOS.csproj
+++ b/src/kOS/kOS.csproj
@@ -95,6 +95,7 @@
     </Compile>
     <Compile Include="Sound\SoundMaker.cs" />
     <Compile Include="Suffixed\HsvColor.cs" />
+    <Compile Include="Suffixed\KUniverseValue.cs" />
     <Compile Include="Suffixed\ResourceTransferValue.cs" />
     <Compile Include="Screen\DelegateDialog.cs" />
     <Compile Include="Screen\KOSManagedWindow.cs" />


### PR DESCRIPTION
This fixes #1148
Adds a new structure (KUniverseValue) from which you can access information about reverting to launch.  You can determine if reverting is possible, and then invoke the revert.
- [x] New KUniverseValue class
- [x] Can revert detection
- [x] Invoke revert
- [x] Documentation
- [x] Fix bug when reverting from action groups