### PR TITLE
Opcodes can now abort execution

### DIFF
--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -219,6 +219,9 @@ namespace kOS.Safe.Compilation
         public short SourceColumn { get; set; }  // column number of the token nearest the cause of this Opcode.
 
         private string label = string.Empty;
+
+        public bool AbortProgram { get; set; }
+        public bool AbortContext { get; set; }
         
         public virtual void Execute(ICpu cpu)
         {
@@ -232,6 +235,8 @@ namespace kOS.Safe.Compilation
         protected Opcode()
         {
             DeltaInstructionPointer = 1;
+            AbortProgram = false;
+            AbortContext = false;
         }
         
         /// <summary>
@@ -729,6 +734,10 @@ namespace kOS.Safe.Compilation
     {
         protected override string Name { get { return "EOF"; } }
         public override ByteCode Code { get { return ByteCode.EOF; } }
+        public override void Execute(ICpu cpu)
+        {
+            AbortContext = true;
+        }
     }
 
     
@@ -736,6 +745,10 @@ namespace kOS.Safe.Compilation
     {
         protected override string Name { get { return "EOP"; } }
         public override ByteCode Code { get { return ByteCode.EOP; } }
+        public override void Execute(ICpu cpu)
+        {
+            AbortProgram = true;
+        }
     }
 
     

--- a/src/kOS/Execution/CPU.cs
+++ b/src/kOS/Execution/CPU.cs
@@ -1009,6 +1009,8 @@ namespace kOS.Execution
             {
                 try
                 {
+                    // If the program is ended from within a trigger, the trigger list will be empty and the pointer
+                    // will be invalid.  Only execute the trigger if it still exists.
                     if (currentContext.Triggers.Contains(triggerPointer))
                     {
                         currentContext.InstructionPointer = triggerPointer;
@@ -1035,6 +1037,8 @@ namespace kOS.Execution
                 }
             }
 
+            // since `run` opcodes don't work in triggers, we can use the opcode count to determine if the
+            // program has been aborted.  If the count isn't right, leave the pointer where it is.
             if (oldCount == currentContext.Program.Count)
             {
                 currentContext.InstructionPointer = currentInstructionPointer;

--- a/src/kOS/Execution/CPU.cs
+++ b/src/kOS/Execution/CPU.cs
@@ -1063,9 +1063,21 @@ namespace kOS.Execution
             }
             try
             {
-                if (!(opcode is OpcodeEOF || opcode is OpcodeEOP))
+                opcode.AbortContext = false;
+                opcode.AbortProgram = false;
+                opcode.Execute(this);
+                if (opcode.AbortProgram)
                 {
-                    opcode.Execute(this);
+                    BreakExecution(false);
+                    SafeHouse.Logger.Log("Execution Broken");
+                    return false;
+                }
+                else if (opcode.AbortContext)
+                {
+                    return false;
+                }
+                else
+                {
                     int prevPointer = context.InstructionPointer;
                     context.InstructionPointer += opcode.DeltaInstructionPointer;
                     if (context.InstructionPointer < 0 || context.InstructionPointer >= context.Program.Count())
@@ -1074,11 +1086,6 @@ namespace kOS.Execution
                             context.InstructionPointer, String.Format("after executing {0:0000} {1} {2}", prevPointer, opcode.Label, opcode));
                     }
                     return true;
-                }
-                if (opcode is OpcodeEOP)
-                {
-                    BreakExecution(false);
-                    SafeHouse.Logger.Log("Execution Broken");
                 }
             }
             catch (Exception)
@@ -1089,7 +1096,6 @@ namespace kOS.Execution
                     SafeHouse.Logger.Log(executeLog.ToString());
                 throw;
             }
-            return false;
         }
 
         private void SkipCurrentInstructionId()

--- a/src/kOS/Execution/CPU.cs
+++ b/src/kOS/Execution/CPU.cs
@@ -1000,6 +1000,7 @@ namespace kOS.Execution
         private void ProcessTriggers()
         {
             if (currentContext.Triggers.Count <= 0) return;
+            int oldCount = currentContext.Program.Count;
 
             int currentInstructionPointer = currentContext.InstructionPointer;
             var triggerList = new List<int>(currentContext.Triggers);
@@ -1008,17 +1009,20 @@ namespace kOS.Execution
             {
                 try
                 {
-                    currentContext.InstructionPointer = triggerPointer;
-
-                    bool executeNext = true;
-                    executeLog.Remove(0, executeLog.Length); // why doesn't StringBuilder just have a Clear() operator?
-                    while (executeNext && instructionsSoFarInUpdate < instructionsPerUpdate)
+                    if (currentContext.Triggers.Contains(triggerPointer))
                     {
-                        executeNext = ExecuteInstruction(currentContext);
-                        instructionsSoFarInUpdate++;
+                        currentContext.InstructionPointer = triggerPointer;
+
+                        bool executeNext = true;
+                        executeLog.Remove(0, executeLog.Length); // why doesn't StringBuilder just have a Clear() operator?
+                        while (executeNext && instructionsSoFarInUpdate < instructionsPerUpdate)
+                        {
+                            executeNext = ExecuteInstruction(currentContext);
+                            instructionsSoFarInUpdate++;
+                        }
+                        if (executeLog.Length > 0)
+                            SafeHouse.Logger.Log(executeLog.ToString());
                     }
-                    if (executeLog.Length > 0)
-                        SafeHouse.Logger.Log(executeLog.ToString());
                 }
                 catch (Exception e)
                 {
@@ -1031,7 +1035,10 @@ namespace kOS.Execution
                 }
             }
 
-            currentContext.InstructionPointer = currentInstructionPointer;
+            if (oldCount == currentContext.Program.Count)
+            {
+                currentContext.InstructionPointer = currentInstructionPointer;
+            }
         }
 
         private void ContinueExecution()

--- a/src/kOS/Function/Misc.cs
+++ b/src/kOS/Function/Misc.cs
@@ -361,6 +361,7 @@ namespace kOS.Function
                 AssertArgBottomAndConsume(shared); // not sure if this matters when rebooting anwyway.
                 shared.Processor.SetMode(ProcessorModes.OFF);
                 shared.Processor.SetMode(ProcessorModes.READY);
+                ((CPU)shared.Cpu).GetCurrentOpcode().AbortProgram = true;
             }
         }
     }
@@ -372,6 +373,7 @@ namespace kOS.Function
         {
             AssertArgBottomAndConsume(shared); // not sure if this matters when shutting down anwyway.
             if (shared.Processor != null) shared.Processor.SetMode(ProcessorModes.OFF);
+            ((CPU)shared.Cpu).GetCurrentOpcode().AbortProgram = true;
         }
     }
 


### PR DESCRIPTION
Fixes #1120
Modify the Opcode class so that any opcode can abort program or context execution and change the cpu to use this new property.  This allows the shutdown and reboot functions to prevent execution of future opcodes as described in the referenced bug.