### PR TITLE
Set volume name to kos tag

### DIFF
--- a/doc/source/general/volumes.rst
+++ b/doc/source/general/volumes.rst
@@ -120,6 +120,9 @@ Therefore using the RENAME command on the volumes is useful when dealing
 with multiple CX-4181's on the same vessel, so they all will refer to
 the volumes using the same names.
 
+If a kOS processor has a name tag set, then that processor's volume 
+will have its name initially set to the value of the name tag.
+
 Archive
 -------
 

--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -293,6 +293,12 @@ namespace kOS.Module
             if (HardDisk == null)
             {
                 HardDisk = new Harddisk(Mathf.Min(diskSpace, PROCESSOR_HARD_CAP));
+
+                if (!String.IsNullOrEmpty(Tag))
+                {
+                    HardDisk.Name = Tag;
+                }
+
                 // populate it with the boot file, but only if using a new disk and in PRELAUNCH situation:
                 if (vessel.situation == Vessel.Situations.PRELAUNCH && bootFile != "None" && !Config.Instance.StartOnArchive)
                 {


### PR DESCRIPTION
Fixes #354 

Sets the initial volume name to processor's kOS name tag.