### PR TITLE
Add Missing Flight Parameters

### DIFF
--- a/src/kOS/Binding/FlightControlManager.cs
+++ b/src/kOS/Binding/FlightControlManager.cs
@@ -153,7 +153,7 @@ namespace kOS.Binding
 
         private void AddNewFlightParam(string name, SharedObjects shared)
         {
-            flightParameters.Add(name, new FlightCtrlParam(name, shared));
+            flightParameters[name] = new FlightCtrlParam(name, shared);
         }
 
         private void AddMissingFlightParam(string name, SharedObjects shared)

--- a/src/kOS/Binding/FlightControlManager.cs
+++ b/src/kOS/Binding/FlightControlManager.cs
@@ -110,6 +110,12 @@ namespace kOS.Binding
 
             foreach (var param in flightParameters.Values)
                 param.UpdateFlightControl(currentVessel);
+
+            // If any paramers were removed in UnbindUnloaded, add them back here
+            AddMissingFlightParam("throttle", Shared);
+            AddMissingFlightParam("steering", Shared);
+            AddMissingFlightParam("wheelthrottle", Shared);
+            AddMissingFlightParam("wheelsteering", Shared);
         }
 
         public static FlightControl GetControllerByVessel(Vessel target)
@@ -148,6 +154,14 @@ namespace kOS.Binding
         private void AddNewFlightParam(string name, SharedObjects shared)
         {
             flightParameters.Add(name, new FlightCtrlParam(name, shared));
+        }
+
+        private void AddMissingFlightParam(string name, SharedObjects shared)
+        {
+            if (!flightParameters.ContainsKey(name))
+            {
+                AddNewFlightParam(name, shared);
+            }
         }
 
         public void UnBind()


### PR DESCRIPTION
Fixes #1205.

Some times UnbindUnloaded will remove the flight parameters after docking changes, but the processor will switch to the new vessel.  In these cases, the FlightControlManager is not reinitialized, so we now re-add any missing parameters after attempting to update the parameters' vessel properties.