### PR TITLE
Compiled script label logic

### DIFF
--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -801,9 +801,9 @@ namespace kOS.Safe.Compilation.KS
                         currentCodeSection = subprogramObject.FunctionCode;
                         // verify if the program has been loaded
                         Opcode functionStart = AddOpcode(new OpcodePush(subprogramObject.PointerIdentifier));
-                        AddOpcode(new OpcodePush(-1));
-                        AddOpcode(new OpcodeCompareEqual());
-                        OpcodeBranchIfFalse branchOpcode = new OpcodeBranchIfFalse();
+                        // if the subprogram's identifier already exists, skip over compiling the code.
+                        AddOpcode(new OpcodeExists());
+                        OpcodeBranchIfTrue branchOpcode = new OpcodeBranchIfTrue();
                         AddOpcode(branchOpcode);
                         // if it wasn't then load it now
                         AddOpcode(new OpcodePush(subprogramObject.PointerIdentifier));
@@ -820,7 +820,7 @@ namespace kOS.Safe.Compilation.KS
                         // set the call opcode as the destination of the previous branch
                         branchOpcode.DestinationLabel = callOpcode.Label;
                         // return to the caller address, after adding a dummy return val:
-                        
+
                         // maybe TODO?  Right now the RETURN command is being prevented from being used outside 
                         // a function declaration.  But in principle we could have programs return exit codes
                         // using the same architecture, and in fact that is why this dummy return value is needed,
@@ -836,10 +836,7 @@ namespace kOS.Safe.Compilation.KS
 
                         // Initialization code
                         currentCodeSection = subprogramObject.InitializationCode;
-                        // initialize the pointer to zero
-                        AddOpcode(new OpcodePush(subprogramObject.PointerIdentifier));
-                        AddOpcode(new OpcodePush(-1));
-                        AddOpcode(new OpcodeStore());
+                        // removed pointer initialization since it overwrote any existing values when loading ksm files.
                     }
                 }
             }

--- a/src/kOS.Safe/Compilation/ProgramBuilder.cs
+++ b/src/kOS.Safe/Compilation/ProgramBuilder.cs
@@ -115,16 +115,11 @@ namespace kOS.Safe.Compilation
             {
                 if (program[index].Label != string.Empty)
                 {
-                    if (labels.ContainsKey(program[index].Label)) //eraseme
-                    { //eraseme
-                        foreach (string s in labels.Keys) //eraseme
-                        { //eraseme
-                            Safe.Utilities.SafeHouse.Logger.LogWarning(string.Format("eraseme: label: {0}  index: {1}", s, labels[s])); //eraseme
-                        } //eraseme
-                        Safe.Utilities.SafeHouse.Logger.LogWarning(string.Format("eraseme: Program count: {0}", program.Count)); //eraseme
-                        throw new kOS.Safe.Exceptions.KOSCompileException(string.Format( //eraseme
-                            "Program Builder: Cannot add label {0}, label already exists.  Opcode: {1}", program[index].Label, program[index].ToString())); //eraseme
-                    } //eraseme
+                    if (labels.ContainsKey(program[index].Label))
+                    {
+                        throw new kOS.Safe.Exceptions.KOSCompileException(string.Format(
+                            "ProgramBuilder.ReplaceLabels: Cannot add label {0}, label already exists.  Opcode: {1}", program[index].Label, program[index].ToString()));
+                    }
                     labels.Add(program[index].Label, index);
                 }
             }

--- a/src/kOS.Safe/Compilation/ProgramBuilder.cs
+++ b/src/kOS.Safe/Compilation/ProgramBuilder.cs
@@ -115,6 +115,16 @@ namespace kOS.Safe.Compilation
             {
                 if (program[index].Label != string.Empty)
                 {
+                    if (labels.ContainsKey(program[index].Label))
+                    {
+                        foreach (string s in labels.Keys)
+                        {
+                            Safe.Utilities.SafeHouse.Logger.LogWarning(string.Format("label: {0}  index: {1}", s, labels[s]));
+                        }
+                        Safe.Utilities.SafeHouse.Logger.LogWarning(string.Format("Program count: {0}", program.Count));
+                        throw new kOS.Safe.Exceptions.KOSCompileException(string.Format(
+                            "Program Builder: Cannot add label {0}, label already exists.  Opcode: {1}", program[index].Label, program[index].ToString()));
+                    }
                     labels.Add(program[index].Label, index);
                 }
             }


### PR DESCRIPTION
This fixes an issue related to #691, though it does not completely fix that issue.  The compiler was updated to remove blanket initialization of program pointers.  The issue was that when a ksm file was generated, the compiler would initialize a variable which caused a key collision when the ProgramBuilder would replace labels.  But using the new OpcodeExists, this issue can be avoided and the initialization code is no longer necessary.