### PR TITLE
Fix issue with boot and argmarker

### DIFF
--- a/src/kOS/Execution/CPU.cs
+++ b/src/kOS/Execution/CPU.cs
@@ -128,8 +128,10 @@ namespace kOS.Execution
                     programContext.Silent = true;
                     var options = new CompilerOptions { LoadProgramsInSameAddressSpace = true };
                     List<CodePart> parts = shared.ScriptHandler.Compile(
-                        filePath, 1, String.Format("run {0}.", filename), "program", options);
+                        "sys:boot", 1, String.Format("run {0}.", filename), "program", options);
                     programContext.AddParts(parts);
+                    // we need to add the arg marker to prevent an issue with the declared parameter count:
+                    shared.Cpu.PushStack(new KOSArgMarkerType());
                 }
             }
         }

--- a/src/kOS/Execution/CPU.cs
+++ b/src/kOS/Execution/CPU.cs
@@ -117,18 +117,27 @@ namespace kOS.Execution
             {
                 string filename = shared.Processor.BootFilename;
                 // Check to make sure the boot file name is valid, and then that the boot file exists.
-                if (String.IsNullOrEmpty(filename)) { SafeHouse.Logger.Log("Boot file name is empty, skipping boot script"); }
+                if (string.IsNullOrEmpty(filename)) { SafeHouse.Logger.Log("Boot file name is empty, skipping boot script"); }
                 else if (filename.Equals("None", StringComparison.InvariantCultureIgnoreCase)) { SafeHouse.Logger.Log("Boot file name is \"None\", skipping boot script"); }
-                else if (shared.VolumeMgr.CurrentVolume.GetByName(filename) == null) { SafeHouse.Logger.Log(String.Format("Boot file \"{0}\" is missing, skipping boot script", filename)); }
+                else if (shared.VolumeMgr.CurrentVolume.GetByName(filename) == null) { SafeHouse.Logger.Log(string.Format("Boot file \"{0}\" is missing, skipping boot script", filename)); }
                 else
                 {
-                    string filePath = shared.VolumeMgr.GetVolumeRawIdentifier(shared.VolumeMgr.CurrentVolume) + "/" + filename;
-                    shared.ScriptHandler.ClearContext("program");
-                    var programContext = ((CPU)shared.Cpu).SwitchToProgramContext();
-                    programContext.Silent = true;
-                    var options = new CompilerOptions { LoadProgramsInSameAddressSpace = true, FuncManager = shared.FunctionManager, IsCalledFromRun = false };
+                    var bootContext = "program";
+                    var bootCommand = string.Format("run {0}.", filename);
+
+                    var options = new CompilerOptions
+                    {
+                        LoadProgramsInSameAddressSpace = true,
+                        FuncManager = shared.FunctionManager,
+                        IsCalledFromRun = false
+                    };
+
+                    shared.ScriptHandler.ClearContext(bootContext);
                     List<CodePart> parts = shared.ScriptHandler.Compile(
-                        "sys:boot", 1, String.Format("run {0}.", filename), "program", options);
+                        "sys:boot", 1, bootCommand, bootContext, options);
+
+                    var programContext = SwitchToProgramContext();
+                    programContext.Silent = true;
                     programContext.AddParts(parts);
                 }
             }

--- a/src/kOS/Execution/CPU.cs
+++ b/src/kOS/Execution/CPU.cs
@@ -126,12 +126,10 @@ namespace kOS.Execution
                     shared.ScriptHandler.ClearContext("program");
                     var programContext = ((CPU)shared.Cpu).SwitchToProgramContext();
                     programContext.Silent = true;
-                    var options = new CompilerOptions { LoadProgramsInSameAddressSpace = true };
+                    var options = new CompilerOptions { LoadProgramsInSameAddressSpace = true, FuncManager = shared.FunctionManager, IsCalledFromRun = false };
                     List<CodePart> parts = shared.ScriptHandler.Compile(
                         "sys:boot", 1, String.Format("run {0}.", filename), "program", options);
                     programContext.AddParts(parts);
-                    // we need to add the arg marker to prevent an issue with the declared parameter count:
-                    shared.Cpu.PushStack(new KOSArgMarkerType());
                 }
             }
         }


### PR DESCRIPTION
CPU.cs
* Push a KOSArgMarkerType when booting.  This prevents everything from
complaining about a declared parameter mismatch.
* Also corrected the reference for the instruction to boot.  It
mistakenly referenced the boot file itself, when the instruction to run
the boot file does not orginate in the boot file itself.