### PR TITLE
Fix stage:solidfuel

### DIFF
--- a/src/kOS/Suffixed/StageValues.cs
+++ b/src/kOS/Suffixed/StageValues.cs
@@ -74,6 +74,13 @@ namespace kOS.Suffixed
                     engine.GetConnectedResources(resourceDef.id, resourceDef.resourceFlowMode, list);
                 }
             }
+            else if (resourceDef.resourceFlowMode == ResourceFlowMode.NO_FLOW) {
+                var engines = VesselUtils.GetListOfActivatedEngines(shared.Vessel);
+                foreach (var engine in engines)
+                {
+                    list.AddRange(engine.Resources.GetAll(resourceDef.id));
+                }
+            }
             else
             {
                 shared.Vessel.rootPart.GetConnectedResources(resourceDef.id, resourceDef.resourceFlowMode, list);


### PR DESCRIPTION
Fixes #1231

StageValue.cs
* Update the GetResourceOfCurrentStage method to return the PartResources contained within an engine in the case of NO_FLOW flow
mode.