### PR TITLE
Call the original BaseEvent when RT is used

### DIFF
--- a/src/kOS/AddOns/RemoteTech/IRemoteTechAPIv1.cs
+++ b/src/kOS/AddOns/RemoteTech/IRemoteTechAPIv1.cs
@@ -13,5 +13,6 @@ namespace kOS.AddOns.RemoteTech
         Func<Guid, double> GetShortestSignalDelay { get; }
         Func<Guid, double> GetSignalDelayToKSC { get; }
         Func<Guid, Guid, double> GetSignalDelayToSatellite { get; }
+        Action<BaseEvent> InvokeOriginalEvent { get; }
     }
 }

--- a/src/kOS/AddOns/RemoteTech/RemoteTechAPI.cs
+++ b/src/kOS/AddOns/RemoteTech/RemoteTechAPI.cs
@@ -13,5 +13,6 @@ namespace kOS.AddOns.RemoteTech
         public Func<Guid, double> GetShortestSignalDelay { get; internal set; }
         public Func<Guid, double> GetSignalDelayToKSC { get; internal set; }
         public Func<Guid, Guid, double> GetSignalDelayToSatellite { get; internal set; }
+        public Action<BaseEvent> InvokeOriginalEvent { get; internal set; }
     }
 }

--- a/src/kOS/Suffixed/PartModuleField/PartModuleFields.cs
+++ b/src/kOS/Suffixed/PartModuleField/PartModuleFields.cs
@@ -8,6 +8,8 @@ using System.Linq;
 using System.Text;
 using UnityEngine;
 using Math = kOS.Safe.Utilities.Math;
+using kOS.AddOns.RemoteTech;
+using kOS.Safe.Utilities;
 
 namespace kOS.Suffixed.PartModuleField
 {
@@ -472,7 +474,15 @@ namespace kOS.Suffixed.PartModuleField
                 throw new KOSLookupFailException("EVENT", suffixName, this);
             if (!EventIsVisible(evt))
                 throw new KOSLookupFailException("EVENT", suffixName, this, true);
-            evt.Invoke();
+
+            if (RemoteTechHook.IsAvailable())
+            {
+                RemoteTechHook.Instance.InvokeOriginalEvent(evt);
+            }
+            else
+            {
+                evt.Invoke();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes RemoteTechnologiesGroup/RemoteTech#437 (using RemoteTechnologiesGroup/RemoteTech#508).

For anyone who'd like to test this: vessel must have no connection, no one on board and must call an event from script. The event must be previously listed in a right-click popup.

Without this PR 'No connection to send command on' would be displayed.

My test script:

```
set p to ship:partstagged("antenna")[0].
set m to p:getmodule("ModuleRTAntenna").

m:doevent("deactivate").
// vessel should have no connection now
wait 10.
// so that we have some time to open the popup
m:doevent("activate"). // this would fail without this PR
```