### PR TITLE
Resource converter (prototype)

### DIFF
--- a/src/kOS/Suffixed/Part/ConverterValue.cs
+++ b/src/kOS/Suffixed/Part/ConverterValue.cs
@@ -1,0 +1,140 @@
+using kOS.Safe.Encapsulation;
+using kOS.Safe.Encapsulation.Suffixes;
+using System.Collections.Generic;
+using kOS.Safe.Exceptions;
+using kOS.Suffixed.PartModuleField;
+using System;
+
+namespace kOS.Suffixed.Part
+{
+
+
+    class ConverterValue : PartValue
+    {
+        private ListValue<ConverterFields> Converters;
+
+        public ConverterValue(global::Part part, SharedObjects sharedObj)
+            : base(part, sharedObj)
+        {
+            Converters = new ListValue<ConverterFields>();
+
+            foreach (PartModule module in Part.Modules)
+            {
+                var ConverterModule = module as ModuleResourceConverter;
+                if (ConverterModule != null)
+                {
+                    Converters.Add(new ConverterFields(ConverterModule, sharedObj));
+                }
+            }
+
+            ConverterInitializeSuffixes();
+
+        }
+
+        private void ConverterInitializeSuffixes()
+        {
+            AddSuffix(new[] { "CONVERTERMODULES", "CONVMODS" }, new Suffix<ListValue<ConverterFields>>(() => Converters, ""));
+            AddSuffix(new[] { "HASCONVERTER", "HASCONV" }, new OneArgsSuffix<bool, string>(HasConverterModule));
+            AddSuffix(new[] { "GETCONVERTER", "GETCONV" }, new OneArgsSuffix<ConverterFields, string>(GetConverterModule));
+
+            // all suffixes
+
+            AddSuffix(new[] { "CONVERTERNAMES", "CONVNAMES" }, new Suffix<ListValue>(() =>
+            {
+                var toReturn = new ListValue();
+                foreach (ConverterFields conv in Converters) { toReturn.Add(conv.Converter.ConverterName); }
+                return toReturn;
+            }));
+
+            //AddSuffix(new[] { "CONVERTERNAME", "CONVNAME" }, new Suffix<string>(() => converter.ConverterName));
+
+            AddSuffix("START", new NoArgsSuffix(() =>
+            {
+                foreach (ConverterFields conv in Converters)
+                {
+                    conv.Converter.StartResourceConverter();
+                }
+            }));
+            AddSuffix("STOP", new NoArgsSuffix(() =>
+            {
+                foreach (ConverterFields conv in Converters)
+                {
+                    conv.Converter.StopResourceConverter();
+                }
+            }));
+            AddSuffix("STATUSALL", new Suffix<ListValue>(() =>
+            {
+                var toReturn = new ListValue();
+                foreach (ConverterFields conv in Converters) { toReturn.Add(conv.Converter.status); }
+                return toReturn;
+            }));
+            //AddSuffix("STATUS", new Suffix<string>(() => converter.status));
+            AddSuffix("ISACTIVATED", new SetSuffix<bool>(() => 
+            {
+                foreach (ConverterFields conv in Converters)
+                {
+                    if (conv.Converter.IsActivated) { return true; }
+                }
+                return false;
+            }, value => {
+                foreach (ConverterFields conv in Converters)
+                {
+                    conv.toggle(value);
+                }
+            }));
+            AddSuffix("ALWAYSACTIVE", new Suffix<bool>(() => {
+                foreach (ConverterFields conv in Converters)
+                {
+                    if (conv.Converter.AlwaysActive) { return true; }
+                }
+                return false;
+            }));
+            AddSuffix("GENERATESHEAT", new Suffix<bool>(() => {
+                foreach (ConverterFields conv in Converters)
+                {
+                    if (conv.Converter.GeneratesHeat) { return true; }
+                }
+                return false;
+            }));
+            AddSuffix(new[] { "CORETEMPERATURE", "CORETEMP" }, new Suffix<double>(() => {
+                if (Converters.Count == 0) { return 0; }
+                return Converters[0].Converter.GetCoreTemperature();
+            })); //same for all (from another module)
+            AddSuffix(new[] { "GOALTEMPERATURE", "GOALTEMP" }, new Suffix<double>(() => {
+                if (Converters.Count == 0) { return 0; }
+                return Converters[0].Converter.GetGoalTemperature();
+            })); //same for all (from another module)
+            //AddSuffix("FILLAMOUNT", new Suffix<float>(() => converter.FillAmount));  //stops when output exceeds this part of storage capacity (fuel cell stop condition).
+            //AddSuffix("TAKEAMOUNT", new Suffix<float>(() => converter.TakeAmount));
+            //AddSuffix("THERMALEFFICIENCY", new Suffix<float>(() => converter.ThermalEfficiency.Evaluate((float)(converter.GetCoreTemperature()))));
+            //          AddSuffix("GETINFO", new Suffix<string>(() => converter.GetInfo()));  //overwrite without extra formatting?
+            //AddSuffix("INPUT", new Suffix<Lexicon<string, double>>(() => ResListLex(converter.inputList, 1))); //maximal input rate
+            //AddSuffix("OUTPUT", new Suffix<Lexicon<string, double>>(() => ResListLex(converter.outputList, 1)));
+
+            //AddSuffix(new[] { "CONVERTERLOAD", "CONVLOAD" }, new Suffix<float>(() => conversionLoadParse(converter.status))); //actual converter load (fraction of maximal)
+            //AddSuffix("CONSUME", new Suffix<Lexicon<string, double>>(() => ResListLex(converter.inputList, conversionLoadParse(converter.status)))); //actual consumption rate
+            //AddSuffix("PRODUCE", new Suffix<Lexicon<string, double>>(() => ResListLex(converter.outputList, conversionLoadParse(converter.status)))); //actual production rate
+
+        }
+
+        private bool HasConverterModule(string convName)
+        {
+            foreach (ConverterFields module in Converters)
+            {
+                if (string.Equals(module.Converter.ConverterName, convName, StringComparison.OrdinalIgnoreCase))  { return true; }
+            }
+            return false;
+        }
+
+        private ConverterFields GetConverterModule(string convName)
+        {
+            foreach (ConverterFields module in Converters)
+            {
+                if (string.Equals(module.Converter.ConverterName, convName, StringComparison.OrdinalIgnoreCase)) { return module; } 
+            }
+            throw new KOSException("Resource Converter Module not found: " + convName); //if not found
+        }
+    }
+
+
+}

--- a/src/kOS/Suffixed/PartModuleField/ConverterFields.cs
+++ b/src/kOS/Suffixed/PartModuleField/ConverterFields.cs
@@ -1,0 +1,72 @@
+using kOS.Safe.Encapsulation.Suffixes;
+using kOS.Safe.Encapsulation;
+using System.Collections.Generic;
+
+namespace kOS.Suffixed.PartModuleField
+{
+    class ConverterFields : PartModuleFields
+    {
+        private readonly ModuleResourceConverter converter;
+
+        public ModuleResourceConverter Converter
+        { get { return converter; } }
+
+        public ConverterFields(ModuleResourceConverter ConverterModule, SharedObjects sharedObj)
+            : base(ConverterModule, sharedObj)
+        {
+            converter = ConverterModule;
+            ConverterModuleInitializeSuffixes();
+        }
+
+        private void ConverterModuleInitializeSuffixes()
+        {
+            AddSuffix(new[] { "CONVERTERNAME", "CONVNAME" }, new Suffix<string>(() => converter.ConverterName));
+            AddSuffix("START", new NoArgsSuffix(() => converter.StartResourceConverter()));
+            AddSuffix("STOP", new NoArgsSuffix(() => converter.StopResourceConverter()));
+            AddSuffix("STATUS", new Suffix<string>(() => converter.status));
+            AddSuffix("ISACTIVATED", new SetSuffix<bool>(() => converter.IsActivated, value => toggle(value)));
+            AddSuffix("ALWAYSACTIVE", new Suffix<bool>(() => converter.AlwaysActive));
+            AddSuffix("GENERATESHEAT", new Suffix<bool>(() => converter.GeneratesHeat));
+            AddSuffix(new[] { "CORETEMPERATURE", "CORETEMP" }, new Suffix<double>(() => converter.GetCoreTemperature()));
+            AddSuffix(new[] { "GOALTEMPERATURE", "GOALTEMP" }, new Suffix<double>(() => converter.GetGoalTemperature())); //optimal temp (returns current temp, if temp independent)
+            AddSuffix("FILLAMOUNT", new Suffix<float>(() => converter.FillAmount));  //stops when output exceeds this part of storage capacity (fuel cell stop condition).
+            AddSuffix("TAKEAMOUNT", new Suffix<float>(() => converter.TakeAmount));
+            AddSuffix("THERMALEFFICIENCY", new Suffix<float>(() => converter.ThermalEfficiency.Evaluate((float)(converter.GetCoreTemperature()))));
+            //          AddSuffix("GETINFO", new Suffix<string>(() => converter.GetInfo()));  //overwrite without extra formatting?
+            AddSuffix("INPUT", new Suffix<Lexicon<string, double>>(() => ResListLex(converter.inputList, 1))); //maximal input rate
+            AddSuffix("OUTPUT", new Suffix<Lexicon<string, double>>(() => ResListLex(converter.outputList, 1)));
+
+            AddSuffix(new[] { "CONVERTERLOAD", "CONVLOAD" }, new Suffix<float>(() => conversionLoadParse(converter.status))); //actual converter load (fraction of maximal)
+            AddSuffix("CONSUME", new Suffix<Lexicon<string, double>>(() => ResListLex(converter.inputList, conversionLoadParse(converter.status)))); //actual consumption rate
+            AddSuffix("PRODUCE", new Suffix<Lexicon<string, double>>(() => ResListLex(converter.outputList, conversionLoadParse(converter.status)))); //actual production rate
+        }
+
+        public void toggle(bool value)
+        {
+            if (value) { converter.StartResourceConverter(); } else { converter.StopResourceConverter(); }
+        }
+
+        public Lexicon<string, double> ResListLex(List<ResourceRatio> resList, float rate)
+        {
+            var toReturn = new Lexicon<string, double>();
+            foreach (ResourceRatio rr in resList)
+            {
+                toReturn.Add(rr.ResourceName, rr.Ratio * rate);
+            }
+            return toReturn;
+        }
+
+        public float conversionLoadParse(string status)
+        {
+            if (status.EndsWith("% load"))
+            {
+                try { return float.Parse(status.Remove(status.Length - 6)) / 100; }
+                catch { return 0; }
+            }
+            else { return 0; }
+        }
+
+
+
+    }
+}


### PR DESCRIPTION
 #1255
ConverterValue.cs not 100% complete yet (need to deal with the rest of the suffixes and maybe add couple more), but here's prototype for handling variable-count converter modules. the ConverterValue struct gives both a way to address specific converter modules and an option to address all of them by calling the same suffixes on it (for single-module case there won't be difference).
Such double-layer system can be useful for handling other cases, like potentially multiple science modules on the same part.
