### PR TITLE
Escape split separator

### DIFF
--- a/src/kOS.Safe/Encapsulation/StringValue.cs
+++ b/src/kOS.Safe/Encapsulation/StringValue.cs
@@ -46,7 +46,7 @@ namespace kOS.Safe.Encapsulation
 
         public bool EndsWith(string s)
         {
-            return internalString.EndsWith(s,true, CultureInfo.CurrentCulture);
+            return internalString.EndsWith(s, StringComparison.OrdinalIgnoreCase);
         }
 
         public int IndexOf(string s)
@@ -93,7 +93,7 @@ namespace kOS.Safe.Encapsulation
 
         public string Replace(string oldString, string newString)
         {
-            return internalString.Replace(oldString, newString);
+            return Regex.Replace(internalString, Regex.Escape(oldString), newString, RegexOptions.IgnoreCase);
         }
 
         public string ToLower()
@@ -108,7 +108,7 @@ namespace kOS.Safe.Encapsulation
 
         public bool StartsWith(string s)
         {
-            return internalString.StartsWith(s, true, CultureInfo.CurrentCulture);
+            return internalString.StartsWith(s, StringComparison.OrdinalIgnoreCase);
         }
 
         public string Trim()
@@ -146,7 +146,7 @@ namespace kOS.Safe.Encapsulation
         // As the regular Split, except returning a ListValue rather than an array.
         public ListValue<string> SplitToList(string separator)
         {
-            string[] split = Regex.Split(internalString, separator, RegexOptions.IgnoreCase);
+            string[] split = Regex.Split(internalString, Regex.Escape(separator), RegexOptions.IgnoreCase);
             return new ListValue<string>(split);
         }
 


### PR DESCRIPTION
Fixes #1270

StringValue.cs
* Call the Regex.Escape method on separator strings when splitting.
This prevents funny results when splitting using regular expression
special characters that most new users won't expect.  For example "."
* Also used Regex and an escaped string in the Replace method for
consistency with case insensitivity through the rest of the string
methods.
* Change EndsWith method to use OrdinalIgnoreCase rather than the
current culture.
* Change StartsWith method to use OrdinalIgnoreCase rather than the
current culture.