### PR TITLE
Fixes 1285 better detection of incomplete command

### DIFF
--- a/src/kOS.Safe/Compilation/KS/KSScript.cs
+++ b/src/kOS.Safe/Compilation/KS/KSScript.cs
@@ -95,40 +95,25 @@ namespace kOS.Safe.Compilation.KS
 
         public override bool IsCommandComplete(string command)
         {
-            // Good FUture Refactor Opportunity:
-            //
-            // It's not good that this is
-            // essentially doing kerboscript-aware syntax thinking
-            // somewhere outside the parser generator TinyPG.  That
-            // puts the same logic in two places of the code, which
-            // is usually a bad thing.  If someone can think of a
-            // better way to query the parser to ask it "is this
-            // statement incomplete?" rather than putting this logic
-            // here, that would be a good opportunity for a refactor.
-            //
-            // The difficulty is that the parser returns "syntax erorr"
-            // the same regardless of whether it's because it's incomplete
-            // or because there's an error.  So we can't say "if parser
-            // doesn't think it's done" wihtout the side effect of it hanging
-            // on syntax errors because it thinks they're "incomplete".            
-
             char[] commandChars = command.ToCharArray();
             int length = commandChars.Length;
-            int openCurlyBrackets = 0;
-            int openParentheses = 0;
             bool inQuotes = false;
             bool inCommentToEoln = false;
+            bool waitForMoreTokens = false;
             char curChar;
             char prevChar = '\0';
-            
+
+            // First, we have to check manually for unterminated string literals because
+            // they are a continuation in the midst of a token, rather than between tokens,
+            // and thus the parser doesn't quite catch them the same way.
             for (int n = 0; n < length; n++)
             {
                 curChar = commandChars[n];
                 switch (curChar)
                 {
-                    // Track if we are in quotes or a comment, which
-                    // should make it bypass the checks for matching
-                    // parentheses and braces:
+                    // Track if we are ina string literal that didn't close,
+                    // and make sure it's not a string literal inside a comment,
+                    // becasue those don't count:
                     case '\"':
                         if (! inCommentToEoln)
                             inQuotes = !(inQuotes);
@@ -141,39 +126,50 @@ namespace kOS.Safe.Compilation.KS
                     case '\r':
                         inCommentToEoln = false;
                         break;
-                        
-                    // match curly brackets:
-                    case '{':
-                        if (!inQuotes && !inCommentToEoln)
-                            openCurlyBrackets++;
-                        break;
-
-                    case '}':
-                        if (!inQuotes && !inCommentToEoln)
-                            openCurlyBrackets--;
-                        break;
-
-                    // match parentheses:
-                    case '(':
-                        if (!inQuotes && !inCommentToEoln)
-                            openParentheses++;
-                        break;
-
-                    case ')':
-                        if (!inQuotes && !inCommentToEoln)
-                            openParentheses--;
-                        break;
                 }
                 prevChar = curChar;
             }
+            
+            // Second, if we aren't in an unterminated literal string, then let
+            // the parser do the rest of the checking by seeing if it reports
+            //    Unexpected Token 'EOF', and looking at what it was expecting instead.
 
-            // Only return true if none of the conditions that
-            // indicate there's more to type are present:            
-            return
-                openCurlyBrackets <= 0 &&
-                openParentheses <= 0   &&
-                (!inQuotes);
+            // - Possible future refactor - 
+            // The string comparison of the human-readable message is the only way
+            // to find out if the error is the exact one we're looking for, which
+            // is what the code below does, and that's a bit fragile.
+            // Making it use a more robust check would first require editing the
+            // TinyPG C# source code and changing the way it encodes a ParseError
+            // so it stores that sort of thing as separate pieces of data in its members.
+            
+            if (!inQuotes)
+            {
+                ParseTree parseTree = parser.Parse(command);
                 
+                foreach (ParseError err in parseTree.Errors)
+                {
+                    System.Console.WriteLine("eraseme:  err msg: " + err.Message);
+                    if (err.Message.StartsWith("Unexpected token 'EOF'"))
+                    {
+                        if (err.Message.Contains("Expected CURLYCLOSE") ||
+                            err.Message.Contains("Expected BRACKETCLOSE"))
+                        {
+                            waitForMoreTokens = true;
+                        }
+                    }
+                    else
+                    {
+                        // If ANY parse errors are NOT of the form "Unexpected Token 'EOF' ... yadda yadda" then that
+                        // automatically means we should fail and not continue regardless of whether or not the other
+                        // parse errors may have indicated a continuation is needed.  We want to let the user see
+                        // the error happen instead.
+                        waitForMoreTokens = false;
+                        break;
+                    }
+                }
+            }
+
+            return (!waitForMoreTokens) && (!inQuotes);
         }
     }
 }

--- a/src/kOS/Screen/Interpreter.cs
+++ b/src/kOS/Screen/Interpreter.cs
@@ -64,6 +64,10 @@ namespace kOS.Screen
             if (key == (char)UnicodeCommand.BREAK)
             {
                 Shared.Cpu.BreakExecution(true);
+                LineBuilder.Remove(0, LineBuilder.Length); // why isn't there a StringBuilder.Clear()?
+
+                NewLine(); // process the now emptied line, to make it do all the updates it normally
+                           // does to the screenbuffers on pressing enter.
             }
 
             if (locked) return false;


### PR DESCRIPTION

Now allows any of the following to be typed on the interpreter command line, with the interpreter being able to detect that a command is in need of continuing rather than just spitting an error:

```
if x = 2 {
   print "two".
}

print ((6 / 2)
  + 5 ).

print "this string
spans several
lines before closing".
```

This problem, that it didn't do this sort of thing right before, was at the heart of what was wrong with #1285 - its 'dumb' string scanner was seeing the parenthesis in the string as a parenthesis in need of continuation and wasn't smart enough to realize it doesn't count when it's inside a string literal like that.
