### PR TITLE
Add ScalarValue structure

### DIFF
--- a/src/kOS.Safe.Test/Structures/ScalarValueTest.cs
+++ b/src/kOS.Safe.Test/Structures/ScalarValueTest.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using kOS.Safe.Encapsulation;
+using NUnit.Framework;
+
+namespace kOS.Safe.Test.Structures
+{
+    [TestFixture]
+    public class ScalarValueTest
+    {
+        [Test]
+        public void CanConvertInt()
+        {
+            int i = 10;
+            var s = ScalarValue.Create(i);
+            Assert.IsTrue(s.IsInt);
+            Assert.IsFalse(s.IsDouble);
+            Assert.AreEqual(i, (int)s);
+        }
+
+        [Test]
+        public void CanConvertDouble()
+        {
+            double d = 3.1415926535897932384626433832795;
+            var s = ScalarValue.Create(d);
+            Assert.IsFalse(s.IsInt);
+            Assert.IsTrue(s.IsDouble);
+            Assert.AreEqual(d, (double)s);
+        }
+
+        // TODO: Uncomment these tests when merged with upstream changes
+        //[Test]
+        //public void CanStructureFromPrimitiveInt()
+        //{
+        //    int i = 10;
+        //    var s = kOS.Safe.Encapsulation.Structure.FromPrimitive(i);
+        //    Assert.AreEqual(i, (ScalarValue)s);
+        //}
+
+        //[Test]
+        //public void CanStructureFromPrimitiveDouble()
+        //{
+        //    double d = 3.1415926535897932384626433832795;
+        //    var s = kOS.Safe.Encapsulation.Structure.FromPrimitive(d);
+        //    Assert.AreEqual(d, (ScalarValue)s, 0d);
+        //}
+
+        //[Test]
+        //public void CanStructureToPrimitiveInt()
+        //{
+        //    int i = 10;
+        //    var s = ScalarValue.Create(i);
+        //    var iTest = kOS.Safe.Encapsulation.Structure.ToPrimitive(s);
+        //    Assert.AreEqual(i, (int)iTest);
+        //}
+
+        //[Test]
+        //public void CanStructureToPrimitiveDouble()
+        //{
+        //    double d = 3.1415926535897932384626433832795;
+        //    var s = ScalarValue.Create(d);
+        //    var dTest = kOS.Safe.Encapsulation.Structure.ToPrimitive(s);
+        //    Assert.AreEqual(d, (double)dTest, 0d);
+        //}
+
+        [Test]
+        public void CanImplicitCastToInt()
+        {
+            int i = 10;
+            var s = ScalarValue.Create(i);
+            int iTest = s;
+            Assert.AreEqual(i, iTest);
+        }
+
+        [Test]
+        public void CanImplicitCastToDouble()
+        {
+            double d = 3.1415926535897932384626433832795;
+            var s = ScalarValue.Create(d);
+            double dTest = s;
+            Assert.AreEqual(d, dTest);
+        }
+
+        [Test]
+        public void CanImplicitCastFromInt()
+        {
+            int i = 10;
+            var s = ScalarValue.Create(i);
+            ScalarValue sTest = i;
+            Assert.AreEqual(s, sTest);
+        }
+
+        [Test]
+        public void CanImplicitCastFromDouble()
+        {
+            double d = 3.1415926535897932384626433832795;
+            var s = ScalarValue.Create(d);
+            ScalarValue sTest = d;
+            Assert.AreEqual(s, sTest);
+        }
+
+        [Test]
+        public void CanAdd()
+        {
+            double d1 = 10.5;
+            double d2 = 5.25;
+            var s1 = ScalarValue.Create(d1);
+            var s2 = ScalarValue.Create(d2);
+            double dResult = d1 + d2;
+            ScalarValue sResult = s1 + s2;
+            Assert.AreEqual(dResult, sResult, 0d);
+        }
+
+        [Test]
+        public void CanAddMixedType()
+        {
+            double d1 = 10.5;
+            int i2 = 5;
+            var s1 = ScalarValue.Create(d1);
+            var s2 = ScalarValue.Create(i2);
+            double dResult = d1 + i2;
+            ScalarValue sResult = s1 + s2;
+            Assert.AreEqual(dResult, sResult, 0d);
+        }
+
+        [Test]
+        public void CanSubtract()
+        {
+            double d1 = 10.5;
+            double d2 = 5.25;
+            var s1 = ScalarValue.Create(d1);
+            var s2 = ScalarValue.Create(d2);
+            double dResult = d1 - d2;
+            ScalarValue sResult = s1 - s2;
+            Assert.AreEqual(dResult, sResult, 0d);
+        }
+
+        [Test]
+        public void CanMultiply()
+        {
+            double d1 = 10.5;
+            double d2 = 5.25;
+            var s1 = ScalarValue.Create(d1);
+            var s2 = ScalarValue.Create(d2);
+            double dResult = d1 * d2;
+            ScalarValue sResult = s1 * s2;
+            Assert.AreEqual(dResult, sResult, 0d);
+        }
+
+        [Test]
+        public void CanDivide()
+        {
+            double d1 = 10.5;
+            double d2 = 5.25;
+            var s1 = ScalarValue.Create(d1);
+            var s2 = ScalarValue.Create(d2);
+            double dResult = d1 / d2;
+            ScalarValue sResult = s1 / s2;
+            Assert.AreEqual(dResult, sResult, 0d);
+        }
+
+        [Test]
+        public void CanPower()
+        {
+            double d1 = 10.5;
+            double d2 = 5.25;
+            var s1 = ScalarValue.Create(d1);
+            var s2 = ScalarValue.Create(d2);
+            double dResult = Math.Pow(d1, d2);
+            ScalarValue sResult = s1 ^ s2;
+            Assert.AreEqual(dResult, sResult, 0d);
+        }
+
+        [Test]
+        public void CanModulus()
+        {
+            double d1 = 10.5;
+            double d2 = 5.25;
+            var s1 = ScalarValue.Create(d1);
+            var s2 = ScalarValue.Create(d2);
+            double dResult = d1 % d2;
+            ScalarValue sResult = s1 % s2;
+            Assert.AreEqual(dResult, sResult, 0d);
+        }
+
+        [Test]
+        public void CanAddAsString()
+        {
+            double d1 = 10.5;
+            string string1 = "foo";
+            var str1 = new StringValue(string1);
+            var s1 = ScalarValue.Create(d1);
+            var strResult = str1 + s1;
+            string stringResult = string1 + d1.ToString();
+            Assert.AreEqual(stringResult, (string)strResult);
+        }
+    }
+}

--- a/src/kOS.Safe.Test/kOS.Safe.Test.csproj
+++ b/src/kOS.Safe.Test/kOS.Safe.Test.csproj
@@ -46,6 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Collections\MixedCollectionPrintingTest.cs" />
+    <Compile Include="Structures\ScalarValueTest.cs" />
     <Compile Include="Structures\StringValueTest.cs" />
     <Compile Include="Structure\ClampSetSuffixTest.cs" />
     <Compile Include="Collections\LexiconTest.cs" />

--- a/src/kOS.Safe/Encapsulation/ScalarDoubleValue.cs
+++ b/src/kOS.Safe/Encapsulation/ScalarDoubleValue.cs
@@ -1,0 +1,20 @@
+﻿namespace kOS.Safe.Encapsulation
+{
+    public class ScalarDoubleValue : ScalarValue
+    {
+        public override bool IsDouble
+        {
+            get { return true; }
+        }
+
+        public override bool IsInt
+        {
+            get { return false; }
+        }
+
+        public ScalarDoubleValue(double value)
+        {
+            Value = value;
+        }
+    }
+}

--- a/src/kOS.Safe/Encapsulation/ScalarIntValue.cs
+++ b/src/kOS.Safe/Encapsulation/ScalarIntValue.cs
@@ -1,0 +1,20 @@
+﻿namespace kOS.Safe.Encapsulation
+{
+    public class ScalarIntValue : ScalarValue
+    {
+        public override bool IsDouble
+        {
+            get { return false; }
+        }
+
+        public override bool IsInt
+        {
+            get { return true; }
+        }
+
+        public ScalarIntValue(int value)
+        {
+            Value = value;
+        }
+    }
+}

--- a/src/kOS.Safe/Encapsulation/ScalarValue.cs
+++ b/src/kOS.Safe/Encapsulation/ScalarValue.cs
@@ -424,11 +424,11 @@ namespace kOS.Safe.Encapsulation
     {
         public override bool IsDouble
         {
-            get { return true; }
+            get { return false; }
         }
         public override bool IsInt
         {
-            get { return false; }
+            get { return true; }
         }
 
         public ScalarIntValue(int value)

--- a/src/kOS.Safe/Encapsulation/ScalarValue.cs
+++ b/src/kOS.Safe/Encapsulation/ScalarValue.cs
@@ -162,7 +162,7 @@ namespace kOS.Safe.Encapsulation
             return new ScalarValue(val1.GetDoubleValue() / val2.GetDoubleValue());
         }
 
-        public static ScalarValue Modulous(ScalarValue val1, ScalarValue val2)
+        public static ScalarValue Modulus(ScalarValue val1, ScalarValue val2)
         {
             if (val1.IsInt && val2.IsInt)
             {
@@ -267,7 +267,7 @@ namespace kOS.Safe.Encapsulation
 
         public static ScalarValue operator %(ScalarValue val1, ScalarValue val2)
         {
-            return Modulous(val1, val2);
+            return Modulus(val1, val2);
         }
 
         public static ScalarValue operator ^(ScalarValue val1, ScalarValue val2)

--- a/src/kOS.Safe/Encapsulation/ScalarValue.cs
+++ b/src/kOS.Safe/Encapsulation/ScalarValue.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Exceptions;
+using System.Reflection;
 
 namespace kOS.Safe.Encapsulation
 {
@@ -97,6 +98,10 @@ namespace kOS.Safe.Encapsulation
             ScalarValue val = obj as ScalarValue;
             if (val != null)
             {
+                if (this.IsInt && val.IsDouble)
+                {
+                    return false;
+                }
                 if (this.IsInt && val.IsInt)
                 {
                     return this.GetIntValue() == val.GetIntValue();
@@ -105,7 +110,8 @@ namespace kOS.Safe.Encapsulation
             }
             else
             {
-                var converter = typeof(ScalarValue).GetMethod("op_Implicit", new[] { obj.GetType() });
+                BindingFlags flags = BindingFlags.ExactBinding | BindingFlags.Static | BindingFlags.Public;
+                var converter = typeof(ScalarValue).GetMethod("op_Implicit", flags, null, new[] { obj.GetType() }, null);
                 if (converter != null)
                 {
                     val = (ScalarValue)converter.Invoke(null, new[] { obj });

--- a/src/kOS.Safe/Encapsulation/ScalarValue.cs
+++ b/src/kOS.Safe/Encapsulation/ScalarValue.cs
@@ -36,9 +36,9 @@ namespace kOS.Safe.Encapsulation
 
         public void InitializeSuffixes()
         {
-            AddSuffix("ISINT", new Suffix<bool>(() => IsInt));
-            AddSuffix("ISDOUBLE", new Suffix<bool>(() => IsDouble));
-            AddSuffix("ISVALID", new Suffix<bool>(() => IsValid));
+            // TODO: Commented suffixes until the introduction of kOS types to the user.
+            //AddSuffix("ISINTEGER", new Suffix<bool>(() => IsInt));
+            //AddSuffix("ISVALID", new Suffix<bool>(() => IsValid));
         }
 
         public static ScalarValue Create(object value)

--- a/src/kOS.Safe/Encapsulation/ScalarValue.cs
+++ b/src/kOS.Safe/Encapsulation/ScalarValue.cs
@@ -94,19 +94,37 @@ namespace kOS.Safe.Encapsulation
         public override bool Equals(object obj)
         {
             if (obj == null) return false;
-            if (obj is ScalarValue)
+            ScalarValue val = obj as ScalarValue;
+            if (val != null)
             {
-                ScalarValue val = obj as ScalarValue;
-                if (val != null)
+                if (this.IsInt && val.IsInt)
                 {
-                    if (this.IsInt && val.IsInt)
-                    {
-                        return this.GetIntValue() == val.GetIntValue();
-                    }
-                    return this.GetDoubleValue() == val.GetDoubleValue();
+                    return this.GetIntValue() == val.GetIntValue();
+                }
+                return this.GetDoubleValue() == val.GetDoubleValue();
+            }
+            else
+            {
+                var converter = typeof(ScalarValue).GetMethod("op_Implicit", new[] { obj.GetType() });
+                if (converter != null)
+                {
+                    val = (ScalarValue)converter.Invoke(null, new[] { obj });
+                    if (Value == val.Value) return true;
                 }
             }
             return false;
+        }
+
+        public static bool NullSafeEquals(object obj1, object obj2)
+        {
+            if (obj1 == null)
+            {
+                if (obj2 == null) return true;
+                return false;
+            }
+            if (obj2 == null) return false;
+            ScalarValue val1 = ScalarValue.Create(obj1);
+            return val1.Equals(obj2);
         }
 
         public override int GetHashCode()
@@ -265,32 +283,12 @@ namespace kOS.Safe.Encapsulation
 
         public static bool operator ==(ScalarValue val1, ScalarValue val2)
         {
-            return val1.Equals(val2);
-        }
-
-        public static bool operator ==(ScalarValue val1, object val2)
-        {
-            return val1.Equals(val2);
-        }
-
-        public static bool operator ==(object val1, ScalarValue val2)
-        {
-            return val2.Equals(val1);
+            return NullSafeEquals(val1, val2);
         }
 
         public static bool operator !=(ScalarValue val1, ScalarValue val2)
         {
-            return !val1.Equals(val2);
-        }
-
-        public static bool operator !=(ScalarValue val1, object val2)
-        {
-            return !val1.Equals(val2);
-        }
-
-        public static bool operator !=(object val1, ScalarValue val2)
-        {
-            return !val2.Equals(val1);
+            return !NullSafeEquals(val1, val2);
         }
 
         public static bool operator >(ScalarValue val1, ScalarValue val2)

--- a/src/kOS.Safe/Encapsulation/ScalarValue.cs
+++ b/src/kOS.Safe/Encapsulation/ScalarValue.cs
@@ -7,7 +7,7 @@ namespace kOS.Safe.Encapsulation
 {
     abstract public class ScalarValue : Structure, IConvertible
     {
-        protected object internalValue;
+        private object internalValue;
 
         abstract public bool IsInt { get; }
 
@@ -28,7 +28,17 @@ namespace kOS.Safe.Encapsulation
             }
         }
 
-        public object Value { get { return internalValue; } }
+        public object Value
+        {
+            get
+            {
+                return internalValue;
+            }
+            protected set
+            {
+                internalValue = value;
+            }
+        }
 
         protected ScalarValue()
         {
@@ -421,40 +431,6 @@ namespace kOS.Safe.Encapsulation
         ulong IConvertible.ToUInt64(IFormatProvider provider)
         {
             return Convert.ToUInt64(GetIntValue());
-        }
-    }
-
-    public class ScalarIntValue : ScalarValue
-    {
-        public override bool IsDouble
-        {
-            get { return false; }
-        }
-        public override bool IsInt
-        {
-            get { return true; }
-        }
-
-        public ScalarIntValue(int value)
-        {
-            internalValue = value;
-        }
-    }
-
-    public class ScalarDoubleValue : ScalarValue
-    {
-        public override bool IsDouble
-        {
-            get { return true; }
-        }
-        public override bool IsInt
-        {
-            get { return false; }
-        }
-
-        public ScalarDoubleValue(double value)
-        {
-            internalValue = value;
         }
     }
 }

--- a/src/kOS.Safe/Encapsulation/ScalarValue.cs
+++ b/src/kOS.Safe/Encapsulation/ScalarValue.cs
@@ -93,14 +93,18 @@ namespace kOS.Safe.Encapsulation
 
         public override bool Equals(object obj)
         {
-            ScalarValue val = obj as ScalarValue;
-            if (val != null)
+            if (obj == null) return false;
+            if (obj is ScalarValue)
             {
-                if (this.IsInt && val.IsInt)
+                ScalarValue val = obj as ScalarValue;
+                if (val != null)
                 {
-                    return this.GetIntValue() == val.GetIntValue();
+                    if (this.IsInt && val.IsInt)
+                    {
+                        return this.GetIntValue() == val.GetIntValue();
+                    }
+                    return this.GetDoubleValue() == val.GetDoubleValue();
                 }
-                return this.GetDoubleValue() == val.GetDoubleValue();
             }
             return false;
         }

--- a/src/kOS.Safe/Encapsulation/ScalarValue.cs
+++ b/src/kOS.Safe/Encapsulation/ScalarValue.cs
@@ -1,0 +1,434 @@
+﻿using System;
+using kOS.Safe.Encapsulation.Suffixes;
+using kOS.Safe.Exceptions;
+
+namespace kOS.Safe.Encapsulation
+{
+    public class ScalarValue : Structure, IConvertible
+    {
+        private int? internalInt;
+        private double? internalDouble;
+
+        public bool IsInt { get { return internalInt.HasValue; } }
+
+        public bool IsDouble { get { return internalDouble.HasValue; } }
+
+        public bool IsValid
+        {
+            get
+            {
+                if (internalInt.HasValue) return true;
+                else if (internalDouble.HasValue)
+                {
+                    if (double.IsInfinity(internalDouble.Value) || double.IsNaN(internalDouble.Value)) return false;
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        public object Value
+        {
+            get
+            {
+                if (IsInt) return internalInt.Value;
+                if (IsDouble) return internalDouble.Value;
+                throw new kOS.Safe.Exceptions.KOSException("Scalar value contains no double or int value");
+            }
+        }
+
+        public ScalarValue(object value)
+            : base()
+        {
+            SetValue(value);
+        }
+
+        public void InitializeSuffixes()
+        {
+            AddSuffix("ISINT", new Suffix<bool>(() => IsInt));
+            AddSuffix("ISDOUBLE", new Suffix<bool>(() => IsDouble));
+            AddSuffix("ISVALID", new Suffix<bool>(() => IsValid));
+        }
+
+        protected void SetValue(object value)
+        {
+            if (value is float)
+                value = Convert.ToDouble(value);
+            if (value is double)
+            {
+                bool inBounds = Int32.MinValue < (double)value && (double)value < Int32.MaxValue;
+                if (inBounds && !double.IsNaN((double)value))
+                {
+                    // I still don't quite get what this part is doing... I'm thinking of rewriting it using modulous instead
+                    int intPart = Convert.ToInt32(value);
+                    if ((double)value == intPart)
+                    {
+                        internalInt = intPart;
+                        internalDouble = null;
+                        return;
+                    }
+                }
+                internalDouble = (double)value;
+                internalInt = null;
+            }
+            else if (value is int)
+            {
+                internalInt = (int)value;
+                internalDouble = null;
+            }
+            else if (value is ScalarValue)
+            {
+                SetValue(((ScalarValue)value).Value);
+            }
+            else
+            {
+                throw new kOS.Safe.Exceptions.KOSException(string.Format("Failed to set scalar value.  Passed type {0}, expected Double or Int", value.GetType().Name));
+            }
+        }
+
+        public int GetIntValue()
+        {
+            if (internalInt.HasValue)
+            {
+                return internalInt.Value;
+            }
+            else
+            {
+                return Convert.ToInt32(internalDouble);
+            }
+        }
+
+        public double GetDoubleValue()
+        {
+            if (IsDouble) return internalDouble.Value;
+            if (IsInt) return Convert.ToDouble(internalInt.Value);
+            throw new kOS.Safe.Exceptions.KOSException("Scalar value contains no double or int value");
+        }
+
+        public override string ToString()
+        {
+            if (IsInt) return GetIntValue().ToString();
+            else if (IsDouble) return GetDoubleValue().ToString();
+            return "NaN";
+        }
+
+        public override bool Equals(object obj)
+        {
+            ScalarValue val = obj as ScalarValue;
+            if (val != null)
+            {
+                if (this.IsInt && val.IsInt)
+                {
+                    return this.GetIntValue() == val.GetIntValue();
+                }
+                return this.GetDoubleValue() == val.GetDoubleValue();
+            }
+            return false;
+        }
+
+        public static ScalarValue Add(ScalarValue val1, ScalarValue val2)
+        {
+            if (val1.IsInt && val2.IsInt)
+            {
+                return new ScalarValue(val1.GetIntValue() + val2.GetIntValue());
+            }
+            return new ScalarValue(val1.GetDoubleValue() + val2.GetDoubleValue());
+        }
+
+        public static ScalarValue Subtract(ScalarValue val1, ScalarValue val2)
+        {
+            if (val1.IsInt && val2.IsInt)
+            {
+                return new ScalarValue(val1.GetIntValue() - val2.GetIntValue());
+            }
+            return new ScalarValue(val1.GetDoubleValue() - val2.GetDoubleValue());
+        }
+
+        public static ScalarValue Multiply(ScalarValue val1, ScalarValue val2)
+        {
+            if (val1.IsInt && val2.IsInt)
+            {
+                return new ScalarValue(val1.GetIntValue() * val2.GetIntValue());
+            }
+            return new ScalarValue(val1.GetDoubleValue() * val2.GetDoubleValue());
+        }
+
+        public static ScalarValue Divide(ScalarValue val1, ScalarValue val2)
+        {
+            if (val1.IsInt && val2.IsInt)
+            {
+                return new ScalarValue(val1.GetIntValue() / val2.GetIntValue());
+            }
+            return new ScalarValue(val1.GetDoubleValue() / val2.GetDoubleValue());
+        }
+
+        public static ScalarValue Modulous(ScalarValue val1, ScalarValue val2)
+        {
+            if (val1.IsInt && val2.IsInt)
+            {
+                return new ScalarValue(val1.GetIntValue() % val2.GetIntValue());
+            }
+            return new ScalarValue(val1.GetDoubleValue() % val2.GetDoubleValue());
+        }
+
+        public static ScalarValue Power(ScalarValue val1, ScalarValue val2)
+        {
+            if (val1.IsInt && val2.IsInt)
+            {
+                return new ScalarValue(Math.Pow(val1.GetIntValue(), val2.GetIntValue()));
+            }
+            return new ScalarValue(Math.Pow(val1.GetDoubleValue(), val2.GetDoubleValue()));
+        }
+
+        public static bool GreaterThan(ScalarValue val1, ScalarValue val2)
+        {
+            if (val1.IsInt && val2.IsInt)
+            {
+                return val1.GetIntValue() > val2.GetIntValue();
+            }
+            return val1.GetDoubleValue() > val2.GetDoubleValue();
+        }
+
+        public static bool LessThan(ScalarValue val1, ScalarValue val2)
+        {
+            if (val1.IsInt && val2.IsInt)
+            {
+                return val1.GetIntValue() < val2.GetIntValue();
+            }
+            return val1.GetDoubleValue() < val2.GetDoubleValue();
+        }
+
+        public static ScalarValue Max(ScalarValue val1, ScalarValue val2)
+        {
+            if (val1.IsInt && val2.IsInt)
+            {
+                return new ScalarValue(Math.Max(val1.GetIntValue(), val2.GetIntValue()));
+            }
+            return new ScalarValue(Math.Max(val1.GetDoubleValue(), val2.GetDoubleValue()));
+        }
+
+        public static ScalarValue Min(ScalarValue val1, ScalarValue val2)
+        {
+            if (val1.IsInt && val2.IsInt)
+            {
+                return new ScalarValue(Math.Min(val1.GetIntValue(), val2.GetIntValue()));
+            }
+            return new ScalarValue(Math.Min(val1.GetDoubleValue(), val2.GetDoubleValue()));
+        }
+
+        public static ScalarValue Abs(ScalarValue val)
+        {
+            if (val.IsInt)
+            {
+                return new ScalarValue(Math.Abs(val.GetIntValue()));
+            }
+            return new ScalarValue(Math.Abs(val.GetDoubleValue()));
+        }
+
+        public static ScalarValue operator +(ScalarValue val1, ScalarValue val2)
+        {
+            return Add(val1, val2);
+        }
+
+        public static ScalarValue operator ++(ScalarValue val)
+        {
+            return new ScalarValue(Add(val, 1));
+        }
+
+        public static ScalarValue operator -(ScalarValue val1, ScalarValue val2)
+        {
+            return Subtract(val1, val2);
+        }
+
+        public static ScalarValue operator --(ScalarValue val)
+        {
+            return new ScalarValue(Subtract(val, 1));
+        }
+
+        public static ScalarValue operator *(ScalarValue val1, ScalarValue val2)
+        {
+            return Multiply(val1, val2);
+        }
+
+        public static ScalarValue operator +(ScalarValue val)
+        {
+            return new ScalarValue(val.Value);
+        }
+
+        public static ScalarValue operator -(ScalarValue val)
+        {
+            return new ScalarValue(Multiply(val, -1));
+        }
+
+        public static ScalarValue operator /(ScalarValue val1, ScalarValue val2)
+        {
+            return Divide(val1, val2);
+        }
+
+        public static ScalarValue operator %(ScalarValue val1, ScalarValue val2)
+        {
+            return Modulous(val1, val2);
+        }
+
+        public static ScalarValue operator ^(ScalarValue val1, ScalarValue val2)
+        {
+            return Power(val1, val2);
+        }
+
+        public static bool operator ==(ScalarValue val1, ScalarValue val2)
+        {
+            return val1.Equals(val2);
+        }
+
+        public static bool operator ==(ScalarValue val1, object val2)
+        {
+            return val1.Equals(val2);
+        }
+
+        public static bool operator ==(object val1, ScalarValue val2)
+        {
+            return val2.Equals(val1);
+        }
+
+        public static bool operator !=(ScalarValue val1, ScalarValue val2)
+        {
+            return !val1.Equals(val2);
+        }
+
+        public static bool operator !=(ScalarValue val1, object val2)
+        {
+            return !val1.Equals(val2);
+        }
+
+        public static bool operator !=(object val1, ScalarValue val2)
+        {
+            return !val2.Equals(val1);
+        }
+
+        public static bool operator >(ScalarValue val1, ScalarValue val2)
+        {
+            return GreaterThan(val1, val2);
+        }
+
+        public static bool operator <(ScalarValue val1, ScalarValue val2)
+        {
+            return LessThan(val1, val2);
+        }
+
+        public static bool operator >=(ScalarValue val1, ScalarValue val2)
+        {
+            return GreaterThan(val1, val2) || val1.Equals(val2);
+        }
+
+        public static bool operator <=(ScalarValue val1, ScalarValue val2)
+        {
+            return LessThan(val1, val2) || val1.Equals(val2);
+        }
+
+        public static implicit operator ScalarValue(int val)
+        {
+            return new ScalarValue(val);
+        }
+
+        public static implicit operator ScalarValue(double val)
+        {
+            return new ScalarValue(val);
+        }
+
+        public static implicit operator int(ScalarValue val)
+        {
+            return val.GetIntValue();
+        }
+
+        public static implicit operator double(ScalarValue val)
+        {
+            return val.GetDoubleValue();
+        }
+
+        TypeCode IConvertible.GetTypeCode()
+        {
+            return TypeCode.Object;
+        }
+
+        bool IConvertible.ToBoolean(IFormatProvider provider)
+        {
+            if (GetIntValue() == 0) return false;
+            return true;
+        }
+
+        byte IConvertible.ToByte(IFormatProvider provider)
+        {
+            throw new KOSCastException(typeof(ScalarValue), typeof(byte));
+        }
+
+        char IConvertible.ToChar(IFormatProvider provider)
+        {
+            throw new KOSCastException(typeof(ScalarValue), typeof(char));
+        }
+
+        DateTime IConvertible.ToDateTime(IFormatProvider provider)
+        {
+            throw new KOSCastException(typeof(ScalarValue), typeof(DateTime));
+        }
+
+        decimal IConvertible.ToDecimal(IFormatProvider provider)
+        {
+            return Convert.ToDecimal(GetDoubleValue());
+        }
+
+        double IConvertible.ToDouble(IFormatProvider provider)
+        {
+            return GetDoubleValue();
+        }
+
+        short IConvertible.ToInt16(IFormatProvider provider)
+        {
+            return Convert.ToInt16(GetIntValue());
+        }
+
+        int IConvertible.ToInt32(IFormatProvider provider)
+        {
+            return GetIntValue();
+        }
+
+        long IConvertible.ToInt64(IFormatProvider provider)
+        {
+            return Convert.ToInt64(GetIntValue());
+        }
+
+        sbyte IConvertible.ToSByte(IFormatProvider provider)
+        {
+            throw new KOSCastException(typeof(ScalarValue), typeof(SByte));
+        }
+
+        float IConvertible.ToSingle(IFormatProvider provider)
+        {
+            throw new KOSCastException(typeof(ScalarValue), typeof(Single));
+        }
+
+        string IConvertible.ToString(IFormatProvider provider)
+        {
+            return ToString();
+        }
+
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider)
+        {
+            return Convert.ChangeType(GetDoubleValue(), conversionType);
+        }
+
+        ushort IConvertible.ToUInt16(IFormatProvider provider)
+        {
+            return Convert.ToUInt16(GetIntValue());
+        }
+
+        uint IConvertible.ToUInt32(IFormatProvider provider)
+        {
+            return Convert.ToUInt32(GetIntValue());
+        }
+
+        ulong IConvertible.ToUInt64(IFormatProvider provider)
+        {
+            return Convert.ToUInt64(GetIntValue());
+        }
+    }
+}

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Encapsulation\ListValue.cs" />
     <Compile Include="Encapsulation\Part\IModuleEngine.cs" />
     <Compile Include="Encapsulation\PIDLoop.cs" />
+    <Compile Include="Encapsulation\ScalarValue.cs" />
     <Compile Include="Encapsulation\Structure.cs" />
     <Compile Include="Encapsulation\StringValue.cs" />
     <Compile Include="Encapsulation\Suffixes\ClampSetSuffix.cs" />

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -80,6 +80,8 @@
     <Compile Include="Encapsulation\ListValue.cs" />
     <Compile Include="Encapsulation\Part\IModuleEngine.cs" />
     <Compile Include="Encapsulation\PIDLoop.cs" />
+    <Compile Include="Encapsulation\ScalarDoubleValue.cs" />
+    <Compile Include="Encapsulation\ScalarIntValue.cs" />
     <Compile Include="Encapsulation\ScalarValue.cs" />
     <Compile Include="Encapsulation\Structure.cs" />
     <Compile Include="Encapsulation\StringValue.cs" />


### PR DESCRIPTION
ScalarValue.cs
* New class to encapsulate number types (int, double, float)
* Class will implicitly convert to both int and double types
* Implements IConvertible to enable Convert.ToDouble and the like to work
* Provide access to the int, double, and validity information
* ISVALID provides a way for users to disable number safe mode and monitor safety of numbers themselves.
* Implement applicable operators for manipulation and equality testing
kOS.Safe.csproj
* Add reference to ScalarValue.cs