### PR TITLE
Fixes #1313 (waypoints).

### DIFF
--- a/src/kOS/Function/Suffixed.cs
+++ b/src/kOS/Function/Suffixed.cs
@@ -478,7 +478,7 @@ namespace kOS.Function
             // exist yet either.  (The base game seems not to instance one until the
             // first time a contract with a waypoint is created).
             if (wpm == null)
-                throw new KOSInvalidArgumentException("waypoint", "\""+pointName+"\"", "no waypoints existl");
+                throw new KOSInvalidArgumentException("waypoint", "\""+pointName+"\"", "no waypoints exist");
             
             string baseName;
             int index;

--- a/src/kOS/Suffixed/WaypointValue.cs
+++ b/src/kOS/Suffixed/WaypointValue.cs
@@ -19,12 +19,6 @@ namespace kOS.Suffixed
             WrappedWaypoint = wayPoint;
             Shared = shared;
             InitializeSuffixes();
-
-            // greekMap is static, so whichever waypoint instance's constructor happens to
-            // get called first will make it, and from then on other waypoints don't need to
-            // keep re-initializing it:
-            if (greekMap == null)
-                InitializeGreekMap();
         }
 
         private void InitializeSuffixes()
@@ -128,10 +122,18 @@ namespace kOS.Suffixed
         /// </summary>
         /// <param name="greekLetterName">string name to check.  Case insensitively.</param>
         /// <param name="index">integer position in alphabet.  -1 if no match.</param>
-        /// <param name="baseName">the name after the greek suffix has been stripped off, if there is one.</param>
+        /// <param name="baseName">the name after the last term has been stripped off, if there are
+        /// space separated terms. Note that if the return value of this method is false, this
+        /// shouldn't be used and you should stick with the original full name.</param>
         /// <returns>true if there was a greek letter suffix</returns>
         public static bool GreekToInteger(string greekLetterName, out int index, out string baseName )
         {
+            // greekMap is static, and we only need to populate it once in
+            // the lifetime of the KSP process.  We'll do so the first time
+            // this method (the only one that uses it) gets called:
+            if (greekMap == null)
+                InitializeGreekMap();
+
             // Get lastmost word (or whole string if there's no spaces):
             int lastSpace = greekLetterName.LastIndexOf(' ');
             string lastTerm;


### PR DESCRIPTION
In testing this I also found a longstanding bug
that we never noticed before, in which it fails
to find a hit when the name does NOT use a greek
letter like "alpha" or "beta", but *does* contain
a space in the contract name.

i.e. like so:

Waypoint("apple") finds a waypoint called "apple"
correctly.

Waypoint("apple gamma") finds a waypoint called
"apple gamma" correctly, by stripping off the word
"gamma" and replacing it with the information that
this is waypoint index 2 of the set of waypoints
called "apple".

But Waypoint("apple lemon pear") fails.  It has spaces but
NOT because it has a greek letter suffix.  What the code
was doing was treating it like the last term was a
greek letter and stripping it whether it really was or not,
so it failed to find the waypoint because it looked for
it by the name "apple lemon".

This was fixed by this PR as well as the original problem
mentioned in the issue about the error message.