### PR TITLE
Use ToString() when a type is not serializable

### DIFF
--- a/src/kOS.Safe/Serialization/SafeSerializationMgr.cs
+++ b/src/kOS.Safe/Serialization/SafeSerializationMgr.cs
@@ -26,12 +26,9 @@ namespace kOS.Safe.Serialization
                 if (dump != null)
                 {
                     dumped[key] = Dump(dump, includeType);
-                } else if (IsValue(dumped[key]))
+                } else if (!IsValue(dumped[key]))
                 {
-                    dumped[key] = dumped[key];
-                } else
-                {
-                    throw new KOSException("This type can't be serialized: " + dumped[key].GetType().Name);
+                    dumped[key] = dumped[key].ToString();
                 }
             }
 


### PR DESCRIPTION
Fixes #1318 