### PR TITLE
Fixes #1314, removing the THRUSTLIMIT increment.

### DIFF
--- a/doc/source/structures/vessels/engine.rst
+++ b/doc/source/structures/vessels/engine.rst
@@ -104,7 +104,23 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
     :access: Get/Set
     :type: scalar (%)
 
-    If this an engine with a thrust limiter (tweakable) enabled, what percentage is it limited to?
+    If this an engine with a thrust limiter (tweakable) enabled, what
+    percentage is it limited to?  Note that this is expressed as a 
+    percentage, not a simple 0..1 coefficient.  e.g. To set thrustlimit
+    to half, you use a value of 50.0, not 0.5.
+
+    This value is not allowed to go outside the range [0..100].  If you
+    attempt to do so, it will be clamped down into the allowed range.
+
+    Note that although a kerboscript is allowed to set the value to a
+    very precise number (for example 10.5123), the stock in-game display
+    widget that pops up when you right-click the engine will automatically
+    round it to the nearest 0.5 whenever you open the panel.  So if you
+    do something like ``set ship:part[20]:thrustlimit to 10.5123.`` in
+    your script, then look at the rightclick menu for the engine, the very
+    act of just looking at the menu will cause it to become 10.5 instead 
+    of 10.5123.  There isn't much that kOS can to to change this.  It's a
+    user interface decision baked into the stock game.
 
 .. _engine_MAXTHRUST:
 

--- a/src/kOS/Suffixed/Part/EngineValue.cs
+++ b/src/kOS/Suffixed/Part/EngineValue.cs
@@ -20,7 +20,10 @@ namespace kOS.Suffixed.Part
         {
             AddSuffix("ACTIVATE", new NoArgsSuffix(() => engine.Activate()));
             AddSuffix("SHUTDOWN", new NoArgsSuffix(() => engine.Shutdown()));
-            AddSuffix("THRUSTLIMIT", new ClampSetSuffix<float>(() => engine.ThrustPercentage, value => engine.ThrustPercentage = value, 0, 100, 0.5f));
+            AddSuffix("THRUSTLIMIT", new ClampSetSuffix<float>(() => engine.ThrustPercentage,
+                                                          value => engine.ThrustPercentage = value,
+                                                          0f, 100f, 0f,
+                                                          "thrust limit percentage for this engine"));
             AddSuffix("MAXTHRUST", new Suffix<float>(() => engine.MaxThrust));
             AddSuffix("THRUST", new Suffix<float>(() => engine.FinalThrust));
             AddSuffix("FUELFLOW", new Suffix<float>(() => engine.FuelFlow));


### PR DESCRIPTION
As per the discussion in that issue, it makes little sense to
limit THRUSTLIMIT to the values the user interface allows when
we aren't doing the same thing with THROTTLE.  If you can have
a THROTTLE as precise as 0.1234 when the user interface makes that
impossible manually, then you should be able to do the same with the
THRUSTLIMIT.