### PR TITLE
Fixes #1283 : better msg for KOSCompileException

### DIFF
--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -85,27 +85,11 @@ namespace kOS.Safe.Compilation.KS
             
             ++context.NumCompilesSoFar;
 
-            try
+            if (tree.Nodes.Count > 0)
             {
-                if (tree.Nodes.Count > 0)
-                {
-                    PreProcess(tree);
-                    CompileProgram(tree);
-                }
+                PreProcess(tree);
+                CompileProgram(tree);
             }
-            catch (KOSException kosException)
-            {
-                if (lastNode != null)
-                {
-                    throw;  // TODO something more sophisticated will go here that will
-                    // attach source/line information to the exception before throwing it upward.
-                    // that's why this seemingly pointless "catch and then throw again" is here.
-                }
-                SafeHouse.Logger.Log("Exception in Compiler: " + kosException.Message);
-                SafeHouse.Logger.Log(kosException.StackTrace);
-                throw;  // throw it up in addition to logging the stack trace, so the kOS terminal will also give the user some message.
-            }
-                        
             return part;
         }
 
@@ -124,31 +108,45 @@ namespace kOS.Safe.Compilation.KS
         /// <summary>
         /// Set the current line/column info and potentially also make a helpful
         /// debug trace useful when making syntax changes.
-        /// 
         /// </summary>
-        /// <returns>true if a line number was found in this node.  mostly used for internal recursion
-        /// and can be safely ignored when this is called.</returns>
-        private bool NodeStartHousekeeping(ParseNode node)
+        private void NodeStartHousekeeping(ParseNode node)
         {
             if (node == null) { throw new ArgumentNullException("node"); }
 
             if (TRACE_PARSE)
                 SafeHouse.Logger.Log("traceParse: visiting node: " + node.Token.Type.ToString() + ", " + node.Token.Text);
 
+            LineCol location = GetLineCol(node);
+            lastLine = location.Line;
+            lastColumn = location.Col;
+        }
+        
+        /// <summary>
+        /// Get a line number and column for a given parse node.  Handles the
+        /// fact that TinyPG does not provide line and col information for all
+        /// nodes - just the terminals.  This means if you, say, ask for the
+        /// line or column of a complex node like an expression, you get the bogus answer 0,0 back
+        /// from TinyPG normally.  This method performes a leftmost walk of the
+        /// parse tree to get the first instance where a token exists with actual
+        /// line and column information populated, and returns that.
+        /// </summary>
+        /// <param name="node">The node to get the line number for</param>
+        /// <returns>line and column pair of the firstmost terminal within the parse node</returns>
+        private LineCol GetLineCol(ParseNode node)
+        {
             if (node.Token == null || node.Token.Line <= 0)
             {
-                // Only those nodes which are primitive tokens will have line number
-                // information.  So perform a leftmost search of the subtree of nodes
-                // until a node with a token with a line number is found:
-                return node.Nodes.Any(NodeStartHousekeeping);
+                foreach (ParseNode child in node.Nodes)
+                {
+                    LineCol candidate = GetLineCol(child);
+                    if (candidate.Line >= 0)
+                        return candidate;
+                }
             }
 
-            lastLine = (short)(node.Token.Line + (startLineNum - 1));
-            lastColumn = (short)(node.Token.Column);
-            return true;
-
+            return new LineCol( (short)(node.Token.Line + (startLineNum - 1)), (short)(node.Token.Column) );
         }
-
+        
         private Opcode AddOpcode(Opcode opcode, string destinationLabel)
         {
             opcode.Label = GetNextLabel(true);
@@ -322,14 +320,16 @@ namespace kOS.Safe.Compilation.KS
             }
             
             // These probably can't happen because the parser would have barfed before it got to this method:
+            int line = node.Token.Line;
+            int col = node.Token.Column;
             if (initBlock == null)
-                throw new KOSCompileException("Missing FROM block in FROM loop.");
+                throw new KOSCompileException(line, col, "Missing FROM block in FROM loop.");
             if (checkExpression == null || untilTokenNode == null)
-                throw new KOSCompileException("Missing UNTIL check expression in FROM loop.");
+                throw new KOSCompileException(line, col, "Missing UNTIL check expression in FROM loop.");
             if (stepBlock == null)
-                throw new KOSCompileException("Missing STEP block in FROM loop.");
+                throw new KOSCompileException(line, col, "Missing STEP block in FROM loop.");
             if (doBlock == null)
-                throw new KOSCompileException("Missing loop body (DO block) in FROM loop.");
+                throw new KOSCompileException(line, col, "Missing loop body (DO block) in FROM loop.");
             
             // Append the step instructions to the tail end of the body block's instructions:
             foreach (ParseNode child in stepBlock.Nodes)
@@ -2225,7 +2225,10 @@ namespace kOS.Safe.Compilation.KS
                     if (isOptionalParam)
                     {
                         if (sawMandatoryParam)
-                            throw new KOSDefaultParamNotAtEndException();
+                        {
+                            LineCol location = GetLineCol(node);
+                            throw new KOSDefaultParamNotAtEndException(location.Line, location.Col);
+                        }
 
                         i -= 2; // skip back a bit further to pass over the extra terms a defaulter has.
                     }
@@ -2464,7 +2467,7 @@ namespace kOS.Safe.Compilation.KS
             NodeStartHousekeeping(node);
 
             if (nowCompilingTrigger)
-                throw new KOSWaitInvalidHereException();
+                throw new KOSWaitInvalidHereException(lastLine, lastColumn);
 
             if (node.Nodes.Count == 3)
             {
@@ -2654,14 +2657,23 @@ namespace kOS.Safe.Compilation.KS
                 lastSubNode.Token.Type == TokenType.declare_identifier_clause &&
                 !allowLazyGlobal)
             {
-                throw new KOSCommandInvalidHereException("a bare DECLARE identifier, without a GLOBAL or LOCAL keyword",
-                                                "in an identifier initialization while under a @LAZYGLOBAL OFF directive",
-                                                "in a file where the default @LAZYGLOBAL behavior is on");
+                LineCol location = GetLineCol(node);
+                throw new KOSCommandInvalidHereException(location.Line, location.Col, 
+                                                         "a bare DECLARE identifier, without a GLOBAL or LOCAL keyword",
+                                                         "in an identifier initialization while under a @LAZYGLOBAL OFF directive",
+                                                         "in a file where the default @LAZYGLOBAL behavior is on");
             }
             if (modifier == StorageModifier.GLOBAL && lastSubNode.Token.Type == TokenType.declare_function_clause)
-                throw new KOSCommandInvalidHereException("GLOBAL", "in a function declaration", "in a variable declaration");
+            {
+                LineCol location = GetLineCol(node);
+                throw new KOSCommandInvalidHereException(location.Line, location.Col, "GLOBAL",
+                                                         "in a function declaration", "in a variable declaration");
+            }
             if (modifier == StorageModifier.GLOBAL && lastSubNode.Token.Type == TokenType.declare_parameter_clause)
-                throw new KOSCommandInvalidHereException("GLOBAL", "in a parameter declaration", "in a variable declaration");
+            {
+                LineCol location = GetLineCol(node);
+                throw new KOSCommandInvalidHereException(location.Line, location.Col, "GLOBAL", "in a parameter declaration", "in a variable declaration");
+            }
 
             return modifier;
         }
@@ -2758,7 +2770,7 @@ namespace kOS.Safe.Compilation.KS
                 ++progNameIndex;
             }
             if (hasOnce && ! options.LoadProgramsInSameAddressSpace)
-                throw new KOSOnceInvalidHereException();
+                throw new KOSOnceInvalidHereException(lastLine, lastColumn);
 
             // process program arguments
             AddOpcode(new OpcodePush(new KOSArgMarkerType())); // regardless of whether it's called directly or indirectly, we still need at least one.
@@ -2959,7 +2971,7 @@ namespace kOS.Safe.Compilation.KS
             NodeStartHousekeeping(node);
 
             if (!nowInALoop)
-                throw new KOSBreakInvalidHereException();
+                throw new KOSBreakInvalidHereException(lastLine, lastColumn);
 
             // Will need to pop out the number of variables scopes equal to the
             // number of braces we're skipping out of.  For now just record the
@@ -2986,8 +2998,8 @@ namespace kOS.Safe.Compilation.KS
             var nestLevelOfFuncBraces = (Int16)GetReturnNestLevel();
 
             if (nestLevelOfFuncBraces < 0)
-                throw new KOSReturnInvalidHereException();
-
+                throw new KOSReturnInvalidHereException(lastLine, lastColumn);
+            
             // Push the return expression onto the stack, or if it was a naked RETURN
             // keyword with no expression, then push a secret dummy return value of zero:
             if (node.Nodes.Count > 2)
@@ -3012,7 +3024,7 @@ namespace kOS.Safe.Compilation.KS
             NodeStartHousekeeping(node);
 
             if (!nowCompilingTrigger)
-                throw new KOSPreserveInvalidHereException();
+                throw new KOSPreserveInvalidHereException(lastLine, lastColumn);
 
             string flagName = PeekTriggerRemoveName();
             AddOpcode(new OpcodePush(flagName));
@@ -3148,6 +3160,8 @@ namespace kOS.Safe.Compilation.KS
         
         public void VisitDirective(ParseNode node)
         {
+            NodeStartHousekeeping(node);
+            
             // For now, let the compiler decide if the compiler directive is in the wrong place, 
             // not the parser.  Therefore the parser treats it like a normal statement and here in
             // the compiler we'll decide per-directive which directives can go where:
@@ -3155,7 +3169,7 @@ namespace kOS.Safe.Compilation.KS
             ParseNode directiveNode = node.Nodes[0]; // a directive contains the exact directive node nested one step inside it.
             
             if (directiveNode.Nodes.Count < 2)
-                throw new KOSCompileException("Kerboscript compiler directive ('@') without a keyword after it.");
+                throw new KOSCompileException(lastLine, lastColumn, "Kerboscript compiler directive ('@') without a keyword after it.");
             
             
             switch (directiveNode.Nodes[1].Token.Type)
@@ -3167,14 +3181,14 @@ namespace kOS.Safe.Compilation.KS
                 // There is room for expansion here if we want to add more compiler directives.
                 
                 default:
-                    throw new KOSCompileException("Kerboscript compiler directive @"+directiveNode.Nodes[1].Text+" is unknown.");
+                    throw new KOSCompileException(lastLine, lastColumn, "Kerboscript compiler directive @"+directiveNode.Nodes[1].Text+" is unknown.");
             }
         }
         
         public void VisitLazyGlobalDirective(ParseNode node)
         {
             if (node.Nodes.Count < 3 || node.Nodes[2].Token.Type != TokenType.onoff_trailer)
-                throw new KOSCompileException("Kerboscript compiler directive @LAZYGLOBAL requires an ON or an OFF keyword.");
+                throw new KOSCompileException(lastLine, lastColumn, "Kerboscript compiler directive @LAZYGLOBAL requires an ON or an OFF keyword.");
             
             // This particular directive is only allowed up at the top of a file, prior to any other non-directive statements.
             // ---------------------------------------------------------------------------------------------------------------
@@ -3220,7 +3234,7 @@ namespace kOS.Safe.Compilation.KS
                 }
             }
             if (!validLocation)
-                throw new KOSCommandInvalidHereException("@LAZYGLOBAL",
+                throw new KOSCommandInvalidHereException(node.Token.Line, node.Token.Line, "@LAZYGLOBAL",
                                                 "after the first command in the file",
                                                 "at the start of a script file, prior to any other statements");
 

--- a/src/kOS.Safe/Compilation/KS/KSScript.cs
+++ b/src/kOS.Safe/Compilation/KS/KSScript.cs
@@ -26,8 +26,16 @@ namespace kOS.Safe.Compilation.KS
                 var compiler = new Compiler();
                 LoadContext(contextId);
 
-                // TODO: handle compile errors (e.g. wrong run parameter count)
-                CodePart mainPart = compiler.Compile(startLineNum, parseTree, currentContext, options);
+                CodePart mainPart;
+                try
+                {
+                    mainPart = compiler.Compile(startLineNum, parseTree, currentContext, options);
+                }
+                catch (KOSCompileException e)
+                {
+                    e.AddSourceText((short)startLineNum, scriptText);
+                    throw e;
+                }
 
                 // add locks and triggers
                 parts.AddRange(currentContext.UserFunctions.GetNewParts());
@@ -148,7 +156,6 @@ namespace kOS.Safe.Compilation.KS
                 
                 foreach (ParseError err in parseTree.Errors)
                 {
-                    System.Console.WriteLine("eraseme:  err msg: " + err.Message);
                     if (err.Message.StartsWith("Unexpected token 'EOF'"))
                     {
                         if (err.Message.Contains("Expected CURLYCLOSE") ||

--- a/src/kOS.Safe/Compilation/KS/LineCol.cs
+++ b/src/kOS.Safe/Compilation/KS/LineCol.cs
@@ -1,0 +1,18 @@
+﻿namespace kOS.Safe.Compilation.KS
+{
+    /// <summary>
+    /// Just a dumb simple tuple of line and column, to be returned in
+    /// places where the compiler needs to treat the pair of them like
+    /// a single return value from a method.
+    /// </summary>
+    public class LineCol
+    {
+        public short Line { get; set; }
+        public short Col { get; set; }
+        public LineCol(short line, short col)
+        {
+            Line = line;
+            Col = col;
+        }
+    }
+}

--- a/src/kOS.Safe/Compilation/ProgramBuilder.cs
+++ b/src/kOS.Safe/Compilation/ProgramBuilder.cs
@@ -132,7 +132,7 @@ namespace kOS.Safe.Compilation
                         Utilities.SafeHouse.Logger.LogError("=====Relabeled Program so far is: =========");
                         Utilities.SafeHouse.Logger.LogError(Utilities.Debug.GetCodeFragment(program));
 
-                        throw new kOS.Safe.Exceptions.KOSCompileException(string.Format(
+                        throw new kOS.Safe.Exceptions.KOSCompileException(-1, -1, string.Format(
                             "ProgramBuilder.ReplaceLabels: Cannot add label {0}, label already exists.  Opcode: {1}", program[index].Label, program[index].ToString()));
                     }
                     labels.Add(program[index].Label, index);

--- a/src/kOS.Safe/Exceptions/KOSBreakInvalidHereException.cs
+++ b/src/kOS.Safe/Exceptions/KOSBreakInvalidHereException.cs
@@ -18,8 +18,8 @@
             "it doesn't mean anything when it's not inside a\n" +
             "loop.\n";
 
-        public KOSBreakInvalidHereException() :
-            base("BREAK", "outside a loop", "in a loop body")
+        public KOSBreakInvalidHereException(int line, int col) :
+            base(line, col, "BREAK", "outside a loop", "in a loop body")
         {
         }
     }

--- a/src/kOS.Safe/Exceptions/KOSCommandInvalidHereException.cs
+++ b/src/kOS.Safe/Exceptions/KOSCommandInvalidHereException.cs
@@ -26,13 +26,15 @@ namespace kOS.Safe.Exceptions
         /// <summary>
         /// Describe the condition under which the invalidity is happening.
         /// </summary>
+        /// <param name="line">current line num in script where the problem was</param>
+        /// <param name="col">current col num in script where the problem was</param>
         /// <param name="command">string name of the invalid command</param>
         /// <param name="badPlace">describing where in code the it's not being allowed.
         /// Use a phrasing that starts with a preposition, i.e. "in a loop", "outside a loop"</param>
         /// <param name="goodPlace">describing what sort of code the it is meant to be used in instead.
         /// Use a phrasing that starts with a preposition, i.e. "in a loop", "outside a loop"</param>
-        public KOSCommandInvalidHereException(string command, string badPlace, string goodPlace) :
-            base(string.Format(TERSE_MSG_FMT, command, badPlace, goodPlace))
+        public KOSCommandInvalidHereException(int line, int col, string command, string badPlace, string goodPlace) :
+            base(line, col, string.Format(TERSE_MSG_FMT, command, badPlace, goodPlace))
         {
         }
     }

--- a/src/kOS.Safe/Exceptions/KOSCompileException.cs
+++ b/src/kOS.Safe/Exceptions/KOSCompileException.cs
@@ -1,4 +1,5 @@
-﻿namespace kOS.Safe.Exceptions
+﻿using System;
+namespace kOS.Safe.Exceptions
 {
     /// <summary>
     /// Thrown whenever KOS compiler encounters something it does not like.
@@ -10,14 +11,69 @@
     /// </summary>
     public class KOSCompileException: KOSException
     {
+        public int Line {get; private set;}
+        public int Col {get; private set;}
+        
+        // In order to make the Message property of an Exception not be read-only, you have
+        // to do it this way - make a writable field underneath the get-only property.  This
+        // is being done so the message of this exception can be altered later after it was
+        // constructed, as the source text information isn't available when the exception
+        // is first constructed.  (See AddSourceText() below).
+        private string message;
+        public override string Message
+        {
+            get { return message; }
+        }
+        
         // Just default the Verbose message to return the terse message:
-        public override string VerboseMessage { get{return base.Message;} }
+        public override string VerboseMessage { get{return Message;} }
 
         // Just nothing by default:
         public override string HelpURL { get{ return "";} }
 
-        public KOSCompileException(string message) : base(message)
+        public KOSCompileException(int line, int col, string message)
         {
+            Line = line;
+            Col = col;
+            this.message = message;
+        }
+        
+        /// <summary>
+        /// Skims through the source text looking for the line snippet
+        /// where the problem is.  This will prepend the source line
+        /// info to the existing message in the exception.
+        /// </summary>
+        /// <param name="sourceText">Text of the entire file that was compiled</param>
+        public void AddSourceText(int startline, string sourceText)
+        {
+            // special case for when the exception cannot show its source line:
+            if (Line <= 0 || Col <= 0)
+                return;
+            // Have to skim through the source text looking for the right line:
+            int sourceLine = startline;
+            int startIndex = 0;
+            int endIndex = sourceText.Length; // endIndex is one past the end, actually.
+            for (int i = 0; i < sourceText.Length ; ++i)
+            {
+                if (sourceText[i] == '\n')
+                {
+                    ++sourceLine;
+                    if (sourceLine == Line)
+                    {
+                        startIndex = i + 1;
+                    }
+                    else if (sourceLine == Line + 1)
+                    {
+                        endIndex = i;
+                        break;
+                    }
+                }
+            }
+            message = string.Format(
+                "{0}\n{1}\nline {2}, col {3}: {4}",
+                sourceText.Substring(startIndex, (endIndex-startIndex)),
+                "^".PadLeft(Col), // put the caret under the right column of the source line
+                Line, Col, message );
         }
     }
 }

--- a/src/kOS.Safe/Exceptions/KOSDefaultParamNotAtEndException.cs
+++ b/src/kOS.Safe/Exceptions/KOSDefaultParamNotAtEndException.cs
@@ -26,8 +26,9 @@
             "because when x had a default then all other\n" +
             "parameters that came after it had to have one.\n";
 
-        public KOSDefaultParamNotAtEndException() :
-            base("An optional parameter (one with a default initializer)",
+        public KOSDefaultParamNotAtEndException(int line, int col) :
+            base(line, col,
+                 "An optional parameter (one with a default initializer)",
                  "before a mandatory parameter (one without a default initializer)",
                  "when all mandatory parameters come before all optional parameters")
         {

--- a/src/kOS.Safe/Exceptions/KOSException.cs
+++ b/src/kOS.Safe/Exceptions/KOSException.cs
@@ -7,6 +7,10 @@ namespace kOS.Safe.Exceptions
         public KOSException(string message):base(message)
         {
         }
+        
+        public KOSException() // a default constructor is needed for how KOSCompileException works
+        {
+        }
 
         public virtual string VerboseMessage
         {

--- a/src/kOS.Safe/Exceptions/KOSOnceInvalidHereException.cs
+++ b/src/kOS.Safe/Exceptions/KOSOnceInvalidHereException.cs
@@ -20,8 +20,8 @@
             "recompiles and re-runs the program\n" +
             "each run.\n";
 
-        public KOSOnceInvalidHereException() :
-            base( "ONCE", "from the terminal interpreter", "inside a program" )
+        public KOSOnceInvalidHereException(int line, int col) :
+            base(line, col, "ONCE", "from the terminal interpreter", "inside a program" )
         {
         }
     }

--- a/src/kOS.Safe/Exceptions/KOSPreserveInvalidHereException.cs
+++ b/src/kOS.Safe/Exceptions/KOSPreserveInvalidHereException.cs
@@ -19,8 +19,8 @@
             "anything when it's not inside a trigger like\n" +
             "WHEN or ON.\n";
 
-        public KOSPreserveInvalidHereException() :
-            base( "PRESERVE", "not in a trigger body", "in triggers" )
+        public KOSPreserveInvalidHereException(int line, int col) :
+            base(line, col, "PRESERVE", "not in a trigger body", "in triggers" )
         {
         }
     }

--- a/src/kOS.Safe/Exceptions/KOSReturnInvalidHereException.cs
+++ b/src/kOS.Safe/Exceptions/KOSReturnInvalidHereException.cs
@@ -18,8 +18,8 @@
             "it doesn't mean anything when it's not inside a\n" +
             "user function.\n";
 
-        public KOSReturnInvalidHereException() :
-            base("RETURN", "outside a FUNCTION", "in a FUNCTION body")
+        public KOSReturnInvalidHereException(int line, int col) :
+            base(line, col, "RETURN", "outside a FUNCTION", "in a FUNCTION body")
         {
         }
     }

--- a/src/kOS.Safe/Exceptions/KOSWaitInValidHereException.cs
+++ b/src/kOS.Safe/Exceptions/KOSWaitInValidHereException.cs
@@ -19,8 +19,8 @@
             "work inside a trigger body, which must complete\n" +
             "its work within one update tick.\n";
 
-        public KOSWaitInvalidHereException() :
-            base( "WAIT", "in a trigger body", "outside of triggers" )
+        public KOSWaitInvalidHereException(int line, int col) :
+            base(line, col, "WAIT", "in a trigger body", "outside of triggers" )
         {
         }
     }

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Compilation\KS\BreakInfo.cs" />
     <Compile Include="Compilation\KS\Compiler.cs" />
     <Compile Include="Compilation\KS\Context.cs" />
+    <Compile Include="Compilation\KS\LineCol.cs" />
     <Compile Include="Compilation\KS\Scope.cs" />
     <Compile Include="Compilation\KS\Subprogram.cs" />
     <Compile Include="Compilation\KS\KSScript.cs" />

--- a/src/kOS/Function/Misc.cs
+++ b/src/kOS/Function/Misc.cs
@@ -130,7 +130,7 @@ namespace kOS.Function
             }
             else if (!shared.Vessel.isActiveVessel)
             {
-                throw new KOSCommandInvalidHereException("STAGE", "a non-active SHIP, KSP does not support this", "Core is on the active vessel");
+                throw new KOSCommandInvalidHereException(-1, -1, "STAGE", "a non-active SHIP, KSP does not support this", "Core is on the active vessel");
             }
         }
     }

--- a/src/kOS/Suffixed/KUniverseValue.cs
+++ b/src/kOS/Suffixed/KUniverseValue.cs
@@ -41,7 +41,7 @@ namespace kOS.Suffixed
             {
                 FlightDriver.RevertToLaunch();
             }
-            else throw new KOSCommandInvalidHereException("REVERTTOLAUNCH", "When revert is disabled", "When revert is enabled");
+            else throw new KOSCommandInvalidHereException(-1, -1, "REVERTTOLAUNCH", "When revert is disabled", "When revert is enabled");
         }
 
         public void RevertToEditor()
@@ -51,7 +51,7 @@ namespace kOS.Suffixed
                 EditorFacility fac = ShipConstruction.ShipType;
                 FlightDriver.RevertToPrelaunch(fac);
             }
-            else throw new KOSCommandInvalidHereException("REVERTTOEDITOR", "When revert is disabled", "When revert is enabled");
+            else throw new KOSCommandInvalidHereException(-1, -1, "REVERTTOEDITOR", "When revert is disabled", "When revert is enabled");
         }
 
         public void RevertTo(string editor)
@@ -73,7 +73,7 @@ namespace kOS.Suffixed
                 }
                 FlightDriver.RevertToPrelaunch(fac);
             }
-            else throw new KOSCommandInvalidHereException("REVERTTO", "When revert is disabled", "When revert is enabled");
+            else throw new KOSCommandInvalidHereException(-1, -1, "REVERTTO", "When revert is disabled", "When revert is enabled");
         }
 
         public bool CanRevert()

--- a/src/kOS/Suffixed/Part/PartValue.cs
+++ b/src/kOS/Suffixed/Part/PartValue.cs
@@ -143,7 +143,7 @@ namespace kOS.Suffixed.Part
             }
             else
             {
-                throw new KOSCommandInvalidHereException("CONTROLFROM", "a generic part value", "a docking port or command part");
+                throw new KOSCommandInvalidHereException(-1, -1, "CONTROLFROM", "a generic part value", "a docking port or command part");
             }
         }
 


### PR DESCRIPTION
An example of the sort of error that is now reported better is this:
```
when x = 0 then {
  print "x is zero".
  wait 2.  // compile error: a wait inside a trigger.
}
```
and this:
```
if x = 0 {
  break. // compile error: you can't break when not in a loop
}
```
Basically, it's all the stuff the parse rules say is fine but
for further contextual reasons the parser isn't smart enough to
understand, it's considered a compile error.