### PR TITLE
Fixes #1328 esc in telnet

### DIFF
--- a/src/kOS.Safe/Compilation/KS/KSScript.cs
+++ b/src/kOS.Safe/Compilation/KS/KSScript.cs
@@ -148,7 +148,6 @@ namespace kOS.Safe.Compilation.KS
                 
                 foreach (ParseError err in parseTree.Errors)
                 {
-                    System.Console.WriteLine("eraseme:  err msg: " + err.Message);
                     if (err.Message.StartsWith("Unexpected token 'EOF'"))
                     {
                         if (err.Message.Contains("Expected CURLYCLOSE") ||

--- a/src/kOS.Safe/Encapsulation/BooleanValue.cs
+++ b/src/kOS.Safe/Encapsulation/BooleanValue.cs
@@ -128,7 +128,7 @@ namespace kOS.Safe.Encapsulation
 
         public static bool operator !=(Structure val1, BooleanValue val2)
         {
-            if (val2 == null) throw new ArgumentNullException(nameof(val2));
+            if (val2 == null) throw new ArgumentNullException("val2");
             val2 = new BooleanValue(Convert.ToBoolean(val1));
             return !NullSafeEquals(val1, val2);
         }

--- a/src/kOS/UserIO/TerminalVT100Mapper.cs
+++ b/src/kOS/UserIO/TerminalVT100Mapper.cs
@@ -152,12 +152,11 @@ namespace kOS.UserIO
 
             for (int index = 0; index < inChars.Length; ++index)
             {
-                Console.WriteLine("eraseme: ch ord = " + (int)inChars[index]);
                 switch (inChars[index])
                 {
                     case ESCAPE_CHARACTER:
-                        Console.WriteLine("eraseme: esc char, next char = " + (int)inChars[index+1]);
-                        if (inChars[index + 1] == '[') // ESC followed by '[' is called the CSI (Control Sequence Initiator) and it's how most VT100 codes start.
+                        if (index + 1 < inChars.Length && inChars[index + 1] == '[')
+                            // ESC followed by '[' is called the CSI (Control Sequence Initiator) and it's how most VT100 codes start.
                         {
                             int numConsumed;
                             char ch = ConvertVT100InputCSI(inChars, index + 2, out numConsumed);
@@ -197,16 +196,20 @@ namespace kOS.UserIO
         /// <returns>The UnicdeCommand equivalent.  NOTE that if numConsumed is zero, this value shouldn't be used as nothing was actually done.</returns>
         protected char ConvertVT100InputCSI(char[] inChars, int offset, out int numConsumed)
         {
-            char returnChar = '\0'; // dummy until changed.
-            switch (inChars[offset])
+            char returnChar = '\0'; // default until changed.
+            numConsumed = 0; // default if all the clauses below get skipped.
+            if (offset < inChars.Length)
             {
-                case 'A': returnChar = (char)UnicodeCommand.UPCURSORONE;    numConsumed = 1; break;
-                case 'B': returnChar = (char)UnicodeCommand.DOWNCURSORONE;  numConsumed = 1; break;
-                case 'C': returnChar = (char)UnicodeCommand.RIGHTCURSORONE; numConsumed = 1; break;
-                case 'D': returnChar = (char)UnicodeCommand.LEFTCURSORONE;  numConsumed = 1; break;
-                case 'H': returnChar = (char)UnicodeCommand.HOMECURSOR;     numConsumed = 1; break;
-                case 'F': returnChar = (char)UnicodeCommand.ENDCURSOR;      numConsumed = 1; break;
-                default: numConsumed = 0; break; // Do nothing if it's not a recognized sequence.  Leave the chars to be read normally.
+                switch (inChars[offset])
+                {
+                    case 'A': returnChar = (char)UnicodeCommand.UPCURSORONE;    numConsumed = 1; break;
+                    case 'B': returnChar = (char)UnicodeCommand.DOWNCURSORONE;  numConsumed = 1; break;
+                    case 'C': returnChar = (char)UnicodeCommand.RIGHTCURSORONE; numConsumed = 1; break;
+                    case 'D': returnChar = (char)UnicodeCommand.LEFTCURSORONE;  numConsumed = 1; break;
+                    case 'H': returnChar = (char)UnicodeCommand.HOMECURSOR;     numConsumed = 1; break;
+                    case 'F': returnChar = (char)UnicodeCommand.ENDCURSOR;      numConsumed = 1; break;
+                    default: numConsumed = 0; break; // Do nothing if it's not a recognized sequence.  Leave the chars to be read normally.
+                }
             }
             // The following are technically VT220 codes, not VT100, but I couldn't be bothered making a separate
             // mapper just for them.  (i.e. the proper way would be to make a VT220Mapper that inherits from this VT100Mapper,

--- a/src/kOS/UserIO/TerminalVT100Mapper.cs
+++ b/src/kOS/UserIO/TerminalVT100Mapper.cs
@@ -1,6 +1,7 @@
 ﻿using kOS.Safe.UserIO;
 using System.Collections.Generic;
 using System.Text;
+using System;
 
 namespace kOS.UserIO
 {
@@ -151,9 +152,11 @@ namespace kOS.UserIO
 
             for (int index = 0; index < inChars.Length; ++index)
             {
+                Console.WriteLine("eraseme: ch ord = " + (int)inChars[index]);
                 switch (inChars[index])
                 {
                     case ESCAPE_CHARACTER:
+                        Console.WriteLine("eraseme: esc char, next char = " + (int)inChars[index+1]);
                         if (inChars[index + 1] == '[') // ESC followed by '[' is called the CSI (Control Sequence Initiator) and it's how most VT100 codes start.
                         {
                             int numConsumed;


### PR DESCRIPTION
The problem was caused by the code presuming every time there
was an ESC that there MUST be another character following it
that it can read ahead on the next index.  When there wasn't
yet and the snippet of input chars just ended at the ESC, the
attempt to go one more character forward threw an array bounds
exception.  This was never sent to the output_log, however
because the telnet server runs in a separate thread and
apparently the output_log only contains the main thread's output.

When the telnet server thread died from the exception, the telnet
client doesn't show anything about it, other than just freezing
for several seconds and then eventually reporting a dropped
connection.