### PR TITLE
Char

### DIFF
--- a/doc/source/math/basic.rst
+++ b/doc/source/math/basic.rst
@@ -74,7 +74,7 @@ constants about the universe that you may find handy in your math operations.
     This constant is provided mainly for the benefit of people who are
     playing with the mod "RemoteTech" installed, who may want to perform
     calculations about signal delays to hypothetical probes.  (Note that
-    if the probe already has a connection, you can 
+    if the probe already has a connection, you can
     :ref:`ask Remotetech directly <remotetech>` what the signal delay is.
 
 .. global:: Constant:AtmToKPa
@@ -91,7 +91,7 @@ constants about the universe that you may find handy in your math operations.
 
     If you have a pressure measurement expressed in kiloPascals (kiloNewtons
     per square meter), you can multiply it by this to get the equivalent
-    in atmospheres. 
+    in atmospheres.
 
 .. global:: Constant:DegToRad
 
@@ -134,6 +134,7 @@ Mathematical Functions
  :func:`ROUND(a)`     round to whole number
  :func:`ROUND(a,b)`   round to nearest place
  :func:`SQRT(a)`      square root
+ :func:`CHAR(a)`      character from unicode
 ==================== ===================================================
 
 .. function:: ABS(a)
@@ -294,3 +295,12 @@ Trigonometric Functions
         PRINT ARCTAN2(0.67, 0.89). // prints 36.9727625
 
     The two parameters resolve ambiguities when taking the arctangent. See the `wikipedia page about atan2 <http://en.wikipedia.org/wiki/Atan2>`_ for more details.
+
+.. function:: CHAR(a)
+
+    :parameter a: (number)
+    :return: (string) single-character string containing the unicode character specified
+
+    ::
+
+        PRINT CHAR(34) + "Apples" + CHAR(34). // prints "Apples"

--- a/src/kOS/Function/Math.cs
+++ b/src/kOS/Function/Math.cs
@@ -94,6 +94,7 @@ namespace kOS.Function
         }
     }
 
+
     [Function("ln")]
     public class FunctionLn : FunctionBase
     {
@@ -235,6 +236,19 @@ namespace kOS.Function
             }
             else
                 throw new KOSException("vector angle calculation attempted with a non-vector value");
+        }
+    }
+
+
+    [Function("char")]
+    public class FunctionChar : FunctionBase
+    {
+        public override void Execute(SharedObjects shared)
+        {
+            double argument = GetDouble(PopValueAssert(shared));
+            AssertArgBottomAndConsume(shared);
+            string result = new string((char) argument, 1);
+            ReturnValue = result;
         }
     }
 }


### PR DESCRIPTION
Provides a `char(65). // "A"` function, which allows for snagging characters such as quote, newline, etc.

`print char(34) + "Foo" + char(34).`

Probably doesn't entirely belong in the Math functions, but we don't really have a section for casting, and this seemed the nearest fit.

Thanks to @hvacengi for the encouragement!