### PR TITLE
Add Unchar for Char parity

### DIFF
--- a/doc/source/math/basic.rst
+++ b/doc/source/math/basic.rst
@@ -135,6 +135,7 @@ Mathematical Functions
  :func:`ROUND(a,b)`   round to nearest place
  :func:`SQRT(a)`      square root
  :func:`CHAR(a)`      character from unicode
+ :func:`UNCHAR(a)`    unicode from character
 ==================== ===================================================
 
 .. function:: ABS(a)
@@ -219,6 +220,15 @@ Mathematical Functions
     ::
 
         PRINT CHAR(34) + "Apples" + CHAR(34). // prints "Apples"
+
+.. function:: UNCHAR(a)
+
+    :parameter a: (string)
+    :return: (number) unicode number representing the character specified
+
+    ::
+
+        PRINT UNCHAR("A"). // prints 65
 
 .. _trig:
 .. index:: Trigonometric Functions

--- a/src/kOS/Function/Math.cs
+++ b/src/kOS/Function/Math.cs
@@ -251,4 +251,16 @@ namespace kOS.Function
             ReturnValue = result;
         }
     }
+
+    [Function("unchar")]
+    public class FunctionUnchar : FunctionBase
+    {
+        public override void Execute(SharedObjects shared)
+        {
+            string argument = PopValueAssert(shared).ToString();
+            AssertArgBottomAndConsume(shared);
+            double result = (double) argument.ToCharArray()[0];
+            ReturnValue = result;
+        }
+    }
 }


### PR DESCRIPTION
Added `unchar` for parity with the `char` function, as per @Dunbaratu's comments on #1343, such that:

```
print unchar(char(65)). // 65
print char(unchar("A")) // "A"
```

Deliberately avoided something like `number("A")`, as that's quite liable to be confusing for new users, who might well expect `number("123") => 123`, and we probably don't want to really support complex type casting at least for now. 