### PR TITLE
Fix uses of 'is string'

### DIFF
--- a/src/kOS.Safe/Encapsulation/Lexicon.cs
+++ b/src/kOS.Safe/Encapsulation/Lexicon.cs
@@ -23,7 +23,7 @@ namespace kOS.Safe.Encapsulation
                     return false;
                 }
 
-                if (x is string && y is string)
+                if ((x is string || x is StringValue) && (y is string || y is StringValue))
                 {
                     var compare = string.Compare(x.ToString(), y.ToString(), StringComparison.InvariantCultureIgnoreCase);
                     return compare == 0;
@@ -34,7 +34,7 @@ namespace kOS.Safe.Encapsulation
 
             public int GetHashCode(TI obj)
             {
-                if (obj is string)
+                if (obj is string || obj is StringValue)
                 {
                     return obj.ToString().ToLower().GetHashCode();
                 }

--- a/src/kOS.Safe/Persistence/VolumeManager.cs
+++ b/src/kOS.Safe/Persistence/VolumeManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using kOS.Safe.Encapsulation;
 
 namespace kOS.Safe.Persistence
 {
@@ -59,7 +60,7 @@ namespace kOS.Safe.Persistence
 
         public Volume GetVolume(object volumeId)
         {
-            if (volumeId is string) return GetVolume(volumeId.ToString());
+            if (volumeId is string || volumeId is StringValue) return GetVolume(volumeId.ToString());
             // Convert to int instead of cast in case the identifier is stored
             // as an encapsulated ScalarValue, preventing an unboxing collision.
             try

--- a/src/kOS/Function/Misc.cs
+++ b/src/kOS/Function/Misc.cs
@@ -426,8 +426,8 @@ namespace kOS.Function
 
             if (processorTagOrVolume is Volume) {
                 processor = shared.ProcessorMgr.GetProcessor(processorTagOrVolume as Volume);
-            } else if (processorTagOrVolume is string) {
-                processor = shared.ProcessorMgr.GetProcessor(processorTagOrVolume as string);
+            } else if (processorTagOrVolume is string || processorTagOrVolume is StringValue) {
+                processor = shared.ProcessorMgr.GetProcessor(processorTagOrVolume.ToString());
             } else {
                 throw new KOSInvalidArgumentException("processor", "processorId", "String or Volume expected");
             }


### PR DESCRIPTION
Fixes at least some of #1357

I've reviewed all occurrences of `is string` in the code and it seems like only those few needed fixing.

This does not fully fix #1357 as there might be still problems caused by `is int`, `is double`, etc