### PR TITLE
Add HASTARGET and HASNODE

### DIFF
--- a/src/kOS/Binding/FlightStats.cs
+++ b/src/kOS/Binding/FlightStats.cs
@@ -40,6 +40,13 @@ namespace kOS.Binding
 
                 return Node.FromExisting(vessel, vessel.patchedConicSolver.maneuverNodes[0], shared);
             });
+            shared.BindingMgr.AddGetter("HASNODE", () =>
+            {
+                var vessel = shared.Vessel;
+                if (vessel.patchedConicSolver == null)
+                    return false; // Since there is no solver, there can be no node.
+                return vessel.patchedConicSolver.maneuverNodes.Count > 0;
+            });
 
             // These are now considered shortcuts to SHIP:suffix
             foreach (var scName in VesselTarget.ShortCuttableShipSuffixes)

--- a/src/kOS/Binding/MissionSettings.cs
+++ b/src/kOS/Binding/MissionSettings.cs
@@ -15,6 +15,10 @@ namespace kOS.Binding
 
             shared.BindingMgr.AddSetter("TARGET", val =>
             {
+                if (shared.Vessel != FlightGlobals.ActiveVessel)
+                {
+                    throw new kOS.Safe.Exceptions.KOSSituationallyInvalidException("TARGET can only be set for the Active Vessel");
+                }
                 var targetable = val as IKOSTargetable;
                 if (targetable != null)
                 {
@@ -44,6 +48,10 @@ namespace kOS.Binding
 
             shared.BindingMgr.AddGetter("TARGET", () =>
             {
+                if (shared.Vessel != FlightGlobals.ActiveVessel)
+                {
+                    throw new kOS.Safe.Exceptions.KOSSituationallyInvalidException("TARGET can only be returned for the Active Vessel");
+                }
                 var currentTarget = FlightGlobals.fetch.VesselTarget;
 
                 var vessel = currentTarget as Vessel;
@@ -62,8 +70,16 @@ namespace kOS.Binding
                     return new DockingPortValue(dockingNode, shared);
                 }
 
-                return null;
+                throw new kOS.Safe.Exceptions.KOSSituationallyInvalidException("No TARGET is selected");
             });
+
+            shared.BindingMgr.AddGetter("HASTARGET", () =>
+            {
+                if (shared.Vessel != FlightGlobals.ActiveVessel) return false;
+                // the ship has a target if the object does not equal null.
+                return FlightGlobals.fetch.VesselTarget != null;
+            });
+
         }
     }
 }


### PR DESCRIPTION
Fixes #1350 
FlightStats.cs
* Add new bound variable HASNODE to let users detect if a node already
exists.

MissionSettings.cs
* Add new bound variable HASTARGET to let users detect if there is
currently a target selected.
* Will always return false for vessels that are not the "Active vessel"
because we currently query FlightGlobals for that information..
* Add exceptions if requesting or setting the target from the non-active
vessel, since it would return or set the target of the active vessel
instead of the cpu vessel.