### PR TITLE
Fix vectors multiplied by ScalarValue

### DIFF
--- a/src/kOS/Suffixed/Vector.cs
+++ b/src/kOS/Suffixed/Vector.cs
@@ -186,7 +186,7 @@ namespace kOS.Suffixed
 
         public static Vector operator *(Vector a, ScalarValue b)
         {
-            return new Vector(a.X * b, a.Y * b, a.Z * b);
+            return a * b.GetDoubleValue();
         }
 
         public static Vector operator *(float b, Vector a)
@@ -201,7 +201,7 @@ namespace kOS.Suffixed
 
         public static Vector operator *(ScalarValue b, Vector a)
         {
-            return new Vector(a.X * b, a.Y * b, a.Z * b);
+            return a * b.GetDoubleValue();
         }
 
         public static Vector operator /(Vector a, ScalarValue b)


### PR DESCRIPTION
Fixes #1370
Vector.cs
* modify the ScalarValue "*" operator to return the value of the double "*" operator.