### PR TITLE
Some v0.19.0 changelog edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ release if the PR's about them don't get merged before release.
 * Automatic serialization system to save/load some kinds of data values to JSON-format files (TODO link to docs)
 * User Programs and Functions now allow trailing optional parameters with defaulted values. (TODO link to docs).
 * There are now some suffixes that work on all value types, even primitive scalars.  To accomplish this, a new "encapsulation" system has wrapped all kOS structures and primitive types inside a generic base type.  (TODO link to docs page about basic structure suffixes)
+* ENGINE type now supports multi-mode cases and has its gimbal accessible through :GIMBAL suffix (http://ksp-kos.github.io/KOS_DOC/structures/vessels/engine.html) 
+* Added GIMBAL:LIMIT suffix. (http://ksp-kos.github.io/KOS_DOC/structures/vessels/gimbal.html)
 * Better support for DMagic's Orbital Science mod (TODO link to orbital science addon doc page here)
 * Char() and Unchar() functions for translating unicode numbers to characters and visa versa (TODO link to doc here)
 * New Range type for iterating over hardcoded lists (TODO link to doc here).
@@ -40,6 +42,8 @@ release if the PR's about them don't get merged before release.
 * The error beep and keyboard click sounds now obey game's UI volume settings. (https://github.com/KSP-KOS/KOS/pull/1287)
 * Fixed two bugs with obtaining waypoints by name. (https://github.com/KSP-KOS/KOS/issues/1313) (https://github.com/KSP-KOS/KOS/pull/1319)
 * Removed unnecessary rounding of THRUSTLIMIT to nearest 0.5%, now it can be more precise. (https://github.com/KSP-KOS/KOS/pull/1329)
+* Removed the ability to activate both modes on multi-mode engine simultaneously.
+* LIST ENGINES now lists all engines and displays part names instead of module names. (https://github.com/KSP-KOS/issues/1251)
 * Fixed bug that caused hitting ESC to crash the telnet server. (https://github.com/KSP-KOS/KOS/issues/1328)
 * Some exceptions didn't cause beep, now they all do. (https://github.com/KSP-KOS/KOS/issues/1317)
 * Vecdraw :SCALE no longer applied to :START.  Only applied to :VEC. (https://github.com/KSP-KOS/KOS/issues/1200)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,6 @@
 kOS Mod Changelog
 =================
 
-
-
------------------ TODO ----------------------
-TODO:  Notice I'm writing this before all of these have
-been merged.  Some of these might need to be deleted before
-release if the PR's about them don't get merged before release.
----------------------------------------------
-
 # v0.19.0
 
 ### BREAKING CHANGES
@@ -16,26 +8,28 @@ release if the PR's about them don't get merged before release.
 * Vecdraw :SCALE no longer applied to :START.  Only applied to :VEC.
 * Varying power consumption might make it so if you have high IPU settings some designs might run out of power when they didn't before.  (in most cases it should draw less power for most people).
 * !!!! Default extension of ".ks" is no longer applied to all new filenames created.  But it still will be looked for when reading existing files if you leave the extension off !!!!
-* FileInfo information now moved to VolumeInfo (TODO Docs).
+* FileInfo information now moved to Volume (http://ksp-kos.github.io/KOS_DOC/structures/volumes_and_files/volume.html).
 * VOLUME:FILES was returning a LIST(), now it returns a LEXICON who's keys are the filename.
+* String sort-order comparisons with "<" and ">" operators were implemented wrongly and just compared lengths.  Now they do a character-by-character comparison (case-insensitively).  On the off chance that anyone was actually trying to use the previous weird length-comparison behavior, that would break.
 
 ### NEW FEATURES
-* Varying power consumption.  Units of electric charge used now varies depending on CPU speed and how much the CPU is being actually used.  If your IPU setting is low, or if your program isn't doing very much and is just stuck on a `wait` statement, it won't use as much power. (TODO link to docs)
-* Ability to read and write whole files at a time as one big string. (TODO link to docs)
-* User Functions can now be referred to with function pointers, or "delegates".  (TODO link to docs)
-* Automatic serialization system to save/load some kinds of data values to JSON-format files (TODO link to docs)
-* User Programs and Functions now allow trailing optional parameters with defaulted values. (TODO link to docs).
-* There are now some suffixes that work on all value types, even primitive scalars.  To accomplish this, a new "encapsulation" system has wrapped all kOS structures and primitive types inside a generic base type.  (TODO link to docs page about basic structure suffixes)
+* Varying power consumption.  Units of electric charge used now varies depending on CPU speed and how much the CPU is being actually used.  If your IPU setting is low, or if your program isn't doing very much and is just stuck on a `wait` statement, it won't use as much power. (http://ksp-kos.github.io/KOS_DOC/general/cpu_hardware#electricdrain)
+* Ability to read and write whole files at a time as one big string. (http://ksp-kos.github.io/KOS_DOC/structures/volumes_and_files/volumefile.html)
+* User Functions can now be referred to with function pointers, or "delegates".  (http://ksp-kos.github.io/KOS_DOC/language/delegates.html)
+* Automatic serialization system to save/load some kinds of data values to JSON-format files (http://ksp-kos.github.io/KOS_DOC/commands/files.html#writejson-object-filename)
+* User Programs and Functions now allow trailing optional parameters with defaulted values. (http://ksp-kos.github.io/KOS_DOC/language/user_functions.html#optional-parameters-parameter-defaults).
+* There are now some suffixes that work on all value types, even primitive scalars.  To accomplish this, a new "encapsulation" system has wrapped all kOS structures and primitive types inside a generic base type.  (http://ksp-kos.github.io/KOS_DOC/structures/reflection.html)
 * ENGINE type now supports multi-mode cases and has its gimbal accessible through :GIMBAL suffix (http://ksp-kos.github.io/KOS_DOC/structures/vessels/engine.html) 
 * Added GIMBAL:LIMIT suffix. (http://ksp-kos.github.io/KOS_DOC/structures/vessels/gimbal.html)
-* Better support for DMagic's Orbital Science mod (TODO link to orbital science addon doc page here)
-* Char() and Unchar() functions for translating unicode numbers to characters and visa versa (TODO link to doc here)
-* New Range type for iterating over hardcoded lists (TODO link to doc here).
-* Ability to iterate over the characters in a string using a FOR loop, as if the string was a LIST() of chars (TODO link to doc here)
+* Better support for DMagic's Orbital Science mod (http://ksp-kos.github.io/KOS_DOC/addons/OrbitalScience.html)
+* Char() and Unchar() functions for translating unicode numbers to characters and visa versa (http://ksp-kos.github.io/KOS_DOC/math/basic.html#function:CHAR)
+* New Range type for iterating over hardcoded lists (http://ksp-kos.github.io/KOS_DOC/structures/collections/range.html).
+* Ability to iterate over the characters in a string using a FOR loop, as if the string was a LIST() of chars.
 * New higher level cpu part. (https://github.com/KSP-KOS/KOS/pull/1380)
-* HASTARGET and HASNODE functions (TODO docs link)
-* :JOIN suffix for LIST to make a string of the elements (TODO docs link)
-* KUNIVERSE now lets you read hours per day setting (TODO link to docs)
+* HASTARGET and HASNODE functions (http://ksp-kos.github.io/KOS_DOC/bindings.html?highlight=hastarget)
+* :JOIN suffix for LIST to make a string of the elements (http://ksp-kos.github.io/KOS_DOC/structures/collections/list.html#method:LIST:JOIN)
+* KUNIVERSE now lets you read hours per day setting (http://ksp-kos.github.io/KOS_DOC/structures/misc/kuniverse.html#attribute:KUNIVERSE:HOURSPERDAY)
+* The reserved word ARCHIVE is now a first-class citizen with proper binding, so you can do SET FOO TO ARCHIVE and it will work like you'd expect.
 
 ### BUG FIXES
 * Numerous attitional checks to prevent control of other vessels the kOS CPU isn't attached to. 
@@ -52,6 +46,9 @@ release if the PR's about them don't get merged before release.
 * Fixed a bug when performing an undock (https://github.com/KSP-KOS/KOS/issues/1321)
 * IR:AVAILABLE was reporting incorrectly ()
 * Boot files now wait until the ship is fully unpacked and ready (https://github.com/KSP-KOS/KOS/issues/1280)
+* The Vessel :HASBODY (aliases :HASOBT and :HASORBIT) suffix was in the documentation, but had been lost in a refactor last year.  It is put back now.
+* String sort-order comparisons with "<" and ">" operators were implemented wrongly and just compared lengths.  Now they do a character-by-character comparison (case-insensitively)
+* Small documentation edits and clarifications all over the place.
 
 # v0.18.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,51 @@
 kOS Mod Changelog
 =================
 
-# v0.18.3
 
-Optional Parameters
-------------------------------
+
+----------------- TODO ----------------------
+TODO:  Notice I'm writing this before all of these have
+been merged.  Some of these might need to be deleted before
+release if the PR's about them don't get merged before release.
+---------------------------------------------
+
+# v0.19.0
 
 ### BREAKING CHANGES
+* As usual, you must recompile any KSM files when using the new version.
+* Vecdraw :SCALE no longer applied to :START.  Only applied to :VEC.
+* Varying power consumption might make it so if you have high IPU settings some designs might run out of power when they didn't before.  (in most cases it should draw less power for most people).
+* 
 
 ### NEW FEATURES
+* Varying power consumption.  Units of electric charge used now varies depending on CPU speed and how much the CPU is being actually used.  If your IPU setting is low, or if your program isn't doing very much and is just stuck on a `wait` statement, it won't use as much power. (TODO link to docs)
+* Ability to read and write whole files at a time as one big string. (TODO link to docs)
+* User Functions can now be referred to with function pointers, or "delegates".  (TODO link to docs)
+* Automatic serialization system to save/load some kinds of data values to JSON-format files (TODO link to docs)
+* User Programs and Functions now allow trailing optional parameters with defaulted values. (TODO link to docs).
+* There are now some suffixes that work on all value types, even primitive scalars.  To accomplish this, a new "encapsulation" system has wrapped all kOS structures and primitive types inside a generic base type.  (TODO link to docs page about basic structure suffixes)
+* Better support for DMagic's Orbital Science mod (TODO link to orbital science addon doc page here)
+* Char() and Unchar() functions for translating unicode numbers to characters and visa versa (TODO link to doc here)
+* New Range type for iterating over hardcoded lists (TODO link to doc here).
+* Ability to iterate over the characters in a string using a FOR loop, as if the string was a LIST() of chars (TODO link to doc here)
+* New higher level cpu part. (https://github.com/KSP-KOS/KOS/pull/1380)
+* HASTARGET and HASNODE functions (TODO docs link)
+* :JOIN suffix for LIST to make a string of the elements (TODO docs link)
+* KUNIVERSE now lets you read hours per day setting (TODO link to docs)
 
 ### BUG FIXES
+* Numerous attitional checks to prevent control of other vessels the kOS CPU isn't attached to. 
+* The error beep and keyboard click sounds now obey game's UI volume settings. (https://github.com/KSP-KOS/KOS/pull/1287)
+* Fixed two bugs with obtaining waypoints by name. (https://github.com/KSP-KOS/KOS/issues/1313) (https://github.com/KSP-KOS/KOS/pull/1319)
+* Removed unnecessary rounding of THRUSTLIMIT to nearest 0.5%, now it can be more precise. (https://github.com/KSP-KOS/KOS/pull/1329)
+* Fixed bug that caused hitting ESC to crash the telnet server. (https://github.com/KSP-KOS/KOS/issues/1328)
+* Some exceptions didn't cause beep, now they all do. (https://github.com/KSP-KOS/KOS/issues/1317)
+* Vecdraw :SCALE no longer applied to :START.  Only applied to :VEC. (https://github.com/KSP-KOS/KOS/issues/1200)
+* Fixed bug that made up-arrow work incorrectly when the cursor is at the bottom of the terminal window. (https://github.com/KSP-KOS/KOS/issues/1289)
+* A multitude of small documentation fixes (https://github.com/KSP-KOS/KOS/pull/1341)
+* Fixed a bug when performing an undock (https://github.com/KSP-KOS/KOS/issues/1321)
+* IR:AVAILABLE was reporting incorrectly ()
+* Boot files now wait until the ship is fully unpacked and ready (https://github.com/KSP-KOS/KOS/issues/1280)
 
 # v0.18.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ release if the PR's about them don't get merged before release.
 * As usual, you must recompile any KSM files when using the new version.
 * Vecdraw :SCALE no longer applied to :START.  Only applied to :VEC.
 * Varying power consumption might make it so if you have high IPU settings some designs might run out of power when they didn't before.  (in most cases it should draw less power for most people).
-* 
+* !!!! Default extension of ".ks" is no longer applied to all new filenames created.  But it still will be looked for when reading existing files if you leave the extension off !!!!
+* FileInfo information now moved to VolumeInfo (TODO Docs).
+* VOLUME:FILES was returning a LIST(), now it returns a LEXICON who's keys are the filename.
 
 ### NEW FEATURES
 * Varying power consumption.  Units of electric charge used now varies depending on CPU speed and how much the CPU is being actually used.  If your IPU setting is low, or if your program isn't doing very much and is just stuck on a `wait` statement, it won't use as much power. (TODO link to docs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,23 @@ kOS Mod Changelog
 * String sort-order comparisons with "<" and ">" operators were implemented wrongly and just compared lengths.  Now they do a character-by-character comparison (case-insensitively)
 * Small documentation edits and clarifications all over the place.
 
+### Contributors this release
+
+(These are generated from records on Github of anyone who's Pull Requests are part of this release.)
+(Names are simply listed here alphabetically, not by code contribution size.  Anyone who even had so much as one line of change is mentioned.)
+
+Stephan Andreev (ZiwKerman) https://github.com/ZiwKerman
+Bert Cotton (BertCotton) https://github.com/BertCotton
+Kevin Gisi (gisikw) https://github.com/gisikw
+Peter Goddard (pgodd) https://github.com/pgodd
+Steven Mading (Dunbaratu) https://github.com/Dunbaratu
+Eric A. Meyer (meyerweb) https://github.com/meyerweb
+Tomek Piotrowski (tomekpiotrowski) https://github.com/tomekpiotrowski
+Brad White (hvacengi) https://github.com/hvacengi
+Chris Woerz (erendrake) https://github.com/erendrake  (repository owner)
+(name not public in github profile) (alchemist_ch) https://github.com/AlchemistCH
+(name not public in github profile) (tdw89) https://github.com/TDW89
+
 # v0.18.2
 
 [Insert witty title here :-P]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ kOS Mod Changelog
 * String sort-order comparisons with "<" and ">" operators were implemented wrongly and just compared lengths.  Now they do a character-by-character comparison (case-insensitively)
 * Small documentation edits and clarifications all over the place.
 
-### Contributors this release
+### CONTRIBUTORS THIS RELEASE
 
 (These are generated from records on Github of anyone who's Pull Requests are part of this release.)
 (Names are simply listed here alphabetically, not by code contribution size.  Anyone who even had so much as one line of change is mentioned.)

--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Addon release thread: http://forum.kerbalspaceprogram.com/threads/68089-0-23-kOS
 
 Addon development thread: http://forum.kerbalspaceprogram.com/threads/68096-kOS-Autopilot
 
+Contribution : If you have contributed to the development of the mod, and wish to be named a certain way in the next release notes, then add your edit to the ``### Contributors`` section of the CHANGELOG.md file in your pull request.

--- a/doc/source/contribute.rst
+++ b/doc/source/contribute.rst
@@ -6,18 +6,54 @@ Contribute
 How to Contribute to this Project
 ---------------------------------
 
-Do you know or are willing to learn C# and the **KSP** public API? Great, we could use your help! The source code for **kOS** is kept on `github`_ and is currently maintained by `Chris Woerz`_ and `Steven Mading`_. The first steps you will want to take is to clone the latest version of **kOS** from github and try to build it using your favorite C# compiler suite.
+Do you know or are willing to learn C# and the **KSP** public API? Great, we could use your help! The source code for **kOS** is kept on `github`_ under http://github.io/KSP-KOS/KOS.
+
+If you are already quite familiar with git and Github, the usual Github project development path is used:
+
+  - Tell github to fork the main repository to your own github clone of it.
+  - Clone your fork to your local computer.
+  - On your local computer, make a branch from ``develop`` (don't edit ``develop`` directly) and make your changes in your branch.
+  - Commit your changes and push them up to the same branch name on your github fork.
+  - Make a Pull Request on Github to merge the branch from your fork to the ``develop`` branch of the main repository.
+  - Wait for a developer to notice the Pull Request and start examining it.  There should be at the very least a comment letting you know it's being looked at, within a short time.  KSP-KOS is quite actively developed and someone should notice it soon.
+
+  - Your request is more likely to get merged quickly if you make sure the ``develop`` branch you start from is always up to date with the latest upstream develop when you first split your branch from it.  If it takes a long time to finish, it may be a good idea to check again before making the Pull Request to see if there's been any new upstream ``develop`` changes, and merge them into your branch yourself so the rest of the team has an easier time deciphering the git diff output.
+
+If you do know how to program on large projects and would like to contribute, but just aren't familiar with how git and Github do repository management, contact one of the developers and ask for help on how to get started, or ask to be added to the Slack channel first.
 
 .. _github: https://github.com/KSP-KOS
-.. _Chris Woerz: https://github.com/erendrake
-.. _Steven Mading: https://github.com/Dunbaratu
+
+Slack Chat
+----------
+
+There is an active Slack chat channel where the developers often discuss complex ideas before even mentioning them in a github issue or pull request.  If you wish to be added to this channel, please contact one of the main developers to ask to be invited to the channel.
+
+How to get credited in the next Release
+---------------------------------------
+
+After version 0.19.0, Only people who opt-in to being credited will be mentioned in the release notes.
+
+When you contribute to the development of the mod, if you wish to be named a certain way in the next release notes, then add your edit to the ``### Contributors`` section of the CHANGELOG.md file in your pull request.
+In past releases we have tried to scour the github history to find all authors and it's a bit of a pain to pull the data together.  In future releases we will simply rely on this opt-in technique.  If you don't edit the file, you won't be opted-in to the contributors section.  This also avoids the hassle of having to ask everyone's permission in the last days of putting a release out, and then waiting for people's responses.
 
 How to Edit this Documentation
 ------------------------------
 
-This documentation was written using `reStructuredText`_ and compiled into HTML using `Sphinx`_ and the `Read The Docs Theme`_. It is maintained by `Steven Mading`_, `Chris Woerz`_ and `Johann Goetz`_
+This documentation was written using `reStructuredText`_ and compiled into HTML using `Sphinx`_ and the `Read The Docs Theme`_.
 
 .. _reStructuredText: http://docutils.sourceforge.net/rst.html
 .. _Sphinx: http://sphinx-doc.org/
 .. _Read The Docs Theme: https://github.com/snide/sphinx_rtd_theme
+
+To re-build the documentation tree locally, get a local clone of the project, `cd` into the `doc/` directory, and do these two commands:
+
+``make clean``
+``make html``
+
+Note, this requires you set up Sphinx and Read-the-Docs first, as described in the links above.
+
+This documentation system was first set up for us by Johann Goetz, to whom we are grateful:
+
 .. _Johann Goetz: http://github.com/theodoregoetz
+
+


### PR DESCRIPTION
This first draft includes ALL the user-facing PR's more recent than Nov 25 (the date of the previous release v0.18.0), which we may or may not actually choose to include in the release.  We may need to trim this list down if we decide to leave some things out of the next release and not do them yet.  At the moment I don't yet know which items will be in release and which won't, so I just mentioned them all for now.

There are a few PR's left off because they contain fixes that the user doesn't really see.

Fixes #1433