### PR TITLE
Gimbal:LIMIT suffix

### DIFF
--- a/doc/source/structures/vessels/gimbal.rst
+++ b/doc/source/structures/vessels/gimbal.rst
@@ -11,6 +11,14 @@ Many engines in KSP have thrust vectoring gimbals and in ksp they are their own 
     .. list-table::
         :header-rows: 1
         :widths: 2 1 4
+		  
+        * - :attr:`LOCK`
+          - boolean
+          - Is the Gimbal locked in neutral position? 
+          
+        * - :attr:`LIMIT`
+          - scalar
+          - Percentage of the maximum range the Gimbal is allowed to travel 
 
         * - Suffix
           - Type
@@ -35,11 +43,27 @@ Many engines in KSP have thrust vectoring gimbals and in ksp they are their own 
         * - :attr:`ROLLANGLE`
           - scalar
           - Current Gimbal Roll 
-		  
-        * - :attr:`LOCK`
-          - boolean
-          - Is the gimbal free to travel? 
-		  
+
+
+.. note::
+
+    :struct:`Gimbal` is a type of :struct:`PartModule`, and therefore can use all the suffixes of :struct:`PartModule`. Shown below are only the suffixes that are unique to :struct:`Gimbal`.
+    :struct:`Gimbal` can be accessed as :attr:`Engine:GIMBAL` atribute of  :struct:`Engine`.
+
+.. attribute:: Gimbal:LOCK
+
+    :type: boolean
+    :access: Get/Set
+        
+    Is this gimbal locked to neutral position and not responding to steeing controls right now? When you set it to true it will snap the engine back to 0s for pitch,yaw and roll
+
+.. attribute:: Gimbal:LIMIT
+
+    :type: scalar
+    :access: Get/Set
+        
+    Percentage of maximum range this gimbal is allowed to travel
+
 .. attribute:: Gimbal:RANGE
 
     :type: scalar
@@ -74,11 +98,4 @@ Many engines in KSP have thrust vectoring gimbals and in ksp they are their own 
     :access: Get only
 
     The gimbals current roll, has a range of -1 to 1. Will always be 0 when LOCK is true
-
-.. attribute:: Gimbal:LOCK
-
-    :type: string
-    :access: Get/Set
-        
-    Can this Gimbal produce torque right now, when you set it to false it will snap the engine back to 0s for pitch,yaw and roll
 

--- a/doc/source/structures/vessels/gimbal.rst
+++ b/doc/source/structures/vessels/gimbal.rst
@@ -29,7 +29,7 @@ Many engines in KSP have thrust vectoring gimbals which are handled by their own
           - Percentage of the maximum range the Gimbal is allowed to travel 
 
         * - :attr:`RANGE`
-          - scalar
+          - scalar (deg)
           - The Gimbal's Possible Range of movement
 
         * - :attr:`RESPONSESPEED`
@@ -59,18 +59,18 @@ Many engines in KSP have thrust vectoring gimbals which are handled by their own
     :type: boolean
     :access: Get/Set
         
-    Is this gimbal locked to neutral position and not responding to steeing controls right now? When you set it to true it will snap the engine back to 0s for pitch,yaw and roll
+    Is this gimbal locked to neutral position and not responding to steering controls right now? When you set it to true it will snap the engine back to 0s for pitch, yaw and roll
 
 .. attribute:: Gimbal:LIMIT
 
-    :type: scalar
+    :type: scalar (%)
     :access: Get/Set
         
     Percentage of maximum range this gimbal is allowed to travel
 
 .. attribute:: Gimbal:RANGE
 
-    :type: scalar
+    :type: scalar (deg)
     :access: Get only
 
     The maximum extent of travel possible for the gimbal along all 3 axis (Pitch, Yaw, Roll) 

--- a/doc/source/structures/vessels/gimbal.rst
+++ b/doc/source/structures/vessels/gimbal.rst
@@ -3,7 +3,7 @@
 Gimbal
 ======
 
-Many engines in KSP have thrust vectoring gimbals and in ksp they are their own module
+Many engines in KSP have thrust vectoring gimbals which are handled by their own module
 
 
 .. structure:: Gimbal
@@ -11,18 +11,22 @@ Many engines in KSP have thrust vectoring gimbals and in ksp they are their own 
     .. list-table::
         :header-rows: 1
         :widths: 2 1 4
-		  
+
+        * - Suffix
+          - Type (units)
+          - Description
+
+        * - All suffixes of :struct:`PartModule`
+          -
+          -
+
         * - :attr:`LOCK`
           - boolean
           - Is the Gimbal locked in neutral position? 
           
         * - :attr:`LIMIT`
-          - scalar
+          - scalar (%)
           - Percentage of the maximum range the Gimbal is allowed to travel 
-
-        * - Suffix
-          - Type
-          - Description
 
         * - :attr:`RANGE`
           - scalar

--- a/src/kOS/Suffixed/PartModuleField/GimbalFields.cs
+++ b/src/kOS/Suffixed/PartModuleField/GimbalFields.cs
@@ -19,6 +19,10 @@ namespace kOS.Suffixed.PartModuleField
             {
                 gimbal.gimbalLock = value;
             }, "Is the Gimbal free to travel?"));
+            AddSuffix("LIMIT", new ClampSetSuffix<ScalarValue>(() => gimbal.gimbalLimiter,
+                                              value => gimbal.gimbalLimiter = value,
+                                              0f, 100f, 1f,
+                                              "Gimbal range limit percentage"));
             AddSuffix("RANGE", new Suffix<ScalarValue>(() => gimbal.gimbalRange ,"The Gimbal's Possible Range of movement"));
             AddSuffix("RESPONSESPEED", new Suffix<ScalarValue>(() => gimbal.gimbalResponseSpeed, "The Gimbal's Possible Rate of travel"));
             AddSuffix("PITCHANGLE", new Suffix<ScalarValue>(() =>  gimbal.gimbalLock ? 0 : gimbal.gimbalAnglePitch, "Current Gimbal Pitch"));


### PR DESCRIPTION
Gimbal range limiter suffix for Gimbal ("Gimbal limit" in GUI)
in addition to #1249

Documentation update also includes:
Comment on access through Engine:GIMBAL 
Fixed description of Gimbal:LOCK (the previous version was described opposite to the current functionality)

