### PR TITLE
added two functions to handle keyboard input in user scripts

### DIFF
--- a/src/kOS.Safe/Encapsulation/TerminalStruct.cs
+++ b/src/kOS.Safe/Encapsulation/TerminalStruct.cs
@@ -51,6 +51,12 @@ namespace kOS.Safe.Encapsulation
             AddSuffix("VISUALBEEP", new SetSuffix<BooleanValue>(() => Shared.Screen.VisualBeep,
                                                        value => Shared.Screen.VisualBeep = value,
                                                        "Get or set the value of whether or not the terminal shows beeps silently with a visual flash."));
+            AddSuffix("GETCH", new Suffix<StringValue>(() => Shared.Screen.getch(), "Retrieve a key stroke from the terminal(s)"));
+            AddSuffix("FLUSHKB", new NoArgsVoidSuffix(() =>shared.Screen.flushKB(), "Clear all pending key strokes from the terminal(s)"));
+            AddSuffix("KEYSTROKESREADY",new NoArgsSuffix<ScalarValue>( () => shared.Screen.KeyStrokesReady(),"Return the number of keystokes in buffer"));
+
+
+
         }
         
         public override string ToString()

--- a/src/kOS.Safe/Screen/IScreenBuffer.cs
+++ b/src/kOS.Safe/Screen/IScreenBuffer.cs
@@ -27,5 +27,10 @@ namespace kOS.Safe.Screen
         void AddResizeNotifier(ScreenBuffer.ResizeNotifier notifier);
         void RemoveResizeNotifier(ScreenBuffer.ResizeNotifier notifier);
         string DebugDump();
+        void putch(string ch);
+        string getch();
+        void flushKB();
+        int KeyStrokesReady();
+      
     }
 }

--- a/src/kOS.Safe/Screen/ScreenBuffer.cs
+++ b/src/kOS.Safe/Screen/ScreenBuffer.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using kOS.Safe.UserIO;
 
+
 namespace kOS.Safe.Screen
 {
     public class ScreenBuffer : IScreenBuffer
@@ -13,7 +14,7 @@ namespace kOS.Safe.Screen
         private int topRow;
         private readonly List<IScreenBufferLine> buffer;
         private readonly List<SubBuffer> subBuffers;
-        
+        private List<String> CharForScript;   // this will be a list of characters( really is a unity keycode string)  availble to the script that calls it.
         public int BeepsPending {get; set;}
         
         // These next two things really belong in TermWindow, but then they can't be reached from
@@ -64,6 +65,7 @@ namespace kOS.Safe.Screen
 
             RowCount = DEFAULT_ROWS;
             ColumnCount = DEFAULT_COLUMNS;
+            CharForScript = new List<String>() ;  // start a new script screen buffer 
             InitializeBuffer();
         }
 
@@ -359,6 +361,38 @@ namespace kOS.Safe.Screen
                 }
             }
             return sb.ToString();
+        }
+        
+     
+        
+        public string getch() // player calls this from a script returns key stroke buffer (FIFO)
+        {
+            if (CharForScript.Count > 0)
+            {
+                string c = CharForScript[0];
+                CharForScript.RemoveAt(0);
+                return c;
+            }
+
+            else {
+                return ("NONE"); // if there was no key press return "none" to player .
+            }
+        }
+
+        public void putch(string ch)
+        {
+        CharForScript.Add(ch);  // to be called from the telnet and gui console \
+        if (CharForScript.Count() > 30) CharForScript.RemoveAt(0); // If the buffer exceeds 30 inputs the user probably isn't using the buffer at all so lets start start dumping the older keys
+        }
+
+        public void flushKB()
+        {
+            CharForScript.Clear();  // a kos script can call this function to clear the character list
+        }
+
+        public int KeyStrokesReady()
+        {
+            return CharForScript.Count;
         }
     }
 }

--- a/src/kOS.Safe/Screen/ScreenBuffer.cs
+++ b/src/kOS.Safe/Screen/ScreenBuffer.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using kOS.Safe.UserIO;
 
-
 namespace kOS.Safe.Screen
 {
     public class ScreenBuffer : IScreenBuffer

--- a/src/kOS/Function/Misc.cs
+++ b/src/kOS/Function/Misc.cs
@@ -496,24 +496,7 @@ namespace kOS.Function
     }
 
 
-    [Function("getch")]
-    public class FunctionGetCh : FunctionBase
-    {
-        public override void Execute(SharedObjects shared)
-        {
-            AssertArgBottomAndConsume(shared);
-            ReturnValue = shared.Window.getch().ToString();
-        }
-    }
-    [Function("flushkb")]
-    public class FunctionFlushKB : FunctionBase
-    {
-        public override void Execute(SharedObjects shared)
-        {
-            AssertArgBottomAndConsume(shared);
-            shared.Window.FlushBuffer();
-        }
-    }
+   
 
 
 }

--- a/src/kOS/Function/Misc.cs
+++ b/src/kOS/Function/Misc.cs
@@ -494,4 +494,26 @@ namespace kOS.Function
            ReturnValue = new BuiltinDelegate(shared.Cpu, name);
         }
     }
+
+
+    [Function("getch")]
+    public class FunctionGetCh : FunctionBase
+    {
+        public override void Execute(SharedObjects shared)
+        {
+            AssertArgBottomAndConsume(shared);
+            ReturnValue = shared.Window.getch().ToString();
+        }
+    }
+    [Function("flushkb")]
+    public class FunctionFlushKB : FunctionBase
+    {
+        public override void Execute(SharedObjects shared)
+        {
+            AssertArgBottomAndConsume(shared);
+            shared.Window.FlushBuffer();
+        }
+    }
+
+
 }

--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -30,7 +30,7 @@ namespace kOS.Screen
         private GUIStyle tinyToggleStyle;
         private Vector2 resizeOldSize;
         private bool resizeMouseDown;
-        
+        private List<UnityEngine.KeyCode> CharForScript;   // this will be a list of characters availble to the script that calls it.
         private bool consumeEvent;
         private bool keyClickEnabled;
         
@@ -135,8 +135,10 @@ namespace kOS.Screen
         public override void GetFocus()
         {
             Lock();
+            CharForScript = new List<UnityEngine.KeyCode>();  // start a new script screen buffer when the player moves focus to the terminal Window
+
         }
-        
+
         public override void LoseFocus()
         {
             Unlock();
@@ -356,6 +358,7 @@ namespace kOS.Screen
             Event e = Event.current;
             if (e.type == EventType.KeyDown)
             {
+                if (e.keyCode != KeyCode.None) CharForScript.Add(e.keyCode);  // add this keypress to the buffer for the user script to pick up later. 
                 // Unity handles some keys in a particular way
                 // e.g. Keypad7 is mapped to 0xffb7 instead of 0x37
                 var c = (char)(e.character & 0x007f);
@@ -959,6 +962,26 @@ namespace kOS.Screen
         {
             return (int)(WindowRect.width - 65) / CHARSIZE;
         }
+        public void FlushBuffer()
+        {
+            CharForScript.Clear();  // a kos script can call this function to clear the character list
+        }
 
+        public UnityEngine.KeyCode getch() // player calls this from a script returns key stroke buffer (FIFO)
+        {
+            if (CharForScript.Count > 0)
+            {
+                UnityEngine.KeyCode c = CharForScript[0];
+                CharForScript.RemoveAt(0);
+                return c;
+            }
+
+            else {
+                return (UnityEngine.KeyCode.None); // if there was no key press return "none" to player .
+            }
+        }
     }
+
+
+
 }


### PR DESCRIPTION
**Getch()** will return characters from the in game terminal for use in a script. It is non-blocking and will return "none" if there isn't a key press availble. The buffer is FIFO.

**FlushKB()** will clear the contents of the buffer and should be called in a script before the user is expected to make a key press.
example use in ks file:
set quit to 0 . 
flushkb().
until quit
{
local s is getch(). 
if (s <> "none") {print s.}
wait .25. 
}
[getkeyboard.ks.txt](https://github.com/KSP-KOS/KOS/files/129535/getkeyboard.ks.txt)

