### PR TITLE
Should allow us to fix ckan

### DIFF
--- a/kOS.netkan
+++ b/kOS.netkan
@@ -1,0 +1,37 @@
+{
+    "spec_version"   : 1,
+    "identifier"     : "kOS",
+    "$kref"          : "#/ckan/github/KSP-KOS/KOS",
+    "$vref"          : "#/ckan/ksp-avc",
+    "name"           : "kOS: Scriptable Autopilot System",
+    "abstract"       : "kOS is a scriptable autopilot Mod for Kerbal Space Program. It allows you write small programs that automate specific tasks.",
+    "author"         : "erendrake",
+    "license"        : "GPL-3.0",
+    "release_status" : "stable",
+    "resources"      : {
+        "homepage"   : "http://ksp-kos.github.io/KOS_DOC/",
+        "manual"     : "http://ksp-kos.github.io/KOS_DOC/",
+        "repository" : "https://github.com/KSP-KOS/KOS"
+    },
+    "conflicts"      :   [ { "name" : "kOS-Classic" } ],
+    "recommends"     : [
+        {
+            "name": "ModuleManager",
+            "min_version": "2.5.6",
+            "comment": "Earlier versions of MM have forward compatibility problems, according to the MM release notes."
+        }
+    ],
+    "suggests": [
+        {
+            "name": "RemoteTech",
+            "min_version": "1.5.1",
+            "comment": "RT gives incentive to having local control of craft, even unmanned ones"
+        }
+    ],
+    "install" : [
+        {
+            "file"   : "GameData/kOS",
+            "install_to" : "GameData"
+        }
+    ]
+}


### PR DESCRIPTION
I AM INTENTIONALLY SUBMITTING THIS PR AGAINST THE MASTER BRANCH
With the closure of Kerbal Stuff, ckan no longer knows where to have a user download our mod.  The recommended answer I got from the ckan team was to create our own netkan file to manage the details ourselves.  This ends up being a 2 part solution: 1) we create our own netkan file (this PR) and then 2) we submit a PR to the netkan repository, changing their netkan file to reference our own instead of Kerbal Stuff.

I'm submitting as a PR for the sake of protocol.  There should be no issue merging this as it will have no effect on the mod itself.

kOS.netkan
* Adding this file should allow us to manage the can listing ourselves,
instead of relying on kerbalstuff (now gone).
* After merged, I will make a PR to the netkan repository so that they
reference this file.
* While this file references out github, we will have the ability to
point it to the Kerbal Stuff replacement, if desired.