### PR TITLE
Fix ckan version string

### DIFF
--- a/kOS.netkan
+++ b/kOS.netkan
@@ -8,6 +8,7 @@
     "author"         : "erendrake",
     "license"        : "GPL-3.0",
     "release_status" : "stable",
+    "x_netkan_version_edit": "^[vV]?(?<version>.+)$",
     "resources"      : {
         "homepage"   : "http://ksp-kos.github.io/KOS_DOC/",
         "manual"     : "http://ksp-kos.github.io/KOS_DOC/",


### PR DESCRIPTION
Found one issue with the netkan file after talking to the ckan guys on IRC.

kOS.netkan
* Per the ckan devs, added a version edit parameter which strips the "v"
from "v0.18.2" to maintain compatibility with former numbering system