### PR TITLE
Move KAL9000 to Automation, resolves #1430

### DIFF
--- a/Resources/GameData/kOS/Parts/kOSkal9000/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSkal9000/part.cfg
@@ -14,7 +14,7 @@ rescaleFactor = 1
 node_attach = 0.01, 0.0, 0.0, 1, 0, 0, 0
 
 // --- Tech tree ---
-TechRequired = precisionEngineering
+TechRequired = automation
 
 // --- editor parameters ---
 cost = 1200


### PR DESCRIPTION
Moving KAL to further in the tech tree, as it's an endgame part.