### PR TITLE
Removed delay on event invoking.

### DIFF
--- a/src/kOS/Suffixed/Part/EngineValue.cs
+++ b/src/kOS/Suffixed/Part/EngineValue.cs
@@ -180,7 +180,8 @@ namespace kOS.Suffixed.Part
             if (!MultiMode)
                 throw new KOSException("Attempted to call the TOGGLEMODE suffix on a non-multi mode engine.");
             // Use Invoke to call ModeEvent, since the underlying method is private.
-            MMengine.Invoke("ModeEvent", 0);
+            // partModule.Invoke(eventName, 0) introduces 1-frame delay. Getting the event directly does it immediately.
+            MMengine.Events.FirstOrDefault(kspEvent => kspEvent.name == "ModeEvent").Invoke();
         }
 
         public BooleanValue GetRunningPrimary()
@@ -216,9 +217,9 @@ namespace kOS.Suffixed.Part
             if (MMengine.autoSwitch != auto)
             {
                 if (auto)
-                    MMengine.Invoke("EnableAutoSwitch", 0);
+                    MMengine.Events.FirstOrDefault(kspEvent => kspEvent.name == "EnableAutoSwitch").Invoke();
                 else
-                    MMengine.Invoke("DisableAutoSwitch", 0);
+                    MMengine.Events.FirstOrDefault(kspEvent => kspEvent.name == "DisableAutoSwitch").Invoke();
             }
         }
 

--- a/src/kOS/Suffixed/Part/EngineValue.cs
+++ b/src/kOS/Suffixed/Part/EngineValue.cs
@@ -181,7 +181,7 @@ namespace kOS.Suffixed.Part
                 throw new KOSException("Attempted to call the TOGGLEMODE suffix on a non-multi mode engine.");
             // Use Invoke to call ModeEvent, since the underlying method is private.
             // partModule.Invoke(eventName, 0) introduces 1-frame delay. Getting the event directly does it immediately.
-            MMengine.Events.FirstOrDefault(kspEvent => kspEvent.name == "ModeEvent").Invoke();
+            MMengine.Events.First(kspEvent => kspEvent.name == "ModeEvent").Invoke();
         }
 
         public BooleanValue GetRunningPrimary()
@@ -217,9 +217,9 @@ namespace kOS.Suffixed.Part
             if (MMengine.autoSwitch != auto)
             {
                 if (auto)
-                    MMengine.Events.FirstOrDefault(kspEvent => kspEvent.name == "EnableAutoSwitch").Invoke();
+                    MMengine.Events.First(kspEvent => kspEvent.name == "EnableAutoSwitch").Invoke();
                 else
-                    MMengine.Events.FirstOrDefault(kspEvent => kspEvent.name == "DisableAutoSwitch").Invoke();
+                    MMengine.Events.First(kspEvent => kspEvent.name == "DisableAutoSwitch").Invoke();
             }
         }
 


### PR DESCRIPTION
It turns out that `PartModule.Invoke(eventName, 0)` introduces 1-frame delay. 
Changed it to the method used in `partmodule:DOEVENT` - getting the event itself and calling  `BaseEvent.Invoke()`, which works immediately.