### PR TITLE
fixes #1413 with string comparisons.

### DIFF
--- a/doc/source/language/features.rst
+++ b/doc/source/language/features.rst
@@ -10,9 +10,8 @@ General Features of the **KerboScript** Language
 Case Insensitivity
 ------------------
 
-Everything in **KerboScript** is case-insensitive, including your own variable names and filenames. The only exception is when you perform a string comparison, (``"Hello"="HELLO"`` will return false.)
-
-Most of the examples here will show the syntax in all-uppercase to help make it stand out from the explanatory text.
+Everything in **KerboScript** is case-insensitive, including your own variable names and filenames.
+This extends to string comparison as well. (``"Hello"="HELLO"`` will return true.)
 
 Expressions
 -----------

--- a/doc/source/language/syntax.rst
+++ b/doc/source/language/syntax.rst
@@ -51,7 +51,7 @@ underscore). The first character must be a letter. The rest may be letters, digi
     My_Variable  my_varible  MY_VARAIBLE
 
 **case-insensitivity**
-    The same case-insensitivity applies throughout the entire language, with all keywords except when comparing literal strings. The values inside the strings are still case-sensitive, for example, the following will print "unequal"::
+    The same case-insensitivity applies throughout the entire language, with all keywords and when comparing literal strings. The values inside the strings are also case-insensitive, for example, the following will print "equal"::
 
         if "hello" = "HELLO" {
             print "equal".

--- a/doc/source/structures/misc/string.rst
+++ b/doc/source/structures/misc/string.rst
@@ -77,7 +77,6 @@ comparison, and then the string comparison looks one character at
 a time and notices that "1" is less than "9" and calls "1234" the
 lesser value.
 
-
 CASE SENSITIVIY
 ~~~~~~~~~~~~~~~
 
@@ -86,6 +85,10 @@ matches, and all string searches, are currently case **in** sensive,
 meaning that for example the letter "A" and the letter "a" are
 indistinguishable.  There are future plans to add mechanisms that
 will let you choose case-sensitivity when you prefer.
+
+At the moment the only way to force a case-sensitive comparison is
+to look at the characters one at a time and obtain their numerical
+ordinal Unicode value with the :func:`unchar(a)` function.
 	
 Structure
 ---------
@@ -330,9 +333,12 @@ Access to Individual Characters
 All string indexes start counting at zero. (The characters are numbered from 0 to N-1 rather than from 1 to N.)
 
 ``string[expression]``
-    operator: access the character at position 'expression'. Any arbitrary complex expression may be used with this syntax, not just a number or variable name.
+
+  - operator: access the character at position 'expression'. Any arbitrary complex expression may be used with this syntax, not just a number or variable name.
+    
 ``FOR VAR IN STRING { ... }.``
-    :ref:`A type of loop <flow>` in which var iterates over all the characters of the string from 0 to LENGTH-1.
+
+  - :ref:`A type of loop <flow>` in which var iterates over all the characters of the string from 0 to LENGTH-1.
 
 Examples::
 

--- a/doc/source/structures/misc/string.rst
+++ b/doc/source/structures/misc/string.rst
@@ -30,16 +30,62 @@ Strings are iterable. This scripts prints the string's characters one per line::
     PRINT c.
   }
 
+Boolean Operators
+-----------------
+
+Equality
+~~~~~~~~
+
+Using the ``=`` and ``<>`` operators, two strings are equal
+if and only if they are the same length and have letters that differ
+only in capitalization (``a`` and ``A`` are considered the same letter
+for this test).
+
+Ordering
+~~~~~~~~
+
+Using the ``<``, ``>``, ``<=``, and ``>=`` operators, one
+string is considered to be less than the other if it is alphabetically
+sooner according to the ordering of its Unicode mapping, with the
+exception that capitalization is ingored (``a`` and ``A`` are
+considered the same letter).  Starting from the lefthand side of the
+two strings, the characters are compered one at a time until the first
+difference is found, and that first difference decides the ordering.
+If one of the strings is shorter length than the other, and the characters
+are all equal up until one of the two strings runs out of characters,
+then the shorter string will be considered "less than" the longer one.
+
+Mixtures of strings and non-strings
+:::::::::::::::::::::::::::::::::::
+
+If you attempt to compare two things only one of which is a string
+and the other is not, then the non-string will be converted into a
+string first, (Giving the same string as its :TOSTRING suffix would
+give), and the two will be compared as strings.  Example::
+
+    print (1234 < 99).    // prints "False"
+    print ("1234" < 99).  // prints "True"
+
+In the first example, both sides of the ``<`` operator are
+:ref:`scalars <scalar>`, so the comparison is done numerically,
+and 1234 is much bigger than 99.
+
+In the second example, one side of the ``<`` operator is a 
+string, so the other side is converted from the :ref:`scalar <scalar>`
+``99`` into the :ref:`string <string>` ``"99"`` to perform the
+comparison, and then the string comparison looks one character at
+a time and notices that "1" is less than "9" and calls "1234" the
+lesser value.
 
 
 CASE SENSITIVIY
 ~~~~~~~~~~~~~~~
 
-NOTE: All string comparisons, substring matches, and searches, are
-currently case **in** sensive, meaning that for example the letter
-"A" and the letter "a" are indistinguishable.  There are future
-plans to add mechanisms that will let you choose case-sensitivity
-when you prefer.
+NOTE: All string comparisons for equality and ordering, all substring
+matches, and all string searches, are currently case **in** sensive,
+meaning that for example the letter "A" and the letter "a" are
+indistinguishable.  There are future plans to add mechanisms that
+will let you choose case-sensitivity when you prefer.
 	
 Structure
 ---------

--- a/kerboscript_tests/string/stringtester.ks
+++ b/kerboscript_tests/string/stringtester.ks
@@ -34,3 +34,45 @@ PRINT "''  Hello!  '':TRIMSTART():    " + "  Hello!  ":TRIMSTART().     // Hello
 PRINT "''  Hello!  '':TRIMEND():      " + "  Hello!  ":TRIMEND().       //   Hello!
 PRINT " ".
 PRINT "Chained: " + "Hello!":SUBSTRING(0, 4):TOUPPER():REPLACE("ELL", "ELEPHANT").  // HELEPHANT
+function comparetest {
+  parameter a, b.
+
+  // This is the correct way, but it can't be run until PR #1412 is merged:
+  //     local qt_a is "".
+  //     if a:istype("string") { set qt_a to CHAR(34). }
+  //     local qt_b is "".
+  //     if b:istype("string") { set qt_b to CHAR(34). }
+  // This is the less good way for now: quote everything, like it or not:
+  local qt_a is CHAR(34).
+  local qt_b is CHAR(34).
+
+  PRINT "string compare: " + qt_a + a + qt_a + " <  " + qt_b + b + qt_b + " is " + (a <  b).
+  PRINT "string compare: " + qt_a + a + qt_a + " <= " + qt_b + b + qt_b + " is " + (a <= b).
+  PRINT "string compare: " + qt_a + a + qt_a + " >  " + qt_b + b + qt_b + " is " + (a >  b).
+  PRINT "string compare: " + qt_a + a + qt_a + " >= " + qt_b + b + qt_b + " is " + (a >= b).
+  PRINT "string compare: " + qt_a + a + qt_a + " =  " + qt_b + b + qt_b + " is " + (a =  b).
+  PRINT "string compare: " + qt_a + a + qt_a + " <> " + qt_b + b + qt_b + " is " + (a <> b).
+}
+SET s1_lower to "abc def".
+SET s1_upper to "ABC DEF".
+SET s2_lower to "abc dfe".
+SET s2_upper to "ABC DFE".
+PRINT "Test: differ in case only:".
+comparetest(s1_lower,s1_upper).
+PRINT "Test: differ in case only:".
+comparetest(s2_lower,s2_upper).
+PRINT "Test: left < right, same case:".
+comparetest(s1_lower,s2_lower).
+PRINT "Test: left < right, different case:".
+comparetest(s1_lower,s2_upper).
+PRINT ":::".
+PRINT "Mixing types with string to make ToString compares:".
+PRINT ":::".
+PRINT "Test: same value, int:".
+comparetest("123", 123).
+PRINT "Test: same value, double:".
+comparetest("123.456", 123.456).
+PRINT "Test: different value, int, note string, not number compare:".
+comparetest("123", 1000).
+PRINT "Test: different value, double, note string, not number compare:".
+comparetest("123.456", 1000.456).

--- a/src/kOS.Safe/Compilation/CalculatorString.cs
+++ b/src/kOS.Safe/Compilation/CalculatorString.cs
@@ -6,17 +6,6 @@ namespace kOS.Safe.Compilation
 {
     public class CalculatorString : Calculator
     {
-        public static void ThrowIfNotStrings(OperandPair pair)
-        {
-            if (!(pair.Left is string))
-            {
-                throw new KOSCastException(pair.Left.GetType(), typeof(string));
-            }
-            if (!(pair.Right is string))
-            {
-                throw new KOSCastException(pair.Right.GetType(), typeof(string));
-            }
-        }
         public override object Add(OperandPair pair)
         {
             return new StringValue(string.Concat(pair.Left, pair.Right));
@@ -44,26 +33,26 @@ namespace kOS.Safe.Compilation
 
         public override object GreaterThan(OperandPair pair)
         {
-            ThrowIfNotStrings(pair);
-            return pair.Left.ToString().Length > pair.Right.ToString().Length;
+            int compareNum = string.Compare(pair.Left.ToString(), pair.Right.ToString(), StringComparison.OrdinalIgnoreCase);
+            return compareNum > 0;
         }
 
         public override object LessThan(OperandPair pair)
         {
-            ThrowIfNotStrings(pair);
-            return pair.Left.ToString().Length < pair.Right.ToString().Length;
+            int compareNum = string.Compare(pair.Left.ToString(), pair.Right.ToString(), StringComparison.OrdinalIgnoreCase);
+            return compareNum < 0;
         }
 
         public override object GreaterThanEqual(OperandPair pair)
         {
-            ThrowIfNotStrings(pair);
-            return pair.Left.ToString().Length >= pair.Right.ToString().Length;
+            int compareNum = string.Compare(pair.Left.ToString(), pair.Right.ToString(), StringComparison.OrdinalIgnoreCase);
+            return compareNum >= 0;
         }
 
         public override object LessThanEqual(OperandPair pair)
         {
-            ThrowIfNotStrings(pair);
-            return pair.Left.ToString().Length <= pair.Right.ToString().Length;
+            int compareNum = string.Compare(pair.Left.ToString(), pair.Right.ToString(), StringComparison.OrdinalIgnoreCase);
+            return compareNum <= 0;
         }
 
         public override object NotEqual(OperandPair pair)
@@ -78,18 +67,18 @@ namespace kOS.Safe.Compilation
 
         public override object Min(OperandPair pair)
         {
-            ThrowIfNotStrings(pair);
             string arg1 = pair.Left.ToString();
             string arg2 = pair.Right.ToString();
-            return (arg1.Length < arg2.Length) ? arg1 : arg2;
+            int compareNum = string.Compare(arg1, arg2, StringComparison.OrdinalIgnoreCase);
+            return (compareNum < 0) ? arg1 : arg2;
         }
 
         public override object Max(OperandPair pair)
         {
-            ThrowIfNotStrings(pair);
             string arg1 = pair.Left.ToString();
             string arg2 = pair.Right.ToString();
-            return (arg1.Length > arg2.Length) ? arg1 : arg2;
+            int compareNum = string.Compare(arg1, arg2, StringComparison.OrdinalIgnoreCase);
+            return (compareNum > 0) ? arg1 : arg2;
         }
     }
 }

--- a/src/kOS.Safe/Encapsulation/StringValue.cs
+++ b/src/kOS.Safe/Encapsulation/StringValue.cs
@@ -228,6 +228,30 @@ namespace kOS.Safe.Encapsulation
             return !(val1 == val2);
         }
 
+        public static bool operator >(StringValue val1, StringValue val2)
+        {
+            int compareNum = string.Compare(val1, val2, StringComparison.OrdinalIgnoreCase);
+            return compareNum > 0;
+        }
+
+        public static bool operator <(StringValue val1, StringValue val2)
+        {
+            int compareNum = string.Compare(val1, val2, StringComparison.OrdinalIgnoreCase);
+            return compareNum < 0;
+        }
+
+        public static bool operator >=(StringValue val1, StringValue val2)
+        {
+            int compareNum = string.Compare(val1, val2, StringComparison.OrdinalIgnoreCase);
+            return compareNum >= 0;
+        }
+
+        public static bool operator <=(StringValue val1, StringValue val2)
+        {
+            int compareNum = string.Compare(val1, val2, StringComparison.OrdinalIgnoreCase);
+            return compareNum <= 0;
+        }
+
         // Implicitly converts to a string (i.e., unboxes itself automatically)
         public static implicit operator string(StringValue value)
         {


### PR DESCRIPTION
Chose OrdinalCaseInsensitive because that's how the
equals check works.

When kerboscript compares a string to a non-string,
the non-string will be ToString()'ed in order to
allow the comparison, which is the same logic as
was used for equality comparison.  As long as ONE
of the two values is a string, the string comparison
rules are used rather than the numerical rules.

Example:

- This is false: `1234 < 99`
- This is true: `1234 < "99"`