### PR TITLE
Added links to types on Structure and String pages.

### DIFF
--- a/doc/source/structures/misc/string.rst
+++ b/doc/source/structures/misc/string.rst
@@ -110,28 +110,28 @@ Structure
           - :ref:`boolean <boolean>`
           - True if this string ends with the given string 
         * - :meth:`FIND(string)`
-          - integer
+          - :struct:`Scalar`
           - Returns the index of the first occurrence of the given string in this string (starting from 0)
         * - :meth:`FINDAT(string, startAt)`
-          - integer
+          - :struct:`Scalar`
           - Returns the index of the first occurrence of the given string in this string (starting from startAt)
         * - :meth:`FINDLAST(string)`
-          - integer
+          - :struct:`Scalar`
           - Returns the index of the last occurrence of the given string in this string (starting from 0)
         * - :meth:`FINDLASTAT(string, startAt)`
-          - integer
+          - :struct:`Scalar`
           - Returns the index of the last occurrence of the given string in this string (starting from startAt)
         * - :meth:`INDEXOF(string)`
-          - integer
+          - :struct:`Scalar`
           - Alias for FIND(string)
         * - :meth:`INSERT(index, string)`
           - :struct:`String`
           - Returns a new string with the given string inserted at the given index into this string
         * - :meth:`LASTINDEXOF(string)`
-          - integer
+          - :struct:`Scalar`
           - Alias for FINDLAST(string)
         * - :attr:`LENGTH`
-          - integer
+          - :struct:`Scalar`
           - Number of characters in the string
         * - :meth:`PADLEFT(width)`
           - :struct:`String`
@@ -195,7 +195,7 @@ Structure
 .. method:: String:FINDAT(string, startAt)
 
     :parameter string: :struct:`String` to look for
-    :parameter startAt: integer index to start searching at
+    :parameter startAt: :struct:`Scalar` (integer) index to start searching at
     :type: :struct:`String`
     
     Returns the index of the first occurrence of the given string in this string (starting from startAt).
@@ -210,7 +210,7 @@ Structure
 .. method:: String:FINDLASTAT(string, startAt)
 
     :parameter string: :struct:`String` to look for
-    :parameter startAt: integer index to start searching at
+    :parameter startAt: :struct:`Scalar` (integer) index to start searching at
     :type: :struct:`String`
 
     Returns the index of the last occurrence of the given string in this string (starting from startAt)
@@ -221,7 +221,7 @@ Structure
 
 .. method:: String:INSERT(index, string)
 
-    :parameter index: integer index to add the string at
+    :parameter index: :struct:`Scalar` (integer) index to add the string at
     :parameter string: :struct:`String` to insert
     :type: :struct:`String`
 
@@ -233,29 +233,29 @@ Structure
 
 .. attribute:: String:LENGTH
 
-    :type: integer
+    :type: :struct:`Scalar` (integer)
     :access: Get only
 
     Number of characters in the string
 
 .. method:: String:PADLEFT(width)
 
-    :parameter width: integer number of characters the resulting string will contain
+    :parameter width: :struct:`Scalar` (integer) number of characters the resulting string will contain
     :type: :struct:`String`
 
     Returns a new right-aligned version of this string padded to the given width by spaces.
 
 .. method:: String:PADRIGHT(width)
 
-    :parameter width: integer number of characters the resulting string will contain
+    :parameter width: :struct:`Scalar` (integer) number of characters the resulting string will contain
     :type: :struct:`String`
 
     Returns a new left-aligned version of this string padded to the given width by spaces.
 
 .. method:: String:REMOVE(index,count)
 
-    :parameter index: integer position of the string from which characters will be removed from the resulting string
-    :parameter count: integer number of characters that will be removing from the resulting string
+    :parameter index: :struct:`Scalar` (integer) position of the string from which characters will be removed from the resulting string
+    :parameter count: :struct:`Scalar` (integer) number of characters that will be removing from the resulting string
     :type: :struct:`String`
 
     Returns a new string out of this string with the given count of characters removed starting at the given index.
@@ -285,8 +285,8 @@ Structure
 
 .. method:: String:SUBSTRING(start,count)
 
-    :parameter start: (integer) starting index (from zero)
-    :parameter count: (integer) resulting length of returned :struct:`String`
+    :parameter start: :struct:`Scalar` (integer) starting index (from zero)
+    :parameter count: :struct:`Scalar` (integer) resulting length of returned :struct:`String`
     :return: :struct:`String`
 
     Returns a new string with the given count of characters from this string starting from the given start position.

--- a/doc/source/structures/reflection/structure.rst
+++ b/doc/source/structures/reflection/structure.rst
@@ -48,11 +48,11 @@ or ``42`` or ``"abc"``.  For example, you can do::
           - Description
 
         * - :attr:`TOSTRING`
-          - String
+          - :struct:`String`
           - The string that gets shown on-screen when doing the PRINT command.
 
         * - :attr:`HASSUFFIX(name)`
-          - Boolean
+          - :struct:`Boolean`
           - Test whether or not this value has a suffix with the given name.
 
         * - :attr:`SUFFIXNAMES`
@@ -60,24 +60,24 @@ or ``42`` or ``"abc"``.  For example, you can do::
           - Gives a list of all the names of all the suffixes this thing has.
 
         * - :attr:`ISSERIALIZABLE`
-          - Boolean
+          - :struct:`Boolean`
           - Is true if this type is one that works with :ref:`WRITEJSON <writejson>`
 
         * - :attr:`TYPENAME`
-          - String
+          - :struct:`String`
           - Gives a string for the name of the type of this object.
 
         * - :attr:`ISTYPE(name)`
-          - Boolean
+          - :struct:`Boolean`
           - true if this value is of the given type name, or is derived from the given type name
 
         * - :attr:`INHERITANCE`
-          - String
+          - :struct:`String`
           - Gives a string describing the kOS type, and the kOS types it is inherited from.
 
 .. attribute:: Structure:TOSTRING
 
-    :type: String
+    :type: :struct:`String`
     :access: Get only
 
     When issuing the command ``PRINT aaa.``, the variable ``aaa`` gets
@@ -87,8 +87,8 @@ or ``42`` or ``"abc"``.  For example, you can do::
 
 .. attribute:: Structure:HASSUFFIX(name)
 
-    :parameter name: string name of the suffix being tested for
-    :type: Boolean
+    :parameter name: :struct:`String` name of the suffix being tested for
+    :type: :struct:`Boolean`
     :access: Get only
 
     Given the name of a suffix, returns true if the object has a suffix
@@ -149,7 +149,7 @@ or ``42`` or ``"abc"``.  For example, you can do::
 
 .. attribute:: Structure:TYPENAME
 
-    :type: String
+    :type: :struct:`String`
     :access: Get only
 
     Gives the name of the type of the object, in kOS terminology.
@@ -187,7 +187,7 @@ or ``42`` or ``"abc"``.  For example, you can do::
 .. attribute:: Structure:ISTYPE(name)
 
     :Parameter name: string name of the type being checked for
-    :type: Boolean
+    :type: :struct:`Boolean`
     :access: Get only
 
     This is ``True`` if the value is of the type mentioned in the name, or
@@ -214,7 +214,7 @@ or ``42`` or ``"abc"``.  For example, you can do::
 
 .. attribute:: Structure:INHERITANCE
 
-    :type: String
+    :type: :struct:`String`
     :access: Get only
 
     Gives a string describing the typename of this value, and the
@@ -235,7 +235,7 @@ or ``42`` or ``"abc"``.  For example, you can do::
 
 .. attribute:: Structure:ISSERIALIZABLE
 
-    :type: Boolean
+    :type: :struct:`Boolean`
     :access: Get only
 
     Not all types can be saved using the built-in serialization function


### PR DESCRIPTION
Type links were missing on these two pages.
Added as ``:struct:`` links because I think that's what we'll likely move everything to later, but at the moment it doesn't matter yet for this PR - there's no consistent rule yet anyway.
