### PR TITLE
Fix hard disk file rename

### DIFF
--- a/src/kOS.Safe/Persistence/Harddisk.cs
+++ b/src/kOS.Safe/Persistence/Harddisk.cs
@@ -63,8 +63,10 @@ namespace kOS.Safe.Persistence
             VolumeFile file = Open(name);
             if (file != null)
             {
-                Delete(name);
-                Save(new HarddiskFile(this, newName));
+                // Add the original file content under the new name
+                files.Add(newName, files[file.Name]);
+                // Then remove the old file content under the old name
+                files.Remove(file.Name);
                 return true;
             }
             return false;
@@ -105,30 +107,35 @@ namespace kOS.Safe.Persistence
 
         private VolumeFile FileSearch(string name, bool ksmDefault = false)
         {
-            VolumeFile file;
-            if (FileList.TryGetValue(name, out file))
+            if (files.Keys.Contains(name))
             {
-                return file;
+                return new HarddiskFile(this, name);
             }
-
-            var kerboscriptFilename = PersistenceUtilities.CookedFilename(name, KERBOSCRIPT_EXTENSION, true);
-            var kosMlFilename = PersistenceUtilities.CookedFilename(name, KOS_MACHINELANGUAGE_EXTENSION, true);
-
-            VolumeFile kerboscriptFile;
-            VolumeFile kosMlFile;
-            bool kerboscriptFileExists = FileList.TryGetValue(kerboscriptFilename, out kerboscriptFile);
-            bool kosMlFileExists = FileList.TryGetValue(kosMlFilename, out kosMlFile);
-            if (kerboscriptFileExists && kosMlFileExists)
+            else
             {
-                return ksmDefault ? kosMlFile : kerboscriptFile;
-            }
-            if (kerboscriptFile != null)
-            {
-                return kerboscriptFile;
-            }
-            if (kosMlFile != null)
-            {
-                return kosMlFile;
+                var kerboscriptFilename = PersistenceUtilities.CookedFilename(name, KERBOSCRIPT_EXTENSION, true);
+                var kosMlFilename = PersistenceUtilities.CookedFilename(name, KOS_MACHINELANGUAGE_EXTENSION, true);
+                bool kerboscriptFileExists = files.ContainsKey(kerboscriptFilename);
+                bool kosMlFileExists = files.ContainsKey(kosMlFilename);
+                if (kerboscriptFileExists && kosMlFileExists)
+                {
+                    if (ksmDefault)
+                    {
+                        return new HarddiskFile(this, kosMlFilename);
+                    }
+                    else
+                    {
+                        return new HarddiskFile(this, kerboscriptFilename);
+                    }
+                }
+                if (kerboscriptFileExists)
+                {
+                    return new HarddiskFile(this, kerboscriptFilename);
+                }
+                if (kosMlFileExists)
+                {
+                    return new HarddiskFile(this, kosMlFilename);
+                }
             }
             return null;
         }

--- a/src/kOS.Safe/Persistence/Harddisk.cs
+++ b/src/kOS.Safe/Persistence/Harddisk.cs
@@ -107,7 +107,7 @@ namespace kOS.Safe.Persistence
 
         private VolumeFile FileSearch(string name, bool ksmDefault = false)
         {
-            if (files.Keys.Contains(name))
+            if (files.ContainsKey(name))
             {
                 return new HarddiskFile(this, name);
             }

--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -341,7 +341,7 @@ namespace kOS.Module
                         FileContent content = bootVolumeFile.ReadAll();
                         if (HardDisk.IsRoomFor(bootFile, content))
                         {
-                            HardDisk.Save(bootFile, bootVolumeFile.ReadAll());
+                            HardDisk.Save(bootFile, content);
                         }
                         else
                         {

--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -338,7 +338,18 @@ namespace kOS.Module
                     var bootVolumeFile = archive.Open(bootFile);
                     if (bootVolumeFile != null)
                     {
-                        HardDisk.Save(bootFile, bootVolumeFile.ReadAll());
+                        FileContent content = bootVolumeFile.ReadAll();
+                        if (HardDisk.IsRoomFor(bootFile, content))
+                        {
+                            HardDisk.Save(bootFile, bootVolumeFile.ReadAll());
+                        }
+                        else
+                        {
+                            // Throwing an exception during InitObjects will break the initialization and won't show
+                            // the error to the user.  So we just log the error instead.  At some point in the future
+                            // it would be nice to queue up these init errors and display them to the user somewhere.
+                            SafeHouse.Logger.LogError("Error copying boot file to local volume: not enough space.");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes #1498
Fixes #1094

Harddisk.cs
* Update Rename method to work with directly with the files dictionary and bypass the normal Delete/Save methods
* Update FileSearch to try and improve performance by avoiding extra HarddiskFile and Dictionary instantiation

kOSProcessor.cs
* Add a check for boot file size because saving the boot file is now size checked, and will throw an exception breaking processor initialization.