### PR TITLE
Fix unit tests

### DIFF
--- a/src/kOS.Safe.Test/Collections/ListValueTest.cs
+++ b/src/kOS.Safe.Test/Collections/ListValueTest.cs
@@ -196,22 +196,30 @@ namespace kOS.Safe.Test.Collections
 
             var baseList = new ListValue();
             var baseDelegate = baseList.GetSuffix("LENGTH");
+            cpu.PushStack(null); // dummy push to be popped by ReverseStackArgs
+            cpu.PushStack(new KOSArgMarkerType());
             baseDelegate.Invoke(cpu);
             Assert.AreEqual(ScalarIntValue.Zero, baseDelegate.Value);
 
             var castList = ListValue.CreateList(new List<object>());
             var castDelegate = castList.GetSuffix("LENGTH");
-            baseDelegate.Invoke(cpu);
+            cpu.PushStack(null); // dummy push to be popped by ReverseStackArgs
+            cpu.PushStack(new KOSArgMarkerType());
+            castDelegate.Invoke(cpu);
             Assert.AreEqual(ScalarIntValue.Zero, castDelegate.Value);
 
             var copyDelegate = baseList.GetSuffix("COPY");
-            baseDelegate.Invoke(cpu);
-            Assert.AreEqual(ScalarIntValue.Zero, castDelegate.Value);
+            cpu.PushStack(null); // dummy push to be popped by ReverseStackArgs
+            cpu.PushStack(new KOSArgMarkerType());
+            copyDelegate.Invoke(cpu);
             var copyList = copyDelegate.Value;
+            Assert.AreEqual(baseList, copyList);
 
             var lengthDelegate = copyList.GetSuffix("LENGTH");
-            baseDelegate.Invoke(cpu);
-            Assert.AreEqual(ScalarIntValue.Zero, lengthDelegate);
+            cpu.PushStack(null); // dummy push to be popped by ReverseStackArgs
+            cpu.PushStack(new KOSArgMarkerType());
+            lengthDelegate.Invoke(cpu);
+            Assert.AreEqual(ScalarIntValue.Zero, lengthDelegate.Value);
         }
     }
 }

--- a/src/kOS.Safe.Test/Collections/RangeValueTest.cs
+++ b/src/kOS.Safe.Test/Collections/RangeValueTest.cs
@@ -30,8 +30,8 @@ namespace kOS.Safe.Test.Collections
         {
             var range = new RangeValue(5);
             Assert.AreEqual(new ScalarIntValue(5), InvokeDelegate(range, "LENGTH"));
-            Assert.AreEqual(new ScalarIntValue(0), InvokeDelegate(range, "FROM"));
-            Assert.AreEqual(new ScalarIntValue(5), InvokeDelegate(range, "TO"));
+            Assert.AreEqual(new ScalarIntValue(0), InvokeDelegate(range, "START"));
+            Assert.AreEqual(new ScalarIntValue(5), InvokeDelegate(range, "STOP"));
             Assert.AreEqual(new ScalarIntValue(1), InvokeDelegate(range, "STEP"));
             Assert.IsFalse((BooleanValue)InvokeDelegate(range, "EMPTY"));
             Assert.IsTrue((BooleanValue)InvokeDelegate(range, "CONTAINS", new ScalarIntValue(1)));
@@ -43,8 +43,8 @@ namespace kOS.Safe.Test.Collections
         {
             var range = new RangeValue(6, -3);
             Assert.AreEqual(new ScalarIntValue(9), InvokeDelegate(range, "LENGTH"));
-            Assert.AreEqual(new ScalarIntValue(6), InvokeDelegate(range, "FROM"));
-            Assert.AreEqual(new ScalarIntValue(-3), InvokeDelegate(range, "TO"));
+            Assert.AreEqual(new ScalarIntValue(6), InvokeDelegate(range, "START"));
+            Assert.AreEqual(new ScalarIntValue(-3), InvokeDelegate(range, "STOP"));
             Assert.AreEqual(new ScalarIntValue(1), InvokeDelegate(range, "STEP"));
             Assert.IsFalse((BooleanValue)InvokeDelegate(range, "EMPTY"));
             Assert.IsTrue((BooleanValue)InvokeDelegate(range, "CONTAINS", new ScalarIntValue(-2)));
@@ -62,8 +62,8 @@ namespace kOS.Safe.Test.Collections
         {
             var range = new RangeValue(2, 12, 3);
             Assert.AreEqual(new ScalarIntValue(4), InvokeDelegate(range, "LENGTH"));
-            Assert.AreEqual(new ScalarIntValue(2), InvokeDelegate(range, "FROM"));
-            Assert.AreEqual(new ScalarIntValue(12), InvokeDelegate(range, "TO"));
+            Assert.AreEqual(new ScalarIntValue(2), InvokeDelegate(range, "START"));
+            Assert.AreEqual(new ScalarIntValue(12), InvokeDelegate(range, "STOP"));
             Assert.AreEqual(new ScalarIntValue(3), InvokeDelegate(range, "STEP"));
             Assert.IsFalse((BooleanValue)InvokeDelegate(range, "EMPTY"));
             Assert.IsTrue((BooleanValue)InvokeDelegate(range, "CONTAINS", new ScalarIntValue(5)));

--- a/src/kOS.Safe.Test/Opcode/FakeCpu.cs
+++ b/src/kOS.Safe.Test/Opcode/FakeCpu.cs
@@ -90,22 +90,22 @@ namespace kOS.Safe.Test.Opcode
 
         public Encapsulation.Structure PopStructureEncapsulated(bool barewordOkay = false)
         {
-            throw new NotImplementedException();
+            return kOS.Safe.Encapsulation.Structure.FromPrimitiveWithAssert(PopValue(barewordOkay));
         }
 
         public Encapsulation.Structure PeekStructureEncapsulated(int digDepth, bool barewordOkay = false)
         {
-            throw new NotImplementedException();
+            return kOS.Safe.Encapsulation.Structure.FromPrimitiveWithAssert(PeekValue(digDepth, barewordOkay));
         }
         
         public object PopValueEncapsulated(bool barewordOkay = false)
         {
-            throw new NotImplementedException();
+            return kOS.Safe.Encapsulation.Structure.FromPrimitive(PopValue(barewordOkay));
         }
 
         public object PeekValueEncapsulated(int digDepth, bool barewordOkay = false)
         {
-            throw new NotImplementedException();
+            return kOS.Safe.Encapsulation.Structure.FromPrimitive(PeekValue(digDepth, barewordOkay));
         }
 
         public int GetStackSize()

--- a/src/kOS.Safe.Test/Opcode/OpcodeGetIndexText.cs
+++ b/src/kOS.Safe.Test/Opcode/OpcodeGetIndexText.cs
@@ -31,7 +31,7 @@ namespace kOS.Safe.Test.Opcode
             opcode.Execute(cpu);
 
             Assert.AreEqual(1, list.Count());
-            Assert.AreEqual("bar", cpu.PopStack());
+            Assert.AreEqual(new StringValue("bar"), cpu.PopStack());
         }
 
         [Test]
@@ -51,7 +51,7 @@ namespace kOS.Safe.Test.Opcode
             opcode.Execute(cpu);
 
             Assert.AreEqual(3, list.Count());
-            Assert.AreEqual("foo", cpu.PopStack());
+            Assert.AreEqual(new StringValue("foo"), cpu.PopStack());
         }
 
         [Test]
@@ -71,7 +71,7 @@ namespace kOS.Safe.Test.Opcode
             opcode.Execute(cpu);
 
             Assert.AreEqual(3, list.Count());
-            Assert.AreEqual("fizz", cpu.PopStack());
+            Assert.AreEqual(new StringValue("fizz"), cpu.PopStack());
         }
 
         [Test]
@@ -89,7 +89,7 @@ namespace kOS.Safe.Test.Opcode
             opcode.Execute(cpu);
 
             Assert.AreEqual(1, list.Count);
-            Assert.AreEqual("bar", cpu.PopStack());
+            Assert.AreEqual(new StringValue("bar"), cpu.PopStack());
         }
 
         [Test]
@@ -108,7 +108,7 @@ namespace kOS.Safe.Test.Opcode
             opcode.Execute(cpu);
 
             Assert.AreEqual(2, list.Count);
-            Assert.AreEqual("bang", cpu.PopStack());
+            Assert.AreEqual(new StringValue("bang"), cpu.PopStack());
         }
     }
 }

--- a/src/kOS.Safe.Test/Opcode/OpcodeSetIndexTest.cs
+++ b/src/kOS.Safe.Test/Opcode/OpcodeSetIndexTest.cs
@@ -35,8 +35,8 @@ namespace kOS.Safe.Test.Opcode
             opcode.Execute(cpu);
 
             Assert.AreEqual(1, list.Count());
-            Assert.AreNotEqual("bar", list[0]);
-            Assert.AreEqual("foo", list[0]);
+            Assert.AreNotEqual(new StringValue("bar"), list[0]);
+            Assert.AreEqual(new StringValue("foo"), list[0]);
         }
 
         [Test]
@@ -57,8 +57,8 @@ namespace kOS.Safe.Test.Opcode
             opcode.Execute(cpu);
 
             Assert.AreEqual(1, list.Count());
-            Assert.AreNotEqual("bar", list[0]);
-            Assert.AreEqual("foo", list[0]);
+            Assert.AreNotEqual(new StringValue("bar"), list[0]);
+            Assert.AreEqual(new StringValue("foo"), list[0]);
         }
 
         [Test]
@@ -79,8 +79,8 @@ namespace kOS.Safe.Test.Opcode
             opcode.Execute(cpu);
 
             Assert.AreEqual(1, list.Count());
-            Assert.AreNotEqual("bar", list[0]);
-            Assert.AreEqual("foo", list[0]);
+            Assert.AreNotEqual(new StringValue("bar"), list[0]);
+            Assert.AreEqual(new StringValue("foo"), list[0]);
         }
 
         [Test]

--- a/src/kOS.Safe.Test/Structure/ClampSetSuffixTest.cs
+++ b/src/kOS.Safe.Test/Structure/ClampSetSuffixTest.cs
@@ -25,10 +25,10 @@ namespace kOS.Safe.Test.Structure
         {
             const int MIN_VALUE = 0;
             const int MAX_VALUE = 1;
-            ScalarDoubleValue SET_VALUE = 0.5f;
+            ScalarValue SET_VALUE = 0.5f;
 
-            ScalarDoubleValue value = 0;
-            var suffix = new ClampSetSuffix<ScalarDoubleValue>(() => value, i => value = i, MIN_VALUE, MAX_VALUE);
+            ScalarValue value = 0;
+            var suffix = new ClampSetSuffix<ScalarValue>(() => value, i => value = i, MIN_VALUE, MAX_VALUE);
 
             suffix.Set(SET_VALUE);
 
@@ -45,11 +45,11 @@ namespace kOS.Safe.Test.Structure
             const float SET_VALUE = 1.5f;
 
             float value = 0;
-            var suffix = new ClampSetSuffix<ScalarDoubleValue>(() => value, i => value = i, MIN_VALUE, MAX_VALUE);
+            var suffix = new ClampSetSuffix<ScalarValue>(() => value, i => value = i, MIN_VALUE, MAX_VALUE);
 
             suffix.Set(SET_VALUE);
 
-            Assert.AreEqual(value, suffix.Get());
+            Assert.AreEqual(ScalarValue.Create(value), suffix.Get().Value);
             Assert.AreNotEqual(SET_VALUE, value);
             Assert.AreEqual(MAX_VALUE, value);
 
@@ -65,11 +65,11 @@ namespace kOS.Safe.Test.Structure
             const float STEP_VALUE = 0.5f;
 
             float value = 0;
-            var suffix = new ClampSetSuffix<ScalarDoubleValue>(() => value, i => value = i, MIN_VALUE, MAX_VALUE, STEP_VALUE);
+            var suffix = new ClampSetSuffix<ScalarValue>(() => value, i => value = i, MIN_VALUE, MAX_VALUE, STEP_VALUE);
 
             suffix.Set(SET_VALUE);
 
-            Assert.AreEqual(value, suffix.Get());
+            Assert.AreEqual(ScalarValue.Create(value), suffix.Get().Value);
             Assert.AreNotEqual(SET_VALUE, value);
             Assert.AreEqual(EXPECTED_VALUE, value);
         }
@@ -84,11 +84,11 @@ namespace kOS.Safe.Test.Structure
             const float STEP_VALUE = 0.5f;
 
             float value = 0;
-            var suffix = new ClampSetSuffix<ScalarDoubleValue>(() => value, i => value = i, MIN_VALUE, MAX_VALUE, STEP_VALUE);
+            var suffix = new ClampSetSuffix<ScalarValue>(() => value, i => value = i, MIN_VALUE, MAX_VALUE, STEP_VALUE);
 
             suffix.Set(SET_VALUE);
 
-            Assert.AreEqual(value, suffix.Get());
+            Assert.AreEqual(ScalarValue.Create(value), suffix.Get().Value);
             Assert.AreNotEqual(SET_VALUE, value);
             Assert.AreEqual(EXPECTED_VALUE, value);
         }

--- a/src/kOS.Safe.Test/Structure/NoArgsSuffixTest.cs
+++ b/src/kOS.Safe.Test/Structure/NoArgsSuffixTest.cs
@@ -2,6 +2,8 @@
 using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
 using NUnit.Framework;
+using kOS.Safe.Test.Opcode;
+using kOS.Safe.Execution;
 
 namespace kOS.Safe.Test.Structure
 {
@@ -13,6 +15,13 @@ namespace kOS.Safe.Test.Structure
     [TestFixture]
     public class NoArgsSuffixTest
     {
+        private ICpu cpu;
+
+        [SetUp]
+        public void Setup()
+        {
+            cpu = new FakeCpu();
+        }
         [Test]
         public void CanCreate()
         {
@@ -37,6 +46,10 @@ namespace kOS.Safe.Test.Structure
             var del = suffix.Get();
             Assert.IsNotNull(del);
 
+            cpu.PushStack(null);  // dummy variable for ReverseStackArgs to pop
+            cpu.PushStack(new KOSArgMarkerType());
+            del.Invoke(cpu);
+
             var value = del.Value;
             Assert.IsNotNull(value);
             Assert.AreSame(obj,value);
@@ -46,14 +59,18 @@ namespace kOS.Safe.Test.Structure
         public void CanGetDelegateValueType()
         {
             const int VALUE = 12345;
-            var suffix = new NoArgsSuffix<Encapsulation.Structure>(() => new ScalarIntValue(VALUE) );
+            var suffix = new NoArgsSuffix<Encapsulation.Structure>(() => ScalarValue.Create(VALUE));
             var del = suffix.Get();
             Assert.IsNotNull(del);
 
+            cpu.PushStack(null);  // dummy variable for ReverseStackArgs to pop
+            cpu.PushStack(new KOSArgMarkerType());
+            del.Invoke(cpu);
+
             var value = del.Value;
             Assert.IsNotNull(value);
-            Assert.IsInstanceOf<int>(value);
-            Assert.AreEqual(VALUE,value);
+            Assert.IsInstanceOf<ScalarValue>(value);
+            Assert.AreEqual(ScalarValue.Create(VALUE), value);
         }
 
     }

--- a/src/kOS.Safe.Test/Structure/SetSuffixTest.cs
+++ b/src/kOS.Safe.Test/Structure/SetSuffixTest.cs
@@ -15,14 +15,8 @@ namespace kOS.Safe.Test.Structure
             SafeHouse.Logger = new TestLogger();
         }
 
-        [Test]
-        public void CanGetDefaultValue()
-        {
-            var suffix = BuildBasicSetSuffix<ScalarIntValue>();
-
-            Assert.IsNotNull(suffix);
-            Assert.AreEqual(default(int), suffix.Get());
-        }
+        // Deleted the CanGetDefaultValue test because all structures
+        // are now reference types with a default value of null.
 
         [Test]
         public void CanSetAndGet()
@@ -31,7 +25,7 @@ namespace kOS.Safe.Test.Structure
 
             Assert.IsNotNull(suffix);
             suffix.Set(15);
-            Assert.AreEqual(15,suffix.Get());
+            Assert.AreEqual(ScalarValue.Create(15),suffix.Get().Value);
         }
 
         private static SetSuffix<TParam> BuildBasicSetSuffix<TParam>() where TParam : Encapsulation.Structure
@@ -52,8 +46,8 @@ namespace kOS.Safe.Test.Structure
             const double TEST_VALUE = 15.0d;
             Assert.IsNotNull(suffix);
             suffix.Set(TEST_VALUE);
-            var finalValue = suffix.Get();
-            Assert.AreEqual(TEST_VALUE,finalValue);
+            var finalValue = suffix.Get().Value;
+            Assert.AreEqual(ScalarValue.Create(TEST_VALUE), finalValue);
         }
 
         [Test]
@@ -65,8 +59,8 @@ namespace kOS.Safe.Test.Structure
             const double TEST_VALUE_TRUNCATED = 15;
             Assert.IsNotNull(suffix);
             suffix.Set(TEST_VALUE);
-            var finalValue = suffix.Get();
-            Assert.AreEqual(TEST_VALUE_TRUNCATED,finalValue);
+            var finalValue = suffix.Get().Value;
+            Assert.AreEqual(ScalarValue.Create(TEST_VALUE_TRUNCATED), finalValue);
         }
 
         [Test]
@@ -77,8 +71,8 @@ namespace kOS.Safe.Test.Structure
             const int TEST_VALUE = 15;
             Assert.IsNotNull(suffix);
             suffix.Set(TEST_VALUE);
-            var finalValue = suffix.Get();
-            Assert.AreEqual(TEST_VALUE,finalValue);
+            var finalValue = suffix.Get().Value;
+            Assert.AreEqual(ScalarValue.Create(TEST_VALUE), finalValue);
         }
     }
 }

--- a/src/kOS.Safe.Test/Structure/StructureSuffixIntegrationTest.cs
+++ b/src/kOS.Safe.Test/Structure/StructureSuffixIntegrationTest.cs
@@ -57,11 +57,11 @@ namespace kOS.Safe.Test.Structure
             structure.TestAddInstanceSuffix("FOO", new SetSuffix<ScalarIntValue>(BuildBasicGetter(strongBox), BuildBasicSetter(strongBox)));
             structure.TestAddInstanceSuffix("BAR", new SetSuffix<ScalarIntValue>(BuildBasicGetter(strongBox), BuildBasicSetter(strongBox)));
 
-            Assert.AreEqual(TEST_VALUE, structure.GetSuffix("FOO"));
+            Assert.AreEqual(ScalarValue.Create(TEST_VALUE), structure.GetSuffix("FOO").Value);
             structure.SetSuffix("FOO", TEST_VALUE - 10);
-            Assert.AreEqual(TEST_VALUE - 10, structure.GetSuffix("FOO"));
+            Assert.AreEqual(ScalarValue.Create(TEST_VALUE - 10), structure.GetSuffix("FOO").Value);
             structure.SetSuffix("FOO", TEST_VALUE / 20);
-            Assert.AreEqual(TEST_VALUE / 20, structure.GetSuffix("FOO"));
+            Assert.AreEqual(ScalarValue.Create(TEST_VALUE / 20), structure.GetSuffix("FOO").Value);
         }
 
         [Test]
@@ -73,14 +73,14 @@ namespace kOS.Safe.Test.Structure
             structure.TestAddInstanceSuffix("FOO", new SetSuffix<ScalarIntValue>(BuildBasicGetter(strongBox), BuildBasicSetter(strongBox)));
             structure.TestAddInstanceSuffix("BAR", new SetSuffix<ScalarIntValue>(BuildBasicGetter(strongBox), BuildBasicSetter(strongBox)));
 
-            Assert.AreEqual(TEST_VALUE, structure.GetSuffix("FOO"));
-            Assert.AreEqual(TEST_VALUE, structure.GetSuffix("BAR"));
+            Assert.AreEqual(ScalarValue.Create(TEST_VALUE), structure.GetSuffix("FOO").Value);
+            Assert.AreEqual(ScalarValue.Create(TEST_VALUE), structure.GetSuffix("BAR").Value);
             structure.SetSuffix("FOO", TEST_VALUE - 10);
-            Assert.AreEqual(TEST_VALUE - 10, structure.GetSuffix("FOO"));
-            Assert.AreEqual(TEST_VALUE - 10, structure.GetSuffix("BAR"));
+            Assert.AreEqual(ScalarValue.Create(TEST_VALUE - 10), structure.GetSuffix("FOO").Value);
+            Assert.AreEqual(ScalarValue.Create(TEST_VALUE - 10), structure.GetSuffix("BAR").Value);
             structure.SetSuffix("BAR", TEST_VALUE / 20);
-            Assert.AreEqual(TEST_VALUE / 20, structure.GetSuffix("BAR"));
-            Assert.AreEqual(TEST_VALUE / 20, structure.GetSuffix("FOO"));
+            Assert.AreEqual(ScalarValue.Create(TEST_VALUE / 20), structure.GetSuffix("BAR").Value);
+            Assert.AreEqual(ScalarValue.Create(TEST_VALUE / 20), structure.GetSuffix("FOO").Value);
         }
 
         private static SuffixSetDlg<TParam> BuildBasicSetter<TParam>(StrongBox<TParam> state) where TParam : Encapsulation.Structure

--- a/src/kOS.Safe.Test/Structure/StructureTest.cs
+++ b/src/kOS.Safe.Test/Structure/StructureTest.cs
@@ -49,7 +49,7 @@ namespace kOS.Safe.Test.Structure
         [Test]
         public void CanAddGlobalSuffix()
         {
-            var testObject = new object();
+            var testObject = Substitute.For<ISuffixResult>();
             var testSuffix = Substitute.For<ISuffix>();
             var testStuffixName = Guid.NewGuid().ToString();
             testSuffix.Get().Returns(testObject);
@@ -61,7 +61,7 @@ namespace kOS.Safe.Test.Structure
         [Test]
         public void CanAddGlobalSuffixWithTwoNames()
         {
-            var testObject = new object();
+            var testObject = Substitute.For<ISuffixResult>();
             var testSuffix = Substitute.For<ISuffix>();
             var testStructure = new TestStructure();
             var suffixName = Guid.NewGuid().ToString();
@@ -77,7 +77,7 @@ namespace kOS.Safe.Test.Structure
         public void GlobalSuffixesAreInFactGlobal()
         {
             var suffixName = Guid.NewGuid().ToString();
-            var testObject = new object();
+            var testObject = Substitute.For<ISuffixResult>();
             var testSuffix = Substitute.For<ISuffix>();
             testSuffix.Get().Returns(testObject);
 
@@ -89,7 +89,7 @@ namespace kOS.Safe.Test.Structure
         [Test]
         public void CanAddInstanceSuffix()
         {
-            var testObject = new object();
+            var testObject = Substitute.For<ISuffixResult>();
             var testSuffix = Substitute.For<ISuffix>();
             var testStructure = new TestStructure();
             var suffixName = Guid.NewGuid().ToString();
@@ -102,7 +102,7 @@ namespace kOS.Safe.Test.Structure
         [Test]
         public void CantFindSuffixThatDoesntExist()
         {
-            var testObject = new object();
+            var testObject = Substitute.For<ISuffixResult>();
             var testSuffix = Substitute.For<ISuffix>();
             var testStructure = new TestStructure();
             var suffixName = Guid.NewGuid().ToString();
@@ -119,7 +119,7 @@ namespace kOS.Safe.Test.Structure
         [Test]
         public void CantFindStaticSuffixThatDoesntExist()
         {
-            var testObject = new object();
+            var testObject = Substitute.For<ISuffixResult>();
             var testSuffix = Substitute.For<ISuffix>();
             var testStructure = new TestStructure();
             var suffixName = Guid.NewGuid().ToString();
@@ -136,7 +136,7 @@ namespace kOS.Safe.Test.Structure
         [Test]
         public void InstanceSuffixesAreInFactInstanced()
         {
-            var testObject = new object();
+            var testObject = Substitute.For<ISuffixResult>();
             var testSuffix = Substitute.For<ISuffix>();
             var testStructure = new TestStructure();
             var suffixName = Guid.NewGuid().ToString();
@@ -156,11 +156,11 @@ namespace kOS.Safe.Test.Structure
         {
             var testStructure = new TestStructure();
 
-            var testObject1 = new object();
+            var testObject1 = Substitute.For<ISuffixResult>();
             var testSuffix1 = Substitute.For<ISuffix>();
             testSuffix1.Get().Returns(testObject1);
 
-            var testObject2 = new object();
+            var testObject2 = Substitute.For<ISuffixResult>();
             var testSuffix2 = Substitute.For<ISuffix>();
             testSuffix2.Get().Returns(testObject2);
 
@@ -178,7 +178,7 @@ namespace kOS.Safe.Test.Structure
         [Test]
         public void CanSetInstanceSuffix()
         {
-            var testObject = new object();
+            var testObject = Substitute.For<ISuffixResult>();
 
             object internalStorage = null;
             var testSuffix = Substitute.For<ISetSuffix>();
@@ -204,7 +204,7 @@ namespace kOS.Safe.Test.Structure
             var testStructure = new TestStructure();
             var suffixName = Guid.NewGuid().ToString();
 
-            var testObject = new object();
+            var testObject = Substitute.For<ISuffixResult>();
             var testSuffix = Substitute.For<ISuffix>();
             testSuffix.Get().ReturnsForAnyArgs(info => testObject);
             testStructure.TestAddInstanceSuffix(suffixName, testSuffix);
@@ -220,8 +220,8 @@ namespace kOS.Safe.Test.Structure
         [Test]
         public void CanSetSynonymInstanceSuffix()
         {
-            var testObject = new object();
-            var testObject2 = new object();
+            var testObject = Substitute.For<ISuffixResult>();
+            var testObject2 = Substitute.For<ISuffixResult>();
 
             object internalStorage = null;
             var testSuffix = Substitute.For<ISetSuffix>();


### PR DESCRIPTION
Fixes #1432
Many changes to the unit tests to get them running with the new encapsulated types as well as the new delegate architecture.  Some tests needed to have a cpu reference added, others just needed the assert tests to check against properly typed "expected" values, while still others needed to invoke a delegate.

Tagging @erendrake @Dunbaratu and @tomekpiotrowski specifically because they have more experience with unit tests than I have, and I just edited to make them work.