### PR TITLE
Remove exception in ToSingle

### DIFF
--- a/src/kOS.Safe/Encapsulation/ScalarValue.cs
+++ b/src/kOS.Safe/Encapsulation/ScalarValue.cs
@@ -394,7 +394,7 @@ namespace kOS.Safe.Encapsulation
 
         float IConvertible.ToSingle(IFormatProvider provider)
         {
-            throw new KOSCastException(typeof(ScalarValue), typeof(float));
+            return Convert.ToSingle(GetDoubleValue());
         }
 
         string IConvertible.ToString(IFormatProvider provider)


### PR DESCRIPTION
Fixes #1503
ScalarValue.cs
* Remove cast exception in ToSingle, instead convert the double value to
a single (float).