### PR TITLE
Fixes #1513 terminal font fails on low texture setting.

### DIFF
--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -13,11 +13,6 @@ namespace kOS.Screen
     // Blockotronix 550 Computor Monitor
     public class TermWindow : KOSManagedWindow , ITermWindow
     {
-        /// <summary>
-        /// Pixel size of one square section of the font template image file holding one character.
-        /// </summary>
-        private int charSourceSize;
-        
         private const string CONTROL_LOCKOUT = "kOSTerminal";
         private const int FONTIMAGE_CHARS_PER_ROW = 16;
         
@@ -146,16 +141,19 @@ namespace kOS.Screen
         
         private void LoadFontArray()
         {
-            // For example, if the image is 128 pixels wide, and there are 16 chars per row,
-            // then each character must be 8 pixels in size.  This allows us to use different
-            // sized font image files as drop-in replacements without recompiling the code
-            // because this value is determined by whatever the file happens to be like:
-            charSourceSize = fontImage.width / FONTIMAGE_CHARS_PER_ROW;
+            // Calculate image size from the presumption that it is a hardcoded number of char
+            // pictures wide and that each image is square.
+            // Then calculate everything else dynamically from that so that
+            // you can experiment with swapping in different font image files and the code
+            // will still work without a recompile:
+            int charSourceSize = fontImage.width / FONTIMAGE_CHARS_PER_ROW;
+            int numRows = fontImage.width / charSourceSize;
+            int numCharImages = numRows * FONTIMAGE_CHARS_PER_ROW;
             
             // Make it hold all possible ASCII values even though many will be blank pictures:
-            fontArray = new Texture2D[128];
+            fontArray = new Texture2D[numCharImages];
             
-            for (int i = 0 ; i < 128 ; ++i)
+            for (int i = 0 ; i < numCharImages ; ++i)
             {
                 // TextureFormat cannot be DXT1 or DXT5 if you want to ever perform a
                 // SetPixel on the texture (which we do).  So we start it off as a ARGB32

--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -14,9 +14,9 @@ namespace kOS.Screen
     public class TermWindow : KOSManagedWindow , ITermWindow
     {
         /// <summary>
-        /// Pixel size of one square section of the font template image file holding one character:
+        /// Pixel size of one square section of the font template image file holding one character.
         /// </summary>
-        private const int CHAR_SOURCE_SIZE = 8;
+        private int charSourceSize;
         
         private const string CONTROL_LOCKOUT = "kOSTerminal";
         private const int FONTIMAGE_CHARS_PER_ROW = 16;
@@ -146,6 +146,12 @@ namespace kOS.Screen
         
         private void LoadFontArray()
         {
+            // For example, if the image is 128 pixels wide, and there are 16 chars per row,
+            // then each character must be 8 pixels in size.  This allows us to use different
+            // sized font image files as drop-in replacements without recompiling the code
+            // because this value is determined by whatever the file happens to be like:
+            charSourceSize = fontImage.width / FONTIMAGE_CHARS_PER_ROW;
+            
             // Make it hold all possible ASCII values even though many will be blank pictures:
             fontArray = new Texture2D[128];
             
@@ -155,7 +161,7 @@ namespace kOS.Screen
                 // SetPixel on the texture (which we do).  So we start it off as a ARGB32
                 // first, long enough to perform the SetPixel call, then compress it
                 // afterward into a DXT5:
-                Texture2D charImage = new Texture2D(CHAR_SOURCE_SIZE, CHAR_SOURCE_SIZE, TextureFormat.ARGB32, true);
+                Texture2D charImage = new Texture2D(charSourceSize, charSourceSize, TextureFormat.ARGB32, false);
 
                 int tx = i % FONTIMAGE_CHARS_PER_ROW;
                 int ty = i / FONTIMAGE_CHARS_PER_ROW;
@@ -164,7 +170,7 @@ namespace kOS.Screen
                 // 3D (2D images put orgin at upper-left, 3D uses lower-left), it doesn't seem
                 // to apply this rule to textures loaded from files like the fontImage.
                 // Thus the difference requiring the upside-down Y coord below.
-                charImage.SetPixels(fontImage.GetPixels(tx * CHAR_SOURCE_SIZE, fontImage.height - (ty+1) * CHAR_SOURCE_SIZE, CHAR_SOURCE_SIZE, CHAR_SOURCE_SIZE));
+                charImage.SetPixels(fontImage.GetPixels(tx * charSourceSize, fontImage.height - (ty+1) * charSourceSize, charSourceSize, charSourceSize));
                 charImage.Compress(false);
                 charImage.Apply();
 


### PR DESCRIPTION
The problem was leaving the "mipmap" option set to true when cutting up the font_sml.png Texture2D into 128 separate smaller character Texture2D's.  That option made Unity apply the graphics quality settings at *that* point when what we really want is just a straight-up copy of every pixel as-is.  It's not until later when drawing the texture that we want to let Unity do texture quality manipulation if it wants to.
