### PR TITLE
Add alias to FORCESETACTIVEVESSEL

### DIFF
--- a/doc/source/structures/misc/kuniverse.rst
+++ b/doc/source/structures/misc/kuniverse.rst
@@ -8,7 +8,7 @@ KUniverse 4th wall methods
 
     :struct:`KUniverse` is a special structure that allows your Kerboscript programs to access some of the functions that break the "4th Wall".  It serves as a place to access object directly connected to the KSP game itself, rather than the interaction with the KSP world (vessels, planets, orbits, etc.).
 
-    .. list-table:: Members and Methods
+    .. list-table::
         :header-rows: 1
         :widths: 3 1 1 4
 
@@ -29,15 +29,15 @@ KUniverse 4th wall methods
           - :ref:`boolean <boolean>`
           - Get
           - Is revert to editor possible?
-        * - :attr:`REVERTTOLAUNCH`
+        * - :meth:`REVERTTOLAUNCH`
           - none
           - Method
           - Invoke revert to launch
-        * - :attr:`REVERTTOEDITOR`
+        * - :meth:`REVERTTOEDITOR`
           - none
           - Method
           - Invoke revert to editor
-        * - :attr:`REVERTTO(name)`
+        * - :meth:`REVERTTO(name)`
           - :ref:`string <string>`
           - Method
           - Invoke revert to the named editor
@@ -49,7 +49,7 @@ KUniverse 4th wall methods
           - :ref:`scalar <scalar>`
           - Get
           - Number of hours per day (6 or 24) according to your game settings.
-        * - :attr:`DEBUGLOG(message)`
+        * - :meth:`DEBUGLOG(message)`
           - none
           - Method
           - Causes a :ref:`string <string>` to append to the Unity debug log file.
@@ -57,14 +57,18 @@ KUniverse 4th wall methods
           - :struct:`LoadDistance`
           - Get
           - Returns the set of default load and pack distances for the game.
-        * - :attr:`ACTIVEVESEL`
+        * - :attr:`ACTIVEVESSEL`
           - :struct:`Vessel`
           - Get/Set
           - Returns the active vessel, or lets you set the active vessel.
-        * - :attr:`FORCEACTIVE(vessel)`
+        * - :meth:`FORCESETACTIVEVESSEL(vessel)`
           - n/a
-          - Set
+          - Method
           - Lets you switch active vessels even when the game refuses to allow it.
+        * - :meth:`FORCEACTIVE(vessel)`
+          - n/a
+          - Method
+          - Same as :meth:`FORCESETACTIVEVESSEL`
 
 
 .. attribute:: KUniverse:CANREVERT
@@ -90,14 +94,14 @@ KUniverse 4th wall methods
     to be false after reloading from a saved game where the vessel was
     already in existence in the saved file when you loaded the game.
 
-.. attribute:: KUniverse:REVERTTOLAUNCH
+.. method:: KUniverse:REVERTTOLAUNCH()
 
     :access: Method
     :type: None.
 
     Initiate the KSP game's revert to launch function.  All progress so far will be lost, and the vessel will be returned to the launch pad or runway at the time it was initially launched.
 
-.. attribute:: KUniverse:REVERTTOEDITOR
+.. method:: KUniverse:REVERTTOEDITOR()
 
     :access: Method
     :type: None.
@@ -146,12 +150,19 @@ KUniverse 4th wall methods
 
     Returns the active vessel object and allows you to set the active vessel.  Note: KSP will not allow you to change vessels by default when the current active vessel is in the atmosphere or under acceleration.  Use :meth:`FORCEACTIVE` under those circumstances.
 
-.. method:: KUniverse:FORCEACTIVE(vessel)
+.. method:: KUniverse:FORCESETACTIVEVESSEL(vessel)
 
     :parameter vessel: :struct:`Vessel` to switch to.
     :return: none
 
     Force KSP to change the active vessel to the one specified.  Note: Switching the active vessel under conditions that KSP normally disallows may cause unexpected results on the initial vessel.  It is possible that the vessel will be treated as if it is re-entering the atmosphere and deleted.
+
+.. method:: KUniverse:FORCEACTIVE(vessel)
+
+    :parameter vessel: :struct:`Vessel` to switch to.
+    :return: none
+
+    Same as :meth:`FORCESETACTIVEVESSEL`.
 
 .. attribute:: KUniverse:HOURSPERDAY
 
@@ -225,7 +236,7 @@ KUniverse 4th wall methods
 
     - Windows 32-bit: [install_dir]\KSP_Data\output_log.txt
     - Windows 64-bit: [install_dir]\KSP_x64_Data\output_log.txt (not officially supported)
-    - Mac OS X: ~/Library/Logs/Unity/Player.log 
+    - Mac OS X: ~/Library/Logs/Unity/Player.log
     - Linux: ~/.config/unity3d/Squad/"Kerbal Space Program"/Player.log
 
     For an example of what it looks like in the log, this::

--- a/src/kOS/Suffixed/KUniverseValue.cs
+++ b/src/kOS/Suffixed/KUniverseValue.cs
@@ -28,7 +28,7 @@ namespace kOS.Suffixed
             AddSuffix("ORIGINEDITOR", new Suffix<StringValue>(OriginatingEditor));
             AddSuffix("DEFAULTLOADDISTANCE", new Suffix<LoadDistanceValue>(() => new LoadDistanceValue(PhysicsGlobals.Instance.VesselRangesDefault)));
             AddSuffix("ACTIVEVESSEL", new SetSuffix<VesselTarget>(() => new VesselTarget(FlightGlobals.ActiveVessel, shared), SetActiveVessel));
-            AddSuffix("FORCESETACTIVEVESSEL", new OneArgsSuffix<VesselTarget>(ForceSetActiveVessel));
+            AddSuffix(new string[] { "FORCESETACTIVEVESSEL", "FORCEACTIVE" }, new OneArgsSuffix<VesselTarget>(ForceSetActiveVessel));
             AddSuffix("HOURSPERDAY", new Suffix<ScalarValue>(GetHoursPerDay));
             AddSuffix("DEBUGLOG", new OneArgsSuffix<StringValue>(DebugLog));
         }


### PR DESCRIPTION
Fixes #1476

KUniverseValue.cs
* Add FORCEACTIVE as an alias to FORCESETACTIVEVESSEL

kuniverse.rst
* Fix documentation to properly reference FORCESETACTIVEVESSEL
* Add FORCEACTIVE alias
* Fix various references that didn't point to their descriptions
correctly
* Remove "Members and Methods" caption from table as it didn't format
correctly