### PR TITLE
CSS to remove extra padding around search results

### DIFF
--- a/doc/source/_static/css/kos_theme.css
+++ b/doc/source/_static/css/kos_theme.css
@@ -15,6 +15,9 @@
 
 a.reference span.pre { color: #2980B9; }
 
+/*removes extra padding around highlighted search results*/
+.rst-content span.highlighted{padding: 0 0px}
+
 /* It is possible to do a lot more here, but let's
  * leave it at that for now.
  */


### PR DESCRIPTION
removes confusing padding around search results, especially when the padding occurs in the middle of an example command line and confuses the structure.