### PR TITLE
Enhancement 1546; Add a way to get the ETA of SOI for any orbit

### DIFF
--- a/src/kOS/Suffixed/OrbitInfo.cs
+++ b/src/kOS/Suffixed/OrbitInfo.cs
@@ -53,6 +53,7 @@ namespace kOS.Suffixed
             AddSuffix("VELOCITY", new Suffix<OrbitableVelocity>(() => GetVelocityAtUT( new TimeSpan(Planetarium.GetUniversalTime() ) )));
             AddSuffix("NEXTPATCH", new Suffix<OrbitInfo>(GetNextPatch));
             AddSuffix("HASNEXTPATCH", new Suffix<BooleanValue>(GetHasNextPatch));
+            AddSuffix("NEXTPATCHETA", new Suffix<ScalarValue>(() =>(GetNextPatchETA())));
 
             //TODO: Determine if these vectors are different than POSITION and VELOCITY
             AddSuffix("VSTATEVECTOR", new Suffix<Vector>(() => new Vector(orbit.vel)));
@@ -105,6 +106,15 @@ namespace kOS.Suffixed
         private OrbitInfo GetNextPatch()
         {
             return ! GetHasNextPatch() ? null : new OrbitInfo(orbit.nextPatch,Shared);
+        }
+
+        /// <summary>
+        /// Returns the ETA of when the nextpatch will happen
+        /// </summary>
+        /// <returns>A double representing the ETA in seconds, or a zero if there isn't any.</returns>
+        private double GetNextPatchETA()
+        {
+            return GetHasNextPatch() ? (orbit.EndUT - Planetarium.GetUniversalTime()) : 0;
         }
 
         /// <summary>


### PR DESCRIPTION
Adds functionality suggested in #1546

I am unsure whether it should return an infinite value when a nextpatch does not exist however.

_Edit: fixes #1546 and fixes #550_