### PR TITLE
Fixes serialization of boolean type

### DIFF
--- a/src/kOS.Safe/Encapsulation/BooleanValue.cs
+++ b/src/kOS.Safe/Encapsulation/BooleanValue.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 namespace kOS.Safe.Encapsulation
 {
     [kOS.Safe.Utilities.KOSNomenclature("Boolean")]
-    public class BooleanValue : Structure, IConvertible
+    public class BooleanValue : Structure, IConvertible, ISerializableValue
     {
         private readonly bool internalValue;
 


### PR DESCRIPTION
I've extended my tests a bit and they revealed that boolean values currently don't serialize properly - they serialize as strings. Somehow `ISerializableValue` interface was not implemented.