### PR TITLE
Fix compiled locks

### DIFF
--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -668,6 +668,11 @@ namespace kOS.Safe.Compilation.KS
                 if (userFuncObject.IsSystemLock())
                 {
                     AddOpcode(new OpcodePush(userFuncObject.ScopelessPointerIdentifier));
+                    AddOpcode(new OpcodeExists());
+                    var branch = new OpcodeBranchIfTrue();
+                    branch.Distance = 4;
+                    AddOpcode(branch);
+                    AddOpcode(new OpcodePush(userFuncObject.ScopelessPointerIdentifier));
                     AddOpcode(new OpcodePushRelocateLater(null), userFuncObject.DefaultLabel);
                     AddOpcode(new OpcodeStore());
                 }

--- a/src/kOS.Safe/Compilation/ProgramBuilder.cs
+++ b/src/kOS.Safe/Compilation/ProgramBuilder.cs
@@ -126,6 +126,8 @@ namespace kOS.Safe.Compilation
                 {
                     if (labels.ContainsKey(program[index].Label))
                     {
+                        if (program[index].Label.EndsWith("-default"))
+                            continue;
                         // This is one of those "should never happen" errors that if it happens
                         // it means kOS devs screwed up - so dump the partially relabeled program
                         // to the log just to help in diagnosing the bug report that may happen:


### PR DESCRIPTION
Fixes #1557
Fixes #1253
Fixes #691

The program builder now ignores duplicate label errors for default user functions (labels that end in "-default").  In this instance, an already existing default function exists, and that instruction pointer is used instead of the new function.

A side effect of the previous logic was also that creating a new lock in a new program would redefine the lock's instruction pointer to refer to the default value.  That means that an already existing lock object would no longer be evaluated.  To fix this, we check to see if the lock's pointer is already defined.  If it is defined, we know that it either points to the existing default function or to the existing lock function.  In either case, we can skip setting the pointer to the default function.

Features:
- [x] Don't throw exceptions for duplicate default function labels.
- [x] Don't overwrite the function pointer if it already exists.
- [x] Check documentation for references to this limitation and remove them if necessary.

Question:
Should we also not throw an exception if a label matches the function's hash?  I believe that the hash now includes the file name, in which case the hashes will not match if two files simply define an identical lock, unless the hash of their file names is an exact match as well.