### PR TITLE
Subdirectories

### DIFF
--- a/doc/source/commands/files.rst
+++ b/doc/source/commands/files.rst
@@ -245,8 +245,9 @@ Files and directories
         make it difficult for the kOS parser to properly handle paths.
 
         Please update your scripts to use the new commands:
-        :ref:`movepath(frompath, topath)`, :ref:`copypath(frompath, topath)` and
-        :ref:`deletepath(path)`.
+        :ref:`movepath(frompath, topath) <movepath>`,
+        :ref:`copypath(frompath, topath) <copypath>` and
+        :ref:`deletepath(path) <deletepath>`.
 
 LIST
 ~~~~
@@ -260,6 +261,8 @@ CD(PATH)
 Changes the current directory to the one pointed to by the :code:`PATH`
 argument. This command will fail if the path is invalid or does not point
 to an existing directory.
+
+.. _copypath:
 
 COPYPATH(FROMPATH, TOPATH)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -309,12 +312,16 @@ to the exact behaviour of this command will differ:
 
    The command will fail.
 
+.. _movepath:
+
 MOVEPATH(FROMPATH, TOPATH)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Moves the file or directory pointed to by :code:`FROMPATH` to the location
 pointed to :code:`TOPATH`. Depending on what kind of items both paths point
 to the exact behaviour of this command will differ, see :code:`COPYPATH` above.
+
+.. _deletepath:
 
 DELETEPATH(PATH)
 ~~~~~~~~~~~~~~~~
@@ -325,22 +332,29 @@ removed along with all the items they contain.
 EXISTS(PATH)
 ~~~~~~~~~~~~
 
-A shortcut for ``CORE:CURRENTVOLUME:EXISTS(PATH)``. See :meth:`Volume:EXISTS`.
+Returns true if there exists a file or a directory under the given path,
+otherwise returns false. Also see :meth:`Volume:EXISTS`.
 
 CREATE(PATH)
 ~~~~~~~~~~~~
 
-A shortcut for ``CORE:CURRENTVOLUME:CREATE(PATH)``. See :meth:`Volume:CREATE`.
+Creates a file under the given path. Will create parent directories if needed.
+It will fail if a file or a directory already exists under the given path.
+Also see :meth:`Volume:CREATE`.
 
 CREATEDIR(PATH)
 ~~~~~~~~~~~~~~~
 
-A shortcut for ``CORE:CURRENTVOLUME:CREATEDIR(PATH)``. See :meth:`Volume:CREATE`.
+Creates a directory under the given path. Will create parent directories
+if needed. It will fail if a file or a directory already exists under the
+given path. Also see :meth:`Volume:CREATEDIR`.
 
 OPEN(PATH)
 ~~~~~~~~~~
 
-A shortcut for ``CORE:CURRENTVOLUME:OPEN(PATH)``. See :meth:`Volume:OPEN`.
+Will return a :struct:`VolumeFile` or :struct:`Directory` representing the item
+pointed to by :code:`PATH`. It will return a :struct:`Boolean` false if there's
+nothing present under the given path. Also see :meth:`Volume:OPEN`.
 
 
 JSON
@@ -503,7 +517,7 @@ Please see :ref:`the details of the Kerboscript ML
 Executable <compiling>`.
 
 EDIT PATH
----------
+~~~~~~~~~
 
 Edits a program pointed to by :code:`PATH`.
 

--- a/doc/source/commands/files.rst
+++ b/doc/source/commands/files.rst
@@ -352,7 +352,7 @@ given path. Also see :meth:`Volume:CREATEDIR`.
 OPEN(PATH)
 ~~~~~~~~~~
 
-Will return a :struct:`VolumeFile` or :struct:`Directory` representing the item
+Will return a :struct:`VolumeFile` or :struct:`VolumeDirectory` representing the item
 pointed to by :code:`PATH`. It will return a :struct:`Boolean` false if there's
 nothing present under the given path. Also see :meth:`Volume:OPEN`.
 

--- a/doc/source/commands/files.rst
+++ b/doc/source/commands/files.rst
@@ -3,11 +3,402 @@
 File I/O
 ========
 
-For information about where files are kept and how to deal with volumes see the :ref:`Volumes <volumes>` page in the general topics section of this documentation.
+For information about where files are kept and how to deal with volumes see the
+:ref:`Volumes <volumes>` page in the general topics section of this
+documentation.
 
 .. contents::
     :local:
     :depth: 2
+
+
+Understanding directories
+-----------------------------------
+
+kOS, just as real life filesystems, has the ability to group files into
+directories. Directories can contain other directories, which can result in
+a tree-like structure.
+
+Directories, contrary to files, do not take up space on the volume. That means
+you can have as many directories on your volume as you want.
+
+Paths
+-----
+
+kOS uses strings of a specific format as a way of describing the location
+of files and directories. We will call them path strings or simply - paths.
+They will look familiar to users of most real operating systems. On Windows
+for example you might have seen something like this::
+
+  C:\Program Files\Some Directory\SomeFile.exe
+
+Linux users are probably more familiar with paths that look like this::
+
+  /home/user/somefile
+
+kOS's paths are quite similar, this is how a full path string might look like::
+
+  0:/lib/launch/base.ks
+
+There are two types of paths in kOS. Absolute paths explicitly state all data
+needed to locate an item. Relative paths describe the location of an item
+relative to the current directory or current volume.
+
+Absolute paths
+~~~~~~~~~~~~~~
+
+Absolute paths have the following format::
+
+  volumeIdOrName:[/directory/subdirectory/...]/filename
+
+The first slash immediately after the colon is optional.
+
+Examples of valid absolute paths::
+
+  0:flight_data/data.json
+  secondcpu: // refers to the root directory of a volume
+  1:/boot.ks
+
+You can use a special two-dot directory name - `..` - to denote the parent
+of a given directory. In the following example the two paths refer to the same
+file::
+
+  0:/directory/subdirectory/../file
+  0:/directory/file
+
+A path that points to the parent of the root directory of a volume is considered
+invalid. Those paths are all invalid::
+
+  0:..
+  0:/../..
+  0:/directory/../..
+
+Current directory
+~~~~~~~~~~~~~~~~~
+
+To facilitate the way you interact with volumes, directories and files kOS
+has a concept of current directory. That means you can make a certain directory
+a `default` one and kOS will look for files you pass on to kOS commands in that
+directory. Let's say for example that you're testing a script located on the
+Archive volume in the `launch_scripts` directory. Normally every time you'd like
+to do something with it (edit it, run it, copy it etc) you'd have to tell kOS
+exactly where that file is.  That could be troublesome, especially when it would
+have to be done multiple times.
+
+Instead you can change your current directory using :code:`cd(path)`
+(as in `change directory`) command and then refer to all the files and
+directories you need by using their relative paths (read more below).
+
+You can always print out the current directory's path like this::
+
+  PRINT PATH().
+
+Remember that you can print the contents of the current directory using the
+:code:`LIST` command (which is a shortcut for :code:`LIST FILES`).
+
+Relative paths
+~~~~~~~~~~~~~~
+
+Relative paths are the second way you can create paths. Those paths are
+transformed by kOS into absolute paths by adding them to the current directory.
+
+Let's say that you've changed your current directory to :code:`0:/scripts`.
+If you pass :code:`launch.ks` path to any command kOS will add it to current
+directory and create an absolute path this way::
+
+  CD("0:/scripts").
+  DELETEPATH("launch.ks"). // this will remove 0:/scripts/launch.ks
+  COPYPATH("../launch.ks", ""). // this will copy 0:/launch.ks to 0:/scripts/launch.ks
+
+As you can see above an empty relative path results in a path pointing to the
+current directory.
+
+If a relative path starts with :code:`/` kOS will only take the current
+directory's volume and add it to the relative path::
+
+  CD("0:/scripts").
+  COPYPATH("/launch.ks", "launch_scripts"). // will copy 0:/launch.ks to 0:/scripts/launch_scripts
+
+
+Paths and bareword arguments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. warning::
+
+  kOS has historically always allowed to skip quotes around file names in certain
+  cases. Although it is still possible (explanation below) we recommend against
+  it now. kOS 1.0 has introduced directory support and as a result the number of
+  cases in which omitting quotes would be fine is less than before. Paths like
+  :code:`../file` make things very confusing to the kOS parser because
+  kerboscript uses a dot to denote the end of an expression. If you're used
+  to skipping quotes you might find that now you will often have to add them to make
+  the path understandable to kOS. The only case in which you can reliably omit
+  quotes is when you want to use simple, relative paths:
+  :code:`RUN script.`, :code:`CD(dir.ext)`.
+
+Any of the commands below which use path arguments follow these rules:
+
+-  A path may be an expression which evaluates to a string.
+-  A path may also be an undefined identifier
+   which does not match a variable name, in which case the bare word
+   name of the identifier will be used as the path. If the
+   identifier does match a variable name, then it will be evaluated as
+   an expression and the variable's contents will be used as the
+   path.
+-  A bareword path may contain file extensions with dots, provided
+   it does not end in a dot.
+-  Bareword filenames containing any characters other than A-Z, 0-9, underscore,
+   and the period extension separator ('.'), can only be referred to
+   using a string expression (with quotes), and cannot be used as a
+   bareword expression (without quotes). This makes it impossible to construct
+   valid kOS paths that contain slashes using bareword paths - you will
+   need to use quotes.
+-  If your filesystem is case-sensitive (Linux and sometimes Mac OSX, or
+   even Windows if using some kinds of remote network drives), then
+   bareword filenames will only work properly on filenames that are all
+   lowercase. If you try to use a file with capital letters in the name
+   on these systems, you will only be able to do so by quoting it.
+
+Putting the above rules together, you can create paths in any of
+the following ways:
+
+-  COPYPATH(myfilename, "1:"). // This is an example of a bareword filename.
+-  COPYPATH("myfilename", "1:"). // This is an example of an EXPRESSION
+   filename.
+-  COPYPATH(myfilename.ks, "1:"). // This is an example of a bareword
+   filename.
+-  COPYPATH(myfilename.txt, "1:"). // This is an example of a bareword
+   filename.
+-  COPYPATH("myfilename.ks", "1:"). // This is an example of an EXPRESSION
+   filename
+-  SET str TO "myfile" + "name" + ".ks". COPYPATH(str, "1:"). // This is an
+   example of an EXPRESSION filename
+
+
+Other data types as paths
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Whenever kOS expects a path string as an argument you can actually pass
+one of the following data types instead:
+
+- :struct:`Path`
+- :struct:`Volume` - will use volume's root path
+- :struct:`VolumeFile` - will use file's path
+- :struct:`VolumeDirectory` - will use directory's path
+
+
+.. _path_command:
+
+path(pathString)
+~~~~~~~~~~~~~~~~
+
+Will create a :struct:`Path` structure representing the given path string. You
+can omit the argument to create a :struct:`Path` for the current directory.
+
+
+scriptpath()
+~~~~~~~~~~~~
+
+Will return a :struct:`Path` structure representing the path to the currently
+running script.
+
+Volumes
+-------
+
+volume(volumeIdOrName)
+~~~~~~~~~~~~~~~~~~~~~~
+
+Will return a :struct:`Volume` structure representing the volume with a given
+id or name. You can omit the argument to create a :struct:`Volume`
+for the current volume.
+
+SWITCH TO Volume|volumeId|volumeName.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Changes the current directory to the root directory of the specified volume.
+Volumes can be referenced by instances of :struct:`Volume`, their ID numbers
+or their names if they've been given one. Understanding how
+:ref:`volumes work <volumes>` is important to understanding this command.
+
+Example::
+
+    SWITCH TO 0.                        // Switch to volume 0.
+    SET VOLUME(1):NAME TO AwesomeDisk.  // Name volume 1 as AwesomeDisk.
+    SWITCH TO AwesomeDisk.              // Switch to volume 1.
+    PRINT VOLUME:NAME.                  // Prints "AwesomeDisk".
+
+
+Files and directories
+---------------------
+
+.. warning::
+
+    .. versionchanged:: 1.0.0
+
+        **COPY, RENAME and DELETE are now deprecated**
+
+        Previously you could use the aformentioned commands to manipulate files.
+        Currently using them will result in a deprecation message being shown.
+        After subdirectories were introduced in kOS 1.0 it was necessary to add
+        more flexible commands that could deal with both files and directories.
+        The old syntax was not designed with directories in mind. It would also
+        make it difficult for the kOS parser to properly handle paths.
+
+        Please update your scripts to use the new commands:
+        :ref:`movepath(frompath, topath)`, :ref:`copypath(frompath, topath)` and
+        :ref:`deletepath(path)`.
+
+LIST
+~~~~
+
+Shortcut for :code:`LIST FILES`. Prints the contents (files and directories)
+of the current directory.
+
+CD(PATH)
+~~~~~~~~
+
+Changes the current directory to the one pointed to by the :code:`PATH`
+argument. This command will fail if the path is invalid or does not point
+to an existing directory.
+
+COPYPATH(FROMPATH, TOPATH)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Copies the file or directory pointed to by :code:`FROMPATH` to the location
+pointed to :code:`TOPATH`. Depending on what kind of items both paths point
+to the exact behaviour of this command will differ:
+
+1. :code:`FROMPATH` points to a file
+
+   - :code:`TOPATH` points to a directory
+
+     The file from :code:`FROMPATH` will be copied to the directory.
+
+   - :code:`TOPATH` points to a file
+
+     Contents of the file pointed to by :code:`FROMPATH` will overwrite
+     the contents of the file pointed to by :code:`TOPATH`.
+
+   - :code:`TOPATH` points to a non-existing path
+
+     New file will be created at :code:`TOPATH`, along with any parent
+     directories if necessary. Its contents will be set to the contents of
+     the file pointed to by :code:`FROMPATH`.
+
+2. :code:`FROMPATH` points to a directory
+
+   If :code:`FROMPATH` points to a directory kOS will copy recursively all
+   contents of that directory to the target location.
+
+   - :code:`TOPATH` points to a directory
+
+     The directory from :code:`FROMPATH` will be copied inside the
+     directory pointed to by :code:`TOPATH`.
+
+   - :code:`TOPATH` points to a file
+
+     The command will fail.
+
+   - :code:`TOPATH` points to a non-existing path
+
+     New directory will be created at :code:`TOPATH`, along with any
+     parent directories if necessary. Its contents will be set to the
+     contents of the directory pointed to by :code:`FROMPATH`.
+
+3. :code:`FROMPATH` points to a non-existing path
+
+   The command will fail.
+
+MOVEPATH(FROMPATH, TOPATH)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Moves the file or directory pointed to by :code:`FROMPATH` to the location
+pointed to :code:`TOPATH`. Depending on what kind of items both paths point
+to the exact behaviour of this command will differ, see :code:`COPYPATH` above.
+
+DELETEPATH(PATH)
+~~~~~~~~~~~~~~~~
+
+Deleted the file or directory pointed to by :code:`FROMPATH`. Directories are
+removed along with all the items they contain.
+
+EXISTS(PATH)
+~~~~~~~~~~~~
+
+A shortcut for ``CORE:CURRENTVOLUME:EXISTS(PATH)``. See :meth:`Volume:EXISTS`.
+
+CREATE(PATH)
+~~~~~~~~~~~~
+
+A shortcut for ``CORE:CURRENTVOLUME:CREATE(PATH)``. See :meth:`Volume:CREATE`.
+
+CREATEDIR(PATH)
+~~~~~~~~~~~~~~~
+
+A shortcut for ``CORE:CURRENTVOLUME:CREATEDIR(PATH)``. See :meth:`Volume:CREATE`.
+
+OPEN(PATH)
+~~~~~~~~~~
+
+A shortcut for ``CORE:CURRENTVOLUME:OPEN(PATH)``. See :meth:`Volume:OPEN`.
+
+
+JSON
+----
+
+.. _writejson:
+
+WRITEJSON(OBJECT, PATH)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Serializes the given object to JSON format and saves it under the given path.
+
+Go to :ref:`Serialization page <serialization>` to read more about serialization.
+
+Usage example::
+
+    SET L TO LEXICON().
+    SET NESTED TO QUEUE().
+
+    L:ADD("key1", "value1").
+    L:ADD("key2", NESTED).
+
+    NESTED:ADD("nestedvalue").
+
+    WRITEJSON(l, "output.json").
+
+READJSON(PATH)
+~~~~~~~~~~~~~~
+
+Reads the contents of a file previously created using ``WRITEJSON`` and deserializes them.
+
+Go to :ref:`Serialization page <serialization>` to read more about serialization.
+
+Example::
+
+
+    SET L TO READJSON("output.json").
+    PRINT L["key1"].
+
+Miscellaneous
+-------------
+
+.. _run_once:
+
+RUN [ONCE] <PATH>.
+~~~~~~~~~~~~~~~~~~
+
+Runs the specified file as a program, optionally passing information to the
+program in the form of a comma-separated list of arguments in parentheses.
+
+If the optional ``ONCE`` keyword is used after the word ``RUN``, it means
+the run will not actually occur if the program has already been run once
+during the current program context.  This is intended mostly for loading library
+program files that may have mainline code in them for initialization purposes
+that you don't want to get run a second time just because you use the library
+in two different subprograms.
+
+``RUN ONCE`` means "Run unless it's already been run, in which case skip it."
 
 .. note::
 
@@ -25,235 +416,10 @@ For information about where files are kept and how to deal with volumes see the 
     lowercase-only filenames or the system may fail to find them when you
     use the ``run`` command.
 
-.. warning::
-
-    .. versionchanged:: 0.15
-
-        **Archive location and file extension change**
-
-        The Archive where KerboScript files are kept has been changed from ``Plugins/PluginData/Archive`` to ``Ships/Script``, but still under the top-level **KSP** installation directory. The file name extensions have also changes from ``.txt`` to ``.ks``.
-
-Volume and Filename arguments
------------------------------
-
-Any of the commands below which use filename arguments, \*\*with the
-exception
-of the RUN command\*\*, follow these rules:
-
--  (expression filenames) A filename may be an expression which
-   evaluates to a string.
--  (bareword filenames) A filename may also be an undefined identifier
-   which does not match a variable name, in which case the bare word
-   name of the identifier will be used as the filename. If the
-   identifier does match a variable name, then it will be evaluated as
-   an expression and the variable's contents will be used as the
-   filename.
--  A bareword filename may contain file extensions with dots, provided
-   it does not end in a dot.
--  Commands that try to read files will add '.ks' to filenames if
-   the original filename was not found, for example ``RUN abc.``
-   will first look for a file named ``abc``. If such a file is not found
-   it will look for ``abc.ks``.
-
-Putting the above rules together, you can refer to filenames in any of
-the following ways:
-
--  copy myfilename to 1. // This is an example of a bareword filename.
--  copy "myfilename" to 1. // This is an example of an EXPRESSION
-   filename.
--  copy myfilename.ks to 1. // This is an example of a bareword
-   filename.
--  copy myfilename.txt to 1. // This is an example of a bareword
-   filename.
--  copy "myfilename.ks" to 1. // This is an example of an EXPRESSION
-   filename
--  set str to "myfile" + "name" + ".ks". copy str to 1. // This is an
-   example of an EXPRESSION filename
-
-**Limits:**
-
-The following rules apply as limitations to the bareword filenames:
-
--  The **RUN command only works with bareword filenames**, not
-   expression filenames. Every other command works with either type of
-   filename.
--  Filenames containing any characters other than A-Z, 0-9, underscore,
-   and the period extension separator ('.'), can only be referred to
-   using a string expression (with quotes), and cannot be used as a
-   bareword expression (without quotes).
--  If your filesystem is case-sensitive (Linux and sometimes Mac OSX, or
-   even Windows if using some kinds of remote network drives), then
-   bareword filenames will only work properly on filenames that are all
-   lowercase. If you try to use a file with capital letters in the name
-   on these systems, you will only be able to do so by quoting it.
-
-**Volumes too:**
-
-The rules for filenames also apply to volumes. You may do this for
-example:
-
--  set volNum to 1. copy "myfile" to volNum.
-
-
-COMPILE program (TO compiledProgram).
--------------------------------------
-
-**(experimental)**
-
-Arguments:
-
-    argument 1
-        Name of source file.
-    argument 2
-        Name of destination file. If the optional argument 2 is missing, it will assume it's the same as argument 1, but with a file extension changed to ``*.ksm``.
-
-Pre-compiles a script into an :ref:`Kerboscript ML Exceutable
-image <compiling>` that can be used
-instead of executing the program script directly.
-
-The RUN command (elsewhere on this page) can work with either \*.ks
-script files or \*.ksm compiled files.
-
-The full details of this process are long and complex enough to be
-placed on a separate page.
-
-Please see :ref:`the details of the Kerboscript ML
-Executable <compiling>`.
-
-COPY programFile FROM/TO Volume|volumeId|volumeName.
-----------------------------------------------------
-
 Arguments
 ^^^^^^^^^
 
--  argument 1: Name of target file.
--  argument 2: Target volume.
-
-Copies a file to or from another volume. Volumes can be referenced by
-instances of :struct:`Volume`, their ID numbers or their names if they’ve been given one. See LIST,
-SWITCH and RENAME.
-
-Understanding how :ref:`volumes
-work <volumes>` is important to
-understanding this command.
-
-Example::
-
-    SWITCH TO 1.                      // Makes volume 1 the active volume
-    COPY file1 FROM 0.                // Copies a file called file1.ks from volume 0 to volume 1
-    COPY file2 TO 0.                  // Copies a file called file2.ks from volume 1 to volume 0
-    COPY file1.ks FROM 0.             // Copies a file called file1.ks from volume 0 to volume 1
-    COPY file2.ksm TO 0.              // Copies a file called file2.ksm from volume 1 to volume 0
-    COPY "file1.ksm" FROM 0.          // Copies a file called file1.ksm from volume 0 to volume 1
-    COPY "file1" + "." + "ks" FROM 0. // Copies a file called file1.ks from volume 0 to volume 1
-    COPY file2.ksm TO CORE:VOLUME.    // Copies a file called file2.ksm to active processor's volume
-    COPY file2.ksm TO "other".        // Copies a file called file2.ksm to volume named 'other'
-
-
-DELETE filename FROM Volume|volumeId|volumeName.
-------------------------------------------------
-
-Deletes a file. Volumes can be referenced by instances of :struct:`Volume`, their ID numbers or their names
-if they’ve been given one.
-
-Arguments
-^^^^^^^^^
-
--  argument 1: Name of target file.
--  argument 2: (optional) Target volume.
-
-Example::
-
-    DELETE file1.                   // Deletes file1.ks from the active volume.
-    DELETE "file1".                 // Deletes file1.ks from the active volume.
-    DELETE file1.txt.               // Deletes file1.txt from the active volume.
-    DELETE "file1.txt".             // Deletes file1.txt from the active volume.
-    DELETE file1 FROM 1.            // Deletes file1.ks from volume 1
-    DELETE file1 FROM CORE:VOLUME.  // Deletes file1.ks from active processor's volume
-    DELETE file1 FROM "other".      // Deletes file1.ks from volume name 'other'
-
-
-EDIT program.
--------------
-
-Edits a program on the currently selected volume.
-
-Arguments
-^^^^^^^^^
-
--  argument 1: Name of file for editing.
-
-.. note::
-
-    The Edit feature was lost in version 0.11 but is back again after version 0.12.2 under a new guise. The new editor is unable to show a monospace font for a series of complex reasons involving how Unity works and how squad bundled the KSP game. The editor works, but will be in a proportional width font, which isn't ideal for editing code. The best way to edit code remains to use a text editor external to KSP, however for a fast peek at the code during play, this editor is useful.
-
-Example::
-
-    EDIT filename.       // edits filename.ks
-    EDIT filename.ks.    // edits filename.ks
-    EDIT "filename.ks".  // edits filename.ks
-    EDIT "filename".     // edits filename.ks
-    EDIT "filename.txt". // edits filename.txt
-
-
-LOG text TO filename.
----------------------
-
-Logs the selected text to a file on the local volume. Can print strings, or the result of an expression.
-
-Arguments
-^^^^^^^^^
-
--  argument 1: Value you would like to log.
--  argument 2: Name of file to log into.
-
-Example::
-
-    LOG "Hello" to mylog.txt.    // logs to "mylog.txt".
-    LOG 4+1 to "mylog" .         // logs to "mylog.ks" because .ks is the default extension.
-    LOG "4 times 8 is: " + (4*8) to mylog.   // logs to mylog.ks because .ks is the default extension.
-
-
-RENAME VOLUME Volume|volumeId|oldVolumeName TO name.
-----------------------------------------------------
-
-RENAME FILE oldName TO newName.
--------------------------------
-
-Renames a file or volume. Volumes can be referenced by
-instances of :struct:`Volume`, their ID numbers or their names if they've been given one.
-
-Arguments
-^^^^^^^^^
-
--  argument 1: Volume/File Name you would like to change.
--  argument 2: New name for $1.
-
-Example::
-
-    RENAME VOLUME 1 TO AwesomeDisk
-    RENAME FILE MyFile TO AutoLaunch.
-
-.. _run_once:
-
-RUN [ONCE] <program>.
----------------------
-
-Runs the specified file as a program, optionally passing information to the program in the form of a comma-separated list of arguments in parentheses.
-
-If the optional ``ONCE`` keyword is used after the word ``RUN``, it means
-the run will not actually occur if the program has already been run once
-during the current program context.  This is intended mostly for loading library
-program files that may have mainline code in them for initialization purposes
-that you don't want to get run a second time just because you use the library
-in two different subprograms.
-
-``RUN ONCE`` means "Run unless it's already been run, in which case skip it."
-
-Arguments
-^^^^^^^^^
-
--  <program>: File to run.
+-  <PATH>: File to run.
 -  comma-separated-args: a list of values to pass into the program.
 
 Example::
@@ -293,99 +459,73 @@ about them at compile time, and the filename has to be set in stone at that
 time. Changing this would require a large re-write of some of the architecture
 of the virtual machine.
 
+LOG TEXT TO PATH
+~~~~~~~~~~~~~~~~
 
-SWITCH TO Volume|volumeId|volumeName.
--------------------------------------
+Logs the selected text to a file. Can print strings, or the result of an expression.
 
-Switches to the specified volume. Volumes can be referenced by
-instances of :struct:`Volume`, their ID numbers or their names if they've been given one. See LIST and RENAME. Understanding how
-:ref:`volumes work <volumes>` is important to understanding this command.
+Arguments
+^^^^^^^^^
 
-Example::
-
-    SWITCH TO 0.                        // Switch to volume 0.
-    RENAME VOLUME 1 TO AwesomeDisk.     // Name volume 1 as AwesomeDisk.
-    SWITCH TO AwesomeDisk.              // Switch to volume 1.
-    PRINT VOLUME:NAME.                  // Prints "AwesomeDisk".
-
-EXISTS(FILENAME).
------------------
-
-A shortcut for ``CORE:CURRENTVOLUME:EXISTS(FILENAME)``. See :meth:`Volume:EXISTS`.
-
-CREATE(FILENAME).
------------------
-
-A shortcut for ``CORE:CURRENTVOLUME:CREATE(FILENAME)``. See :meth:`Volume:CREATE`.
-
-OPEN(FILENAME).
----------------
-
-A shortcut for ``CORE:CURRENTVOLUME:OPEN(FILENAME)``. See :meth:`Volume:OPEN`.
-
-.. _writejson:
-
-WRITEJSON(OBJECT, FILENAME).
-----------------------------
-
-Serializes the given object to JSON format and saves it under the given filename on the current volume.
-
-Go to :ref:`Serialization page <serialization>` to read more about serialization.
-
-Usage example::
-
-    SET L TO LEXICON().
-    SET NESTED TO QUEUE().
-
-    L:ADD("key1", "value1").
-    L:ADD("key2", NESTED).
-
-    NESTED:ADD("nestedvalue").
-
-    WRITEJSON(l, "output.json").
-
-READJSON(FILENAME).
--------------------
-
-Reads the contents of a file previously created using ``WRITEJSON`` and deserializes them.
-
-Go to :ref:`Serialization page <serialization>` to read more about serialization.
+-  argument 1: Value you would like to log.
+-  argument 2: Path pointing to the file to log into.
 
 Example::
 
+    LOG "Hello" to mylog.txt.    // logs to "mylog.txt".
+    LOG 4+1 to "mylog" .         // logs to "mylog.ks" because .ks is the default extension.
+    LOG "4 times 8 is: " + (4*8) to mylog.   // logs to mylog.ks because .ks is the default extension.
 
-    SET L TO READJSON("output.json").
-    PRINT L["key1"].
 
+COMPILE PROGRAM (TO COMPILEDPROGRAM)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. _boot:
-
-Special handling of files starting with "boot" (example ``boot.ks``)
---------------------------------------------------------------------
 **(experimental)**
 
-For users requiring even more automation, the feature of custom boot scripts was introduced. If you have at least 1 file in your Archive volume starting with "boot" (for example "boot.ks", "boot2.ks" or even "boot_custom_script.ks"), you will be presented with the option to choose one of those files as a boot script for your kOS CPU.
- 
-.. image:: http://i.imgur.com/05kp7Sy.jpg
+Arguments:
 
-As soon as you vessel leaves VAB/SPH and is being initialised on the launchpad (e.g. its status is PRELAUNCH) the assigned script will be copied to CPU's local hard disk with the same name.  If kOS is configured to start on the archive, the file will not be copied locally automatically. This script will be run as soon as CPU boots, e.g. as soon as you bring your CPU in physics range or power on your CPU if it was turned off.  You may get or set the name of the boot file using the :ref:`core:bootfilename<core>` suffix.
+    argument 1
+        Path to the source file.
+    argument 2
+        Path to the destination file. If the optional argument 2 is missing, it will assume it's the same as argument 1, but with a file extension changed to ``*.ksm``.
 
-.. warning::
+Pre-compiles a script into an :ref:`Kerboscript ML Exceutable
+image <compiling>` that can be used
+instead of executing the program script directly.
 
-    .. versionchanged:: 0.18
+The RUN command (elsewhere on this page) can work with either \*.ks
+script files or \*.ksm compiled files.
 
-        **boot file name changed**
+The full details of this process are long and complex enough to be
+placed on a separate page.
 
-        Previously boot files were copied to the local hard disk as "boot.ks".  This behaviour was changed so that boot files could be handled consistently if kOS is configured to start on the Archive.  Some scripts may have terminated with a generic "delete boot." line to clear the boot script.  Going forward you should use the new core:bootfilename suffix when dealing the boot file.
+Please see :ref:`the details of the Kerboscript ML
+Executable <compiling>`.
 
-Important things to consider:
-	* kOS CPU hard disk space is limited, avoid using complex boot scripts or increase disk space using MM config.
-	* Boot script runs immediately on initialisation, it should avoid interaction with parts/modules until physics fully load. It is best to wait for couple seconds or until certain trigger.
-	
-	
-Possible uses for boot scripts:
+EDIT PATH
+---------
 
-	* Automatically activate sleeper/background scripts which will run on CPU until triggered by certain condition.
-	* Create basic station-keeping scripts - you will only have to focus your probes once in a while and let the boot script do the orbit adjustment automatically.
-	* Create multi-CPU vessels with certain cores dedicated to specific tasks, triggered by user input or external events (Robotic-heavy Vessels)
-	* Anything else you can come up with
+Edits a program pointed to by :code:`PATH`.
+
+Arguments
+^^^^^^^^^
+
+-  argument 1: Path of the file for editing.
+
+.. note::
+
+    The Edit feature was lost in version 0.11 but is back again after version
+    0.12.2 under a new guise. The new editor is unable to show a monospace
+    font for a series of complex reasons involving how Unity works and how
+    Squad bundled the KSP game. The editor works, but will be in a proportional
+    width font, which isn't ideal for editing code. The best way to edit code
+    remains to use a text editor external to KSP, however for a fast peek at
+    the code during play, this editor is useful.
+
+Example::
+
+    EDIT filename.       // edits filename.ks
+    EDIT filename.ks.    // edits filename.ks
+    EDIT "filename.ks".  // edits filename.ks
+    EDIT "filename".     // edits filename.ks
+    EDIT "filename.txt". // edits filename.txt

--- a/doc/source/general/volumes.rst
+++ b/doc/source/general/volumes.rst
@@ -4,20 +4,12 @@
 Files and Volumes
 =================
 
-Using the COPY, SWITCH, DELETE, and RENAME commands, you can manipulate the archive and the volumes as described in the :ref:`File I/O page <files>`. But before you do that, it's useful to know how kOS manages the archive and the volumes, and what they mean.
+Using the COPYPATH, SWITCH, DELETEPATH, and RENAMEPATH commands, you can manipulate the archive and the volumes as described in the :ref:`File I/O page <files>`. But before you do that, it's useful to know how kOS manages the archive and the volumes, and what they mean.
 
 .. contents::
     :local:
     :depth: 2
 
-.. warning::
-
-    .. versionchanged:: 0.15
-
-        **Archive location and file extension change**
-
-        The Archive where KerboScript files are kept has been changed from ``Plugins/PluginData/Archive`` to ``Ships/Script``, but still under the top-level **KSP** installation directory. The file name extensions have also changes from ``.txt`` to ``.ks``.
-    
 Script Files
 ------------
 
@@ -53,7 +45,7 @@ program on it. To simulate the sense that this game takes place at the
 dawn of the space race with 1960's and 1970's technology, the storage
 capacity of a volume is very limited.
 
-For example, the CX-4181 Scriptable Control System part defaults to only 
+For example, the CX-4181 Scriptable Control System part defaults to only
 allowing 1000 bytes of storage.
 
 The byte count of a program is just the
@@ -99,8 +91,7 @@ volume inside it.
 If you have multiple CX-4181 parts on the same craft, they are assumed
 to be networked together on the same system, and capable of reading each
 other's hard drives. Their disk drives each have a different Volume, and
-by default they are simply numbered 1,2,3, … unless you rename them with
-the RENAME command.
+by default they are simply numbered 1,2,3, … unless you rename them.
 
 For example, if you have two CX-4181's on the same craft, called 1 and
 2, with volumes on them called 1 and 2, respectively, it is possible for
@@ -116,11 +107,13 @@ different CPUs. The same volume which was called '2' when one CPU was
 looking at it might instead be called '1' when a different CPU is
 looking at it. Each CPU thinks of its OWN volume as number '1'.
 
-Therefore using the RENAME command on the volumes is useful when dealing
+Therefore using the SET command on the volumes is useful when dealing
 with multiple CX-4181's on the same vessel, so they all will refer to
-the volumes using the same names.
+the volumes using the same names::
 
-If a kOS processor has a name tag set, then that processor's volume 
+  SET VOLUME("0"):NAME TO "newname".
+
+If a kOS processor has a name tag set, then that processor's volume
 will have its name initially set to the value of the name tag.
 
 Archive
@@ -163,4 +156,36 @@ volume but with the following exceptions:
    a persistence file, on the other hand, is a bad idea and probably
    constitutes a form of cheating similar to any other edit of the
    persistence file.
+
+.. _boot:
+
+Special handling of files in the "boot" directory
+-------------------------------------------------
+
+For users requiring even more automation, the feature of custom boot scripts
+was introduced. If you have at least 1 file in the :code:`boot` directory on
+your Archive volume, you will be presented with the option to choose one of
+those files as a boot script for your kOS CPU.
+
+.. image:: http://i.imgur.com/05kp7Sy.jpg
+
+As soon as you vessel leaves VAB/SPH and is being initialised on the launchpad
+(e.g. its status is PRELAUNCH) the assigned script will be copied to CPU's
+local hard disk with the same name.  If kOS is configured to start on the
+archive, the file will not be copied locally automatically. This script will
+be run as soon as CPU boots, e.g. as soon as you bring your CPU in physics
+range or power on your CPU if it was turned off.  You may get or set the name
+of the boot file using the :attr:`kOSProcessor:BOOTFILENAME` suffix.
+
+Important things to consider:
+
+  * kOS CPU hard disk space is limited, avoid using complex boot scripts or increase disk space using MM config.
+  * Boot script runs immediately on initialisation, it should avoid interaction with parts/modules until physics fully load. It is best to wait for couple seconds or until certain trigger.
+
+Possible uses for boot scripts:
+
+  * Automatically activate sleeper/background scripts which will run on CPU until triggered by certain condition.
+  * Create basic station-keeping scripts - you will only have to focus your probes once in a while and let the boot script do the orbit adjustment automatically.
+  * Create multi-CPU vessels with certain cores dedicated to specific tasks, triggered by user input or external events (Robotic-heavy Vessels)
+  * Anything else you can come up with
 

--- a/doc/source/structures/volumes_and_files/path.rst
+++ b/doc/source/structures/volumes_and_files/path.rst
@@ -44,6 +44,9 @@ Instances of this structure can be passed as arguments instead of ordinary, stri
         * - :attr:`PARENT`
           - :struct:`Path`
           - Parent path
+        * - :meth:`CHANGENAME(name)`
+          - :struct:`Path`
+          - Returns a new path with its name (last segment) changed
         * - :meth:`CHANGEEXTENSION(extension)`
           - :struct:`Path`
           - Returns a new path with extension changed
@@ -111,6 +114,13 @@ Instances of this structure can be passed as arguments instead of ordinary, stri
     :access: Get only
 
     Returns a new path that points to this path's parent. This method will throw an exception if this path does not have a parent (its length is 0).
+
+.. method:: Path:CHANGENAME(name)
+
+    :parameter name: :struct:`String` new path name
+    :return: :struct:`Path`
+
+    Will return a new path with the value of the last segment of this path replaced (or added if there's none).
 
 .. method:: Path:CHANGEEXTENSION(extension)
 

--- a/doc/source/structures/volumes_and_files/path.rst
+++ b/doc/source/structures/volumes_and_files/path.rst
@@ -1,0 +1,134 @@
+.. _path:
+
+Path
+====
+
+Represents a path. Contains suffixes that can be helpful when using and manipulating paths. You can use
+:ref:`path() <path_command>` to create new instances.
+
+Instances of this structure can be passed as arguments instead of ordinary, string paths, for example::
+
+  copypath("../file", path()).
+
+.. structure:: Path
+
+    .. list-table::
+        :header-rows: 1
+        :widths: 2 1 4
+
+        * - Suffix
+          - Type
+          - Description
+
+        * - :attr:`VOLUME`
+          - :struct:`Volume`
+          - Volume this path belongs to
+        * - :attr:`SEGMENTS`
+          - :struct:`List` of :struct:`String`
+          - List of this path's segments
+        * - :attr:`LENGTH`
+          - :struct:`Scalar`
+          - Number of segments in this path
+        * - :attr:`NAME`
+          - :struct:`String`
+          - Name of file or directory this path points to
+        * - :attr:`HASEXTENSION`
+          - :struct:`Boolean`
+          - True if path contains an extension
+        * - :attr:`EXTENSION`
+          - :struct:`String`
+          - This path's extension
+        * - :attr:`ROOT`
+          - :struct:`Path`
+          - Root path of this path's volume
+        * - :attr:`PARENT`
+          - :struct:`Path`
+          - Parent path
+        * - :meth:`CHANGEEXTENSION(extension)`
+          - :struct:`Path`
+          - Returns a new path with extension changed
+        * - :meth:`ISPARENT(path)`
+          - :struct:`Boolean`
+          - True if `path` is the parent of this path
+        * - :meth:`COMBINE(name1, [name2, ...])`
+          - :struct:`Path`
+          - Returns a new path created from this one
+
+.. attribute:: Path:VOLUME
+
+    :type: :struct:`Volume`
+    :access: Get only
+
+    Volume this path belongs to.
+
+.. attribute:: Path:SEGMENTS
+
+    :type: :struct:`List` of :struct:`String`
+    :access: Get only
+
+    List of segments this path contains. Segments are parts of the path separated by `/`. For example path `0:/directory/subdirectory/script.ks` contains the following segments:
+    `directory`, `subdirectory` and `script.ks`.
+
+.. attribute:: Path:LENGTH
+
+    :type: :struct:`Scalar`
+    :access: Get only
+
+    Number of this path's segments.
+
+.. attribute:: Path:NAME
+
+    :type: :struct:`String`
+    :access: Get only
+
+    Name of file or directory this path points to (same as the last segment).
+
+
+.. attribute:: Path:HASEXTENSION
+
+    :type: :struct:`Boolean`
+    :access: Get only
+
+    True if the last segment of this path has an extension.
+
+.. attribute:: Path:EXTENSION
+
+    :type: :struct:`String`
+    :access: Get only
+
+    Extension of the last segment of this path.
+
+.. attribute:: Path:ROOT
+
+    :type: :struct:`Path`
+    :access: Get only
+
+    Returns a new path that points to the root directory of this path's volume.
+
+.. attribute:: Path:PARENT
+
+    :type: :struct:`Path`
+    :access: Get only
+
+    Returns a new path that points to this path's parent. This method will throw an exception if this path does not have a parent (its length is 0).
+
+.. method:: Path:CHANGEEXTENSION(extension)
+
+    :parameter extension: :struct:`String` new path extension
+    :return: :struct:`Path`
+
+    Will return a new path with the extension of the last segment of this path replaced (or added if there's none).
+
+.. method:: Path:ISPARENT(path)
+
+    :parameter path: :struct:`Path` path to check
+    :return: :struct:`Boolean`
+
+    Returns true if `path` is the parent of this path.
+
+.. method:: Path:COMBINE(name1, [name2, ...])
+
+    :parameter name: :struct:`String` segments to add
+    :return: :struct:`Path`
+
+    Will return a new path created by adding segments to this path.

--- a/doc/source/structures/volumes_and_files/volume.rst
+++ b/doc/source/structures/volumes_and_files/volume.rst
@@ -116,7 +116,7 @@ Represents a :struct:`kOSProcessor` hard disk or the archive.
 
     :return: :struct:`VolumeItem`
 
-    Opens the file or directory pointed to by the given path and returns :struct:`VolumeItem`. It will fail if the file or directory doesn't exist.
+    Opens the file or directory pointed to by the given path and returns :struct:`VolumeItem`. It will return a boolean false if the given file or directory does not exist.
 
 .. method:: Volume:CREATE(path)
 

--- a/doc/source/structures/volumes_and_files/volume.rst
+++ b/doc/source/structures/volumes_and_files/volume.rst
@@ -34,27 +34,31 @@ Represents a :struct:`kOSProcessor` hard disk or the archive.
 
         * - :attr:`FILES`
           - :struct:`Lexicon`
-          - Lexicon of all files on the volume
+          - Lexicon of all files and directories on the volume
 
         * - :attr:`POWERREQUIREMENT`
           - :ref:`scalar <scalar>`
           - Amount of power consumed when this volume is set as the current volume
 
-        * - :meth:`EXISTS(filename)`
+        * - :meth:`EXISTS(path)`
           - :ref:`boolean <boolean>`
-          - Returns true if the given file exists
+          - Returns true if the given file or directory exists
 
-        * - :meth:`CREATE(filename)`
+        * - :meth:`CREATE(path)`
           - :struct:`VolumeFile`
           - Creates a file
 
-        * - :meth:`OPEN(filename)`
-          - :struct:`VolumeFile`
-          - Opens a file
+        * - :meth:`CREATEDIR(path)`
+          - :struct:`VolumeDirectory`
+          - Creates a directory
 
-        * - :meth:`DELETE(filename)`
+        * - :meth:`OPEN(path)`
+          - :struct:`VolumeItem`
+          - Opens a file or directory
+
+        * - :meth:`DELETE(path)`
           - :ref:`boolean <boolean>`
-          - Deletes a file
+          - Deletes a file or directory
 
 .. attribute:: Volume:FREESPACE
 
@@ -87,10 +91,10 @@ Represents a :struct:`kOSProcessor` hard disk or the archive.
 
 .. attribute:: Volume:FILES
 
-    :type: :struct:`Lexicon` of :struct:`VolumeFile`
+    :type: :struct:`Lexicon` of :struct:`VolumeItem`
     :access: Get only
 
-    List of files on this volume. Keys are the names of all files on this volume and values are the associated :struct:`VolumeFile` structures.
+    List of files and directories on this volume. Keys are the names of all items on this volume and values are the associated :struct:`VolumeItem` structures.
 
 
 .. attribute:: Volume:POWERREQUIREMENT
@@ -101,28 +105,34 @@ Represents a :struct:`kOSProcessor` hard disk or the archive.
     Amount of power consumed when this volume is set as the current volume
 
 
-.. method:: Volume:EXISTS(filename)
+.. method:: Volume:EXISTS(path)
 
-    :return: :ref:`boolean <boolean>`
+    :return: :struct:`Boolean`
 
-    Returns true if the given file exists. This will also return true when the given file does not exist, but there is a file with the same name and `.ks` or `.ksm` extension added.
-    Use ``Volume:FILES:HASKEY(filename)`` to perform a strict check.
+    Returns true if the given file or directory exists. This will also return true when the given file does not exist, but there is a file with the same name and `.ks` or `.ksm` extension added.
+    Use ``Volume:FILES:HASKEY(name)`` to perform a strict check.
 
-.. method:: Volume:OPEN(filename)
+.. method:: Volume:OPEN(path)
+
+    :return: :struct:`VolumeItem`
+
+    Opens the file or directory pointed to by the given path and returns :struct:`VolumeItem`. It will fail if the file or directory doesn't exist.
+
+.. method:: Volume:CREATE(path)
 
     :return: :struct:`VolumeFile`
 
-    Opens the file with the given name and returns :struct:`VolumeFile`. It will fail if the file doesn't exist.
+    Creates a file under the given path and returns :struct:`VolumeFile`. It will fail if the file already exists.
 
-.. method:: Volume:CREATE(filename)
+.. method:: Volume:CREATEDIR(path)
 
-    :return: :struct:`VolumeFile`
+    :return: :struct:`VolumeDirectory`
 
-    Creates a file with the given name and returns :struct:`VolumeFile`. It will fail if the file already exists.
+    Creates a directory under the given path and returns :struct:`VolumeDirectory`. It will fail if the directory already exists.
 
-.. method:: Volume:DELETE(filename)
+.. method:: Volume:DELETE(path)
 
     :return: boolean
 
-    Deletes the given file. It will return true if file was successfully deleted and false otherwise.
+    Deletes the given file or directory (recursively). It will return true if the given item was successfully deleted and false otherwise.
 

--- a/doc/source/structures/volumes_and_files/volume.rst
+++ b/doc/source/structures/volumes_and_files/volume.rst
@@ -17,19 +17,19 @@ Represents a :struct:`kOSProcessor` hard disk or the archive.
           - Description
 
         * - :attr:`FREESPACE`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Free space left on the volume
 
         * - :attr:`CAPACITY`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Total space on the volume
 
         * - :attr:`NAME`
-          - :ref:`String`
+          - :struct:`String`
           - Volume name
 
         * - :attr:`RENAMEABLE`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - True if the name can be changed
 
         * - :attr:`ROOT`
@@ -41,11 +41,11 @@ Represents a :struct:`kOSProcessor` hard disk or the archive.
           - Lexicon of all files and directories on the volume
 
         * - :attr:`POWERREQUIREMENT`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Amount of power consumed when this volume is set as the current volume
 
         * - :meth:`EXISTS(path)`
-          - :ref:`boolean <boolean>`
+          - :struct:`Boolean`
           - Returns true if the given file or directory exists
 
         * - :meth:`CREATE(path)`
@@ -57,41 +57,40 @@ Represents a :struct:`kOSProcessor` hard disk or the archive.
           - Creates a directory
 
         * - :meth:`OPEN(path)`
-          - :struct:`VolumeItem`
+          - :struct:`VolumeItem` or :struct:`Boolean`
           - Opens a file or directory
 
         * - :meth:`DELETE(path)`
-          - :ref:`boolean <boolean>`
+          - :struct:`Boolean`
           - Deletes a file or directory
 
 .. attribute:: Volume:FREESPACE
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     Free space left on the volume
 
 .. attribute:: Volume:CAPACITY
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     Total space on the volume
 
 .. attribute:: Volume:NAME
 
-    :type: :ref:`String`
+    :type: :struct:`String`
     :access: Get only
 
     Volume name. This name can be used instead of the volumeId with some :ref:`file and volume-related commands<files>`
 
 .. attribute:: Volume:RENAMEABLE
 
-    :type: :ref:`boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get only
 
     True if the name of this volume can be changed. Currently only the name of the archive can't be changed.
-
 
 .. attribute:: Volume:FILES
 
@@ -109,11 +108,10 @@ Represents a :struct:`kOSProcessor` hard disk or the archive.
 
 .. attribute:: Volume:POWERREQUIREMENT
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     Amount of power consumed when this volume is set as the current volume
-
 
 .. method:: Volume:EXISTS(path)
 
@@ -122,11 +120,15 @@ Represents a :struct:`kOSProcessor` hard disk or the archive.
     Returns true if the given file or directory exists. This will also return true when the given file does not exist, but there is a file with the same name and `.ks` or `.ksm` extension added.
     Use ``Volume:FILES:HASKEY(name)`` to perform a strict check.
 
+    Paths passed as the argument to this command should not contain a volume id or name and should not be relative.
+
 .. method:: Volume:OPEN(path)
 
-    :return: :struct:`VolumeItem`
+    :return: :struct:`VolumeItem` or :struct:`Boolean` false
 
     Opens the file or directory pointed to by the given path and returns :struct:`VolumeItem`. It will return a boolean false if the given file or directory does not exist.
+
+    Paths passed as the argument to this command should not contain a volume id or name and should not be relative.
 
 .. method:: Volume:CREATE(path)
 
@@ -134,15 +136,21 @@ Represents a :struct:`kOSProcessor` hard disk or the archive.
 
     Creates a file under the given path and returns :struct:`VolumeFile`. It will fail if the file already exists.
 
+    Paths passed as the argument to this command should not contain a volume id or name and should not be relative.
+
 .. method:: Volume:CREATEDIR(path)
 
     :return: :struct:`VolumeDirectory`
 
     Creates a directory under the given path and returns :struct:`VolumeDirectory`. It will fail if the directory already exists.
 
+    Paths passed as the argument to this command should not contain a volume id or name and should not be relative.
+
 .. method:: Volume:DELETE(path)
 
     :return: boolean
 
     Deletes the given file or directory (recursively). It will return true if the given item was successfully deleted and false otherwise.
+
+    Paths passed as the argument to this command should not contain a volume id or name and should not be relative.
 

--- a/doc/source/structures/volumes_and_files/volume.rst
+++ b/doc/source/structures/volumes_and_files/volume.rst
@@ -26,7 +26,7 @@ Represents a :struct:`kOSProcessor` hard disk or the archive.
 
         * - :attr:`NAME`
           - :struct:`String`
-          - Volume name
+          - Get or set volume name
 
         * - :attr:`RENAMEABLE`
           - :struct:`Scalar`
@@ -81,9 +81,9 @@ Represents a :struct:`kOSProcessor` hard disk or the archive.
 .. attribute:: Volume:NAME
 
     :type: :struct:`String`
-    :access: Get only
+    :access: Get and Set
 
-    Volume name. This name can be used instead of the volumeId with some :ref:`file and volume-related commands<files>`
+    Gets or sets volume name. This name can be used instead of the volumeId with some :ref:`file and volume-related commands<files>`
 
 .. attribute:: Volume:RENAMEABLE
 

--- a/doc/source/structures/volumes_and_files/volume.rst
+++ b/doc/source/structures/volumes_and_files/volume.rst
@@ -32,6 +32,10 @@ Represents a :struct:`kOSProcessor` hard disk or the archive.
           - :ref:`scalar <scalar>`
           - True if the name can be changed
 
+        * - :attr:`ROOT`
+          - :struct:`VolumeDirectory`
+          - Volume's root directory
+
         * - :attr:`FILES`
           - :struct:`Lexicon`
           - Lexicon of all files and directories on the volume
@@ -96,6 +100,12 @@ Represents a :struct:`kOSProcessor` hard disk or the archive.
 
     List of files and directories on this volume. Keys are the names of all items on this volume and values are the associated :struct:`VolumeItem` structures.
 
+.. attribute:: Volume:ROOT
+
+    :type: :struct:`VolumeDirectory`
+    :access: Get only
+
+    Returns volume's root directory
 
 .. attribute:: Volume:POWERREQUIREMENT
 

--- a/doc/source/structures/volumes_and_files/volumedirectory.rst
+++ b/doc/source/structures/volumes_and_files/volumedirectory.rst
@@ -1,0 +1,34 @@
+.. _volumedirectory:
+
+VolumeDirecotry
+===============
+
+Represents a directory on a kOS file system.
+
+Instances of this class are enumerable, every step of iteration will provide a :struct:`VolumeFile` or a :struct:`VolumeDirectory` contained in this directory.
+
+.. structure:: VolumeDirectory
+
+    .. list-table:: Members
+        :header-rows: 1
+        :widths: 1 1 4
+
+        * - Suffix
+          - Type
+          - Description
+
+        * - All suffixes of :struct:`VolumeItem`
+          -
+          - :struct:`VolumeDirectory` objects are a type of :struct:`VolumeItem`
+
+        * - :meth:`LIST`
+          - :struct:`List` of :struct:`VolumeFile` or :struct:`VolumeDirectory`
+          - Lists all files and directories
+
+
+.. method:: VolumeDirectory:LIST
+
+    :return: :struct:`List` of :struct:`VolumeFile` or :struct:`VolumeDirectory`
+
+    Returns a list of all files and directories in this directory.
+

--- a/doc/source/structures/volumes_and_files/volumedirectory.rst
+++ b/doc/source/structures/volumes_and_files/volumedirectory.rst
@@ -1,6 +1,6 @@
 .. _volumedirectory:
 
-VolumeDirecotry
+VolumeDirectory
 ===============
 
 Represents a directory on a kOS file system.

--- a/doc/source/structures/volumes_and_files/volumefile.rst
+++ b/doc/source/structures/volumes_and_files/volumefile.rst
@@ -1,7 +1,7 @@
 .. _volumefile:
 
 VolumeFile
-================
+==========
 
 File name and size information. You can obtain a list of values of type VolumeFile using the :ref:`LIST FILES <list command>` command.
 
@@ -15,16 +15,10 @@ File name and size information. You can obtain a list of values of type VolumeFi
           - Type
           - Description
 
+        * - All suffixes of :struct:`VolumeItem`
+          -
+          - :struct:`VolumeFile` objects are a type of :struct:`VolumeItem`
 
-        * - :attr:`NAME`
-          - :struct:`String`
-          - Name of the file including extension
-        * - :attr:`EXTENSION`
-          - :struct:`String`
-          - File extension
-        * - :attr:`SIZE`
-          - :ref:`scalar <scalar>` (bytes)
-          - Size of the file
         * - :meth:`READALL`
           - :struct:`FileContent`
           - Reads file contents
@@ -37,28 +31,6 @@ File name and size information. You can obtain a list of values of type VolumeFi
         * - :meth:`CLEAR`
           - None
           - Clears this file
-
-
-.. attribute:: VolumeFile:NAME
-
-    :access: Get only
-    :type: :struct:`String`
-
-    name of the file, including its file extension.
-
-.. attribute:: VolumeFile:EXTENSION
-
-    :access: Get only
-    :type: :struct:`String`
-
-    File extension (part of the filename after the last dot).
-
-.. attribute:: VolumeFile:SIZE
-
-    :access: Get only
-    :type: :ref:`scalar <scalar>`
-
-    size of the file, in bytes.
 
 
 .. method:: VolumeFile:READALL

--- a/doc/source/structures/volumes_and_files/volumeitem.rst
+++ b/doc/source/structures/volumes_and_files/volumeitem.rst
@@ -1,0 +1,59 @@
+.. _volumeitem:
+
+VolumeItem
+==========
+
+Contains suffixes common to :struct:`files <VolumeFile>` and :struct:`directories <VolumeDirectory>`.
+
+.. structure:: VolumeItem
+
+    .. list-table:: Members
+        :header-rows: 1
+        :widths: 1 1 4
+
+        * - Suffix
+          - Type
+          - Description
+
+
+        * - :attr:`NAME`
+          - :struct:`String`
+          - Name of the item including extension
+        * - :attr:`EXTENSION`
+          - :struct:`String`
+          - Item extension
+        * - :attr:`SIZE`
+          - :struct:`Scalar`
+          - Size of the file
+        * - :attr:`ISFILE`
+          - :struct:`Scalar`
+          - Size of the file
+
+.. attribute:: VolumeItem:NAME
+
+    :access: Get only
+    :type: :struct:`String`
+
+    Name of the item, including the extension.
+
+.. attribute:: VolumeItem:EXTENSION
+
+    :access: Get only
+    :type: :struct:`String`
+
+    Item extension (part of the name after the last dot).
+
+.. attribute:: VolumeItem:SIZE
+
+    :access: Get only
+    :type: :struct:`Scalar`
+
+    Size of the item, in bytes.
+
+.. attribute:: VolumeItem:ISFILE
+
+    :access: Get only
+    :type: :struct:`Boolean`
+
+    True if this item is a file
+

--- a/src/kOS.Safe.Test/Communication/MessageQueueTest.cs
+++ b/src/kOS.Safe.Test/Communication/MessageQueueTest.cs
@@ -141,9 +141,9 @@ namespace kOS.Safe.Test.Communication
         {
             Lexicon lex = new Lexicon();
             lex.Add(new StringValue("key1"), new StringValue("value1"));
-            queue.Push(new BaseMessage(new SafeSerializationMgr().Dump(lex), 0, 0));
+            queue.Push(new BaseMessage(new SafeSerializationMgr(null).Dump(lex), 0, 0));
 
-            Lexicon read = new SafeSerializationMgr().CreateFromDump(queue.Pop().Content as Dump) as Lexicon;
+            Lexicon read = new SafeSerializationMgr(null).CreateFromDump(queue.Pop().Content as Dump) as Lexicon;
             Assert.AreEqual(new StringValue("value1"), read[new StringValue("key1")]);
         }
 

--- a/src/kOS.Safe.Test/Persistence/ArchiveAndHarddiskCopyAndMoveTest.cs
+++ b/src/kOS.Safe.Test/Persistence/ArchiveAndHarddiskCopyAndMoveTest.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using NUnit.Framework;
+using System.IO;
+using kOS.Safe.Persistence;
+
+namespace kOS.Safe.Test.Persistence
+{
+    public abstract class ArchiveAndHarddiskCopyAndMoveTest : CopyAndMoveTest
+    {
+        public string KosTestDirectory = "kos_archive_tests";
+        protected string archivePath;
+        protected Archive archive;
+        protected Harddisk harddisk;
+
+        public ArchiveAndHarddiskCopyAndMoveTest()
+        {
+            archivePath = Path.Combine(Path.GetTempPath(), KosTestDirectory);
+
+            archive = PrepareArchive(archivePath);
+            harddisk = new Harddisk(1000);
+        }
+
+        private Archive PrepareArchive(string archivePath)
+        {
+            if (Directory.Exists(archivePath))
+            {
+                Directory.Delete(archivePath, true);
+            }
+
+            Directory.CreateDirectory(archivePath);
+
+            return new Archive(archivePath);
+        }
+    }
+}
+

--- a/src/kOS.Safe.Test/Persistence/ArchiveTest.cs
+++ b/src/kOS.Safe.Test/Persistence/ArchiveTest.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using NUnit.Framework;
+using System.IO;
+using kOS.Safe.Persistence;
+using kOS.Safe.Utilities;
+
+namespace kOS.Safe.Test.Persistence
+{
+    [TestFixture]
+    public class ArchiveTest : VolumeTest
+    {
+        public const string KosTestDirectory = "kos_archive_tests";
+
+        protected override int ExpectedCapacity {
+            get {
+                return Volume.INFINITE_CAPACITY;
+            }
+        }
+
+        protected override bool ExpectedRenameable {
+            get {
+                return false;
+            }
+        }
+
+        protected string testPath = Path.Combine(Path.GetTempPath(), KosTestDirectory);
+
+        [SetUp]
+        public void Setup()
+        {
+            if (Directory.Exists(testPath))
+            {
+                Directory.Delete(testPath, true);
+            }
+
+            Directory.CreateDirectory(testPath);
+
+            TestVolume = new Archive(testPath);
+        }
+    }
+}
+

--- a/src/kOS.Safe.Test/Persistence/ArchiveToHarddiskCopyAndMoveTest.cs
+++ b/src/kOS.Safe.Test/Persistence/ArchiveToHarddiskCopyAndMoveTest.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using NUnit.Framework;
+using System.IO;
+using kOS.Safe.Persistence;
+
+namespace kOS.Safe.Test.Persistence
+{
+    [TestFixture]
+    public class ArchiveToHarddiskCopyAndMoveTest : ArchiveAndHarddiskCopyAndMoveTest
+    {
+        public override kOS.Safe.Persistence.Volume SourceVolume {
+            get {
+                return archive;
+            }
+        }
+
+        public override kOS.Safe.Persistence.Volume TargetVolume {
+            get {
+                return harddisk;
+            }
+        }
+    }
+}
+

--- a/src/kOS.Safe.Test/Persistence/CopyAndMoveTest.cs
+++ b/src/kOS.Safe.Test/Persistence/CopyAndMoveTest.cs
@@ -85,9 +85,19 @@ namespace kOS.Safe.Test
             Assert.AreEqual("subsubdir1File1\n", (parent.List()[file1] as VolumeFile).ReadAll().String);
         }
 
+        [Test]
+        public void CanCopyFileToRootDirectory()
+        {
+            GlobalPath targetPath = GlobalPath.FromString("1:");
+            Assert.IsTrue(volumeManager.Copy(subsubdir1File1Path, targetPath));
+
+            Assert.AreEqual(1, TargetVolume.Root.List().Count);
+            VolumeFile file = (TargetVolume.Open(file1) as VolumeFile);
+            Assert.AreEqual("subsubdir1File1\n", file.ReadAll().String);
+        }
 
         [Test]
-        public void CanCopyFileToDirectory()
+        public void CanCopyFileToSubdirectory()
         {
             GlobalPath targetPath = GlobalPath.FromString("1:/dir1");
             TargetVolume.CreateDirectory(targetPath);
@@ -132,6 +142,13 @@ namespace kOS.Safe.Test
             CompareDirectories(dir1Path, targetPath);
         }
 
+        [Test]
+        public void CanCopyDirectoryToRootDirectory()
+        {
+            Assert.IsTrue(volumeManager.Copy(dir1Path, GlobalPath.FromString("1:/")));
+
+            CompareDirectories(dir1Path, GlobalPath.FromString("1:/" + dir1));
+        }
 
         [Test]
         public void CanFailToCopyFileIfThereIsNoSpaceToCopy()

--- a/src/kOS.Safe.Test/Persistence/CopyAndMoveTest.cs
+++ b/src/kOS.Safe.Test/Persistence/CopyAndMoveTest.cs
@@ -1,0 +1,191 @@
+﻿using System;
+using NUnit.Framework;
+using System.IO;
+using kOS.Safe.Persistence;
+using kOS.Safe.Utilities;
+using kOS.Safe.Exceptions;
+using System.Text;
+using System.Collections.Generic;
+
+namespace kOS.Safe.Test
+{
+    public abstract class CopyAndMoveTest
+    {
+        public abstract Volume SourceVolume { get; }
+        public abstract Volume TargetVolume { get; }
+
+        protected VolumeManager volumeManager;
+
+        protected string dir1 = "dir1", subdir1 = "subdir1", subdir2 = "subdir2", subsubdir1 = "subsubdir1";
+        protected string file1 = "file1", file2 = "file2", file3 = "file3";
+
+        protected GlobalPath dir1Path, subdir1Path, subdir2Path, subsubdir1Path;
+
+        protected GlobalPath file1Path, dir1File1Path, dir1File2Path, subdir1File1Path, subsubdir1File1Path;
+
+        [SetUp]
+        public void SetupLogger()
+        {
+            SafeHouse.Logger = new TestLogger();
+        }
+
+        [SetUp]
+        public void SetupVolumeManager()
+        {
+            volumeManager = new VolumeManager();
+            volumeManager.Add(SourceVolume);
+            volumeManager.Add(TargetVolume);
+        }
+
+        [SetUp]
+        public void SetupVolumes()
+        {
+            dir1Path = GlobalPath.FromString("0:" + dir1);
+            subdir1Path = dir1Path.Combine(subdir1);
+            subdir2Path = dir1Path.Combine(subdir2);
+            subsubdir1Path = subdir1Path.Combine(subsubdir1);
+
+            file1Path = GlobalPath.FromString("0:" + file1);
+            dir1File1Path = dir1Path.Combine(file1);
+            dir1File2Path = dir1Path.Combine(file2);
+            subdir1File1Path = subdir1Path.Combine(file1);
+            subsubdir1File1Path = subsubdir1Path.Combine(file1);
+
+            SourceVolume.Clear();
+            TargetVolume.Clear();
+
+            SourceVolume.CreateDirectory(subdir2Path);
+            SourceVolume.CreateDirectory(subsubdir1Path);
+
+            SourceVolume.CreateFile(file1Path).WriteLn(file1);
+            SourceVolume.CreateFile(subsubdir1File1Path).WriteLn("subsubdir1File1");
+
+            var dir1List = SourceVolume.Root.List();
+
+            GlobalPath targetPath = GlobalPath.FromString("1:/dir1/file1");
+
+        }
+
+        [Test]
+        public void CanCopyFileToExistingFile()
+        {
+            GlobalPath targetPath = GlobalPath.FromString("1:/dir1/file1");
+            TargetVolume.CreateFile(targetPath);
+            volumeManager.Copy(subsubdir1File1Path, targetPath);
+
+            Assert.AreEqual(1, TargetVolume.Root.List().Count);
+            VolumeDirectory parent = (TargetVolume.Open(dir1Path) as VolumeDirectory);
+            Assert.AreEqual(1, parent.List().Count);
+            Assert.AreEqual("subsubdir1File1\n", (parent.List()[file1] as VolumeFile).ReadAll().String);
+        }
+
+        [Test]
+        public void CanCopyFileToNewFile()
+        {
+            volumeManager.Copy(subsubdir1File1Path, GlobalPath.FromString("1:/dir1/file1"));
+
+            Assert.AreEqual(1, TargetVolume.Root.List().Count);
+            VolumeDirectory parent = (TargetVolume.Open(dir1Path) as VolumeDirectory);
+            Assert.AreEqual(1, parent.List().Count);
+            Assert.AreEqual("subsubdir1File1\n", (parent.List()[file1] as VolumeFile).ReadAll().String);
+        }
+
+
+        [Test]
+        public void CanCopyFileToDirectory()
+        {
+            GlobalPath targetPath = GlobalPath.FromString("1:/dir1");
+            TargetVolume.CreateDirectory(targetPath);
+            volumeManager.Copy(subsubdir1File1Path, targetPath);
+
+            Assert.AreEqual(1, TargetVolume.Root.List().Count);
+            VolumeDirectory parent = (TargetVolume.Open(dir1Path) as VolumeDirectory);
+            Assert.AreEqual(1, parent.List().Count);
+            Assert.AreEqual("subsubdir1File1\n", (parent.List()[file1] as VolumeFile).ReadAll().String);
+        }
+
+        [Test]
+        [ExpectedException(typeof(KOSPersistenceException))]
+        public void CanFailWhenTryingToCopyDirectoryToAFile()
+        {
+            VolumePath filePath = TargetVolume.CreateFile("newfile").Path;
+            volumeManager.Copy(dir1Path, GlobalPath.FromString("1:/newfile"));
+        }
+
+        [Test]
+        [ExpectedException(typeof(KOSPersistenceException))]
+        public void CanFailWhenTryingToCopyDirectoryIntoItself()
+        {
+            volumeManager.Copy(dir1Path, subdir1Path);
+        }
+
+        [Test]
+        public void CanCopyDirectoryToExistingDirectory()
+        {
+            TargetVolume.CreateDirectory(VolumePath.FromString("/newdirectory"));
+            volumeManager.Copy(dir1Path, GlobalPath.FromString("1:/newdirectory"));
+
+            CompareDirectories(dir1Path, GlobalPath.FromString("1:/newdirectory/" + dir1));
+        }
+
+        [Test]
+        public void CanCopyDirectoryToNewDirectory()
+        {
+            GlobalPath targetPath = GlobalPath.FromString("1:/newname");
+            volumeManager.Copy(dir1Path, targetPath);
+
+            CompareDirectories(dir1Path, targetPath);
+        }
+
+        /*
+        [Test]
+        public void CanFailIfThereIsNoSpaceToCopy()
+        {
+            Assert.Fail();
+        }
+
+        [Test]
+        public void CanMoveEvenIfThereIsNoSpaceToCopy()
+        {
+            Assert.Fail();
+        }
+        */
+
+        private void CompareDirectories(GlobalPath dir1Path, GlobalPath dir2Path)
+        {
+            Volume dir1Volume = volumeManager.GetVolumeFromPath(dir1Path);
+            Volume dir2Volume = volumeManager.GetVolumeFromPath(dir2Path);
+
+            VolumeDirectory dir1 = dir1Volume.Open(dir1Path) as VolumeDirectory;
+            VolumeDirectory dir2 = dir2Volume.Open(dir2Path) as VolumeDirectory;
+
+            int dir1Count = dir1.List().Count;
+            int dir2Count = dir2.List().Count;
+
+            if (dir1Count != dir2Count)
+            {
+                Assert.Fail("Item count not equal: " + dir1Count + " != " + dir2Count);
+            }
+
+            foreach (KeyValuePair<string, VolumeItem> pair in dir1.List())
+            {
+                VolumeItem dir2Item = dir2Volume.Open(dir2Path.Combine(pair.Key));
+
+                if (pair.Value is VolumeDirectory && dir2Item is VolumeDirectory)
+                {
+                    CompareDirectories(dir1Path.Combine(pair.Key), dir2Path.Combine(pair.Key));
+                } else if (pair.Value is VolumeFile && dir2Item is VolumeFile)
+                {
+                    VolumeFile file1 = pair.Value as VolumeFile;
+                    VolumeFile file2 = dir2Item as VolumeFile;
+
+                    Assert.AreEqual(file1.ReadAll(), file2.ReadAll());
+                } else
+                {
+                    Assert.Fail("Items are not of the same type: " + dir1Path.Combine(pair.Key) + ", " + dir2Path.Combine(pair.Key));
+                }
+            }
+        }
+    }
+}
+

--- a/src/kOS.Safe.Test/Persistence/CopyAndMoveTest.cs
+++ b/src/kOS.Safe.Test/Persistence/CopyAndMoveTest.cs
@@ -165,63 +165,109 @@ namespace kOS.Safe.Test
             Assert.IsFalse(volumeManager.Copy(subdir1Path, GlobalPath.FromString("1:/copy2")));
         }
 
-        /*
+
         [Test]
         public void CanMoveFileToExistingFile()
         {
-            Assert.Fail();
+            GlobalPath targetPath = GlobalPath.FromString("1:/dir1/file1");
+            TargetVolume.CreateFile(targetPath);
+            Assert.IsTrue(volumeManager.Move(subsubdir1File1Path, targetPath));
+
+            Assert.IsFalse(SourceVolume.Exists(subsubdir1File1Path));
+            Assert.AreEqual(1, TargetVolume.Root.List().Count);
+            VolumeDirectory parent = (TargetVolume.Open(dir1Path) as VolumeDirectory);
+            Assert.AreEqual(1, parent.List().Count);
+            Assert.AreEqual("subsubdir1File1\n", (parent.List()[file1] as VolumeFile).ReadAll().String);
+
         }
 
         [Test]
         public void CanMoveFileToNewFile()
         {
-            Assert.Fail();        }
+            Assert.IsTrue(volumeManager.Move(subsubdir1File1Path, GlobalPath.FromString("1:/dir1/file1")));
+
+            Assert.IsFalse(SourceVolume.Exists(subsubdir1File1Path));
+            Assert.AreEqual(1, TargetVolume.Root.List().Count);
+            VolumeDirectory parent = (TargetVolume.Open(dir1Path) as VolumeDirectory);
+            Assert.AreEqual(1, parent.List().Count);
+            Assert.AreEqual("subsubdir1File1\n", (parent.List()[file1] as VolumeFile).ReadAll().String);
+        }
 
 
         [Test]
         public void CanMoveFileToDirectory()
         {
-            Assert.Fail();
+            GlobalPath targetPath = GlobalPath.FromString("1:/dir1");
+            TargetVolume.CreateDirectory(targetPath);
+            Assert.IsTrue(volumeManager.Move(subsubdir1File1Path, targetPath));
+
+            Assert.IsFalse(SourceVolume.Exists(subsubdir1File1Path));
+            Assert.AreEqual(1, TargetVolume.Root.List().Count);
+            VolumeDirectory parent = (TargetVolume.Open(dir1Path) as VolumeDirectory);
+            Assert.AreEqual(1, parent.List().Count);
+            Assert.AreEqual("subsubdir1File1\n", (parent.List()[file1] as VolumeFile).ReadAll().String);
+
         }
 
         [Test]
         [ExpectedException(typeof(KOSPersistenceException))]
         public void CanFailWhenTryingToMoveDirectoryToAFile()
         {
-            Assert.Fail();
+            VolumePath filePath = TargetVolume.CreateFile("newfile").Path;
+            volumeManager.Move(dir1Path, GlobalPath.FromString("1:/newfile"));
         }
 
         [Test]
         [ExpectedException(typeof(KOSPersistenceException))]
         public void CanFailWhenTryingToMoveDirectoryIntoItself()
         {
-            Assert.Fail();
+            volumeManager.Move(dir1Path, subdir1Path);
         }
 
         [Test]
         public void CanMoveDirectoryToExistingDirectory()
         {
-            Assert.Fail();
+            TargetVolume.CreateDirectory(VolumePath.FromString("/newdirectory"));
+            Assert.IsTrue(volumeManager.Move(dir1Path, GlobalPath.FromString("1:/newdirectory")));
+            Assert.IsFalse(SourceVolume.Exists(dir1Path));
         }
 
         [Test]
         public void CanMoveDirectoryToNewDirectory()
         {
-            Assert.Fail();
+            GlobalPath targetPath = GlobalPath.FromString("1:/newname");
+            Assert.IsTrue(volumeManager.Move(dir1Path, targetPath));
+            Assert.IsFalse(SourceVolume.Exists(dir1Path));
         }
 
         [Test]
-        public void CanMoveEvenIfThereIsNoSpaceToCopy()
+        public void CanFailToMoveWhenTheresNoSpaceOnTargetVolume()
         {
-        if (TargetVolume.Capacity == Volume.INFINITE_CAPACITY)
+            if (TargetVolume.Capacity == Volume.INFINITE_CAPACITY)
             {
+                Assert.Pass();
                 return;
             }
 
-            Assert.Fail();
+            (SourceVolume.Open(subsubdir1File1Path) as VolumeFile)
+                .WriteLn(new string('a', (int)TargetVolume.Capacity / 2 + 1));
+            Assert.IsTrue(volumeManager.Copy(subdir1Path, GlobalPath.FromString("1:/copy1")));
+            Assert.IsFalse(volumeManager.Move(subdir1Path, GlobalPath.FromString("1:/copy2")));
         }
 
-        */
+        [Test]
+        public void CanMoveEvenIfThereIsNoSpaceOnSameVolume()
+        {
+            if (SourceVolume.Capacity == Volume.INFINITE_CAPACITY)
+            {
+                Assert.Pass();
+                return;
+            }
+
+            (SourceVolume.Open(subsubdir1File1Path) as VolumeFile)
+                .WriteLn(new string('a', (int)SourceVolume.Capacity / 2 + 1));
+            Assert.IsTrue(volumeManager.Move(subdir1Path, GlobalPath.FromString("0:/newname")));
+        }
 
         private void CompareDirectories(GlobalPath dir1Path, GlobalPath dir2Path)
         {

--- a/src/kOS.Safe.Test/Persistence/CopyAndMoveTest.cs
+++ b/src/kOS.Safe.Test/Persistence/CopyAndMoveTest.cs
@@ -146,6 +146,16 @@ namespace kOS.Safe.Test
         }
 
         [Test]
+        public void CanCopyDirectoryToExistingDirectoryTwice()
+        {
+            TargetVolume.CreateDirectory(VolumePath.FromString("/newdirectory"));
+            Assert.IsTrue(volumeManager.Copy(dir1Path, GlobalPath.FromString("1:/newdirectory")));
+            Assert.IsTrue(volumeManager.Copy(dir1Path, GlobalPath.FromString("1:/newdirectory")));
+
+            CompareDirectories(dir1Path, GlobalPath.FromString("1:/newdirectory/" + dir1));
+        }
+
+        [Test]
         public void CanCopyDirectoryToNewDirectory()
         {
             GlobalPath targetPath = GlobalPath.FromString("1:/newname");
@@ -263,7 +273,6 @@ namespace kOS.Safe.Test
             VolumeDirectory parent = (TargetVolume.Open(dir1Path) as VolumeDirectory);
             Assert.AreEqual(1, parent.List().Count);
             Assert.AreEqual("subsubdir1File1\n", (parent.List()[file1] as VolumeFile).ReadAll().String);
-
         }
 
         [Test]
@@ -307,6 +316,23 @@ namespace kOS.Safe.Test
             GlobalPath targetPath = GlobalPath.FromString("1:/newname");
             Assert.IsTrue(volumeManager.Move(dir1Path, targetPath));
             Assert.IsFalse(SourceVolume.Exists(dir1Path));
+        }
+
+        [Test]
+        public void CanMoveDirectoryToRootDirectory()
+        {
+            GlobalPath targetPath = GlobalPath.FromString("1:");
+            Assert.IsTrue(volumeManager.Move(dir1Path, targetPath));
+            Assert.IsFalse(SourceVolume.Exists(dir1Path));
+        }
+
+        [Test]
+        [ExpectedException(typeof(KOSPersistenceException))]
+        public void CanFailToMoveRootDirectory()
+        {
+            GlobalPath sourcePath = GlobalPath.FromString("0:");
+            GlobalPath targetPath = GlobalPath.FromString("1:/newname");
+            volumeManager.Move(sourcePath, targetPath);
         }
 
         [Test]

--- a/src/kOS.Safe.Test/Persistence/CopyAndMoveTest.cs
+++ b/src/kOS.Safe.Test/Persistence/CopyAndMoveTest.cs
@@ -163,6 +163,14 @@ namespace kOS.Safe.Test
         }
 
         [Test]
+        public void CanCopyRootDirectoryToRootDirectory()
+        {
+            Assert.IsTrue(volumeManager.Copy(GlobalPath.FromString("0:/"), GlobalPath.FromString("1:/")));
+
+            CompareDirectories(GlobalPath.FromString("0:/"), GlobalPath.FromString("1:/"));
+        }
+
+        [Test]
         public void CanFailToCopyFileIfThereIsNoSpaceToCopy()
         {
             if (TargetVolume.Capacity == Volume.INFINITE_CAPACITY)
@@ -317,6 +325,9 @@ namespace kOS.Safe.Test
 
             VolumeDirectory dir1 = dir1Volume.Open(dir1Path) as VolumeDirectory;
             VolumeDirectory dir2 = dir2Volume.Open(dir2Path) as VolumeDirectory;
+
+            Assert.NotNull(dir1);
+            Assert.NotNull(dir2);
 
             int dir1Count = dir1.List().Count;
             int dir2Count = dir2.List().Count;

--- a/src/kOS.Safe.Test/Persistence/CopyAndMoveTest.cs
+++ b/src/kOS.Safe.Test/Persistence/CopyAndMoveTest.cs
@@ -171,6 +171,26 @@ namespace kOS.Safe.Test
         }
 
         [Test]
+        public void CanCopyRootDirectoryToExistingDirectory()
+        {
+            TargetVolume.CreateDirectory(VolumePath.FromString("/newdirectory"));
+            Assert.IsTrue(volumeManager.Copy(GlobalPath.FromString("0:/"), GlobalPath.FromString("1:/newdirectory")));
+
+            CompareDirectories(GlobalPath.FromString("0:/"), GlobalPath.FromString("1:/newdirectory"));
+        }
+
+        [Test]
+        public void CanCopyRootDirectoryToRootDirectoryTwice()
+        {
+            GlobalPath source = GlobalPath.FromString("0:/");
+            GlobalPath destination = GlobalPath.FromString("1:/");
+            Assert.IsTrue(volumeManager.Copy(source, destination));
+            Assert.IsTrue(volumeManager.Copy(source, destination));
+
+            CompareDirectories(source, destination);
+        }
+
+        [Test]
         public void CanFailToCopyFileIfThereIsNoSpaceToCopy()
         {
             if (TargetVolume.Capacity == Volume.INFINITE_CAPACITY)

--- a/src/kOS.Safe.Test/Persistence/CopyAndMoveTest.cs
+++ b/src/kOS.Safe.Test/Persistence/CopyAndMoveTest.cs
@@ -17,11 +17,11 @@ namespace kOS.Safe.Test
         protected VolumeManager volumeManager;
 
         protected string dir1 = "dir1", subdir1 = "subdir1", subdir2 = "subdir2", subsubdir1 = "subsubdir1";
-        protected string file1 = "file1", file2 = "file2", file3 = "file3";
+        protected string file1 = "file1", file2 = "file2", file3 = "file3.ks";
 
         protected GlobalPath dir1Path, subdir1Path, subdir2Path, subsubdir1Path;
 
-        protected GlobalPath file1Path, dir1File1Path, dir1File2Path, subdir1File1Path, subsubdir1File1Path;
+        protected GlobalPath file1Path, dir1File1Path, dir1File2Path, dir1File3Path, subdir1File1Path, subsubdir1File1Path;
 
         [SetUp]
         public void SetupLogger()
@@ -48,6 +48,7 @@ namespace kOS.Safe.Test
             file1Path = GlobalPath.FromString("0:" + file1);
             dir1File1Path = dir1Path.Combine(file1);
             dir1File2Path = dir1Path.Combine(file2);
+            dir1File3Path = dir1Path.Combine(file3);
             subdir1File1Path = subdir1Path.Combine(file1);
             subsubdir1File1Path = subsubdir1Path.Combine(file1);
 
@@ -58,6 +59,7 @@ namespace kOS.Safe.Test
             SourceVolume.CreateDirectory(subsubdir1Path);
 
             SourceVolume.CreateFile(file1Path).WriteLn(file1);
+            SourceVolume.CreateFile(dir1File3Path).WriteLn(file2);
             SourceVolume.CreateFile(subsubdir1File1Path).WriteLn("subsubdir1File1");
         }
 
@@ -94,6 +96,16 @@ namespace kOS.Safe.Test
             Assert.AreEqual(1, TargetVolume.Root.List().Count);
             VolumeFile file = (TargetVolume.Open(file1) as VolumeFile);
             Assert.AreEqual("subsubdir1File1\n", file.ReadAll().String);
+        }
+
+        [Test]
+        public void CanCopyFileByCookedName()
+        {
+            GlobalPath targetPath = GlobalPath.FromString("1:");
+            Assert.IsTrue(volumeManager.Copy(dir1Path.Combine("file3"), targetPath));
+
+            Assert.AreEqual(1, TargetVolume.Root.List().Count);
+            Assert.IsTrue(TargetVolume.Root.List()[file3] is VolumeFile);
         }
 
         [Test]
@@ -224,6 +236,18 @@ namespace kOS.Safe.Test
             Assert.AreEqual(1, parent.List().Count);
             Assert.AreEqual("subsubdir1File1\n", (parent.List()[file1] as VolumeFile).ReadAll().String);
 
+        }
+
+        [Test]
+        public void CanMoveFileByCookedName()
+        {
+            var sourcePath = dir1Path.Combine("file3");
+            GlobalPath targetPath = GlobalPath.FromString("1:");
+            Assert.IsTrue(volumeManager.Move(sourcePath, targetPath));
+
+            Assert.IsFalse(SourceVolume.Exists(sourcePath));
+            Assert.AreEqual(1, TargetVolume.Root.List().Count);
+            Assert.IsTrue(TargetVolume.Root.List()[file3] is VolumeFile);
         }
 
         [Test]

--- a/src/kOS.Safe.Test/Persistence/GlobalPathTest.cs
+++ b/src/kOS.Safe.Test/Persistence/GlobalPathTest.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using NUnit.Framework;
+using kOS.Safe.Persistence;
+
+namespace kOS.Safe.Test.Persistence
+{
+    [TestFixture]
+    public class GlobalPathTest
+    {
+        [Test]
+        public void CanReturnParent()
+        {
+            GlobalPath path = GlobalPath.FromString("othervolume:/level1/level2");
+            Assert.AreEqual("othervolume", path.VolumeId);
+            Assert.AreEqual(2, path.Depth);
+            Assert.AreEqual(2, path.Length);
+        }
+
+        [Test]
+        public void CanIdentifyParents()
+        {
+            GlobalPath path = GlobalPath.FromString("othervolume:/level1/level2");
+            GlobalPath parent1 = GlobalPath.FromString("othervolume:");
+            GlobalPath parent2 = GlobalPath.FromString("othervolume:/level1");
+            GlobalPath notParent1 = GlobalPath.FromString("othervolume:/sthelse");
+            GlobalPath notParent2 = GlobalPath.FromString("othervolume:/level1/level2/level3");
+            GlobalPath notParent3 = GlobalPath.FromString("othervolume2:/level1/level2");
+
+            Assert.IsTrue(parent1.IsParent(path));
+            Assert.IsTrue(parent2.IsParent(path));
+            Assert.IsFalse(path.IsParent(path));
+            Assert.IsFalse(notParent1.IsParent(path));
+            Assert.IsFalse(notParent2.IsParent(path));
+            Assert.IsFalse(notParent3.IsParent(path));
+        }
+
+        [Test]
+        public void CanHandleVolumeNames()
+        {
+            GlobalPath path = GlobalPath.FromString("othervolume:/level1/level2");
+            Assert.AreEqual("othervolume", path.VolumeId);
+            Assert.AreEqual(2, path.Depth);
+            Assert.AreEqual(2, path.Length);
+        }
+
+        [Test]
+        public void CanHandleVolumeIds()
+        {
+            GlobalPath path = GlobalPath.FromString("1:level1/level2");
+            Assert.AreEqual(1, path.VolumeId);
+            Assert.AreEqual(2, path.Depth);
+            Assert.AreEqual(2, path.Length);
+        }
+
+        [Test]
+        public void CanHandleJustVolumeName()
+        {
+            GlobalPath path = GlobalPath.FromString("othervolume:");
+            Assert.AreEqual("othervolume", path.VolumeId);
+            Assert.AreEqual(0, path.Depth);
+            Assert.AreEqual(0, path.Length);
+        }
+
+        [Test]
+        [ExpectedException(typeof(KOSInvalidPathException))]
+        public void CanHandleGlobalPathWithLessThanZeroDepth()
+        {
+            GlobalPath.FromString("othervolume:/test/../../");
+        }
+    }
+}

--- a/src/kOS.Safe.Test/Persistence/GlobalPathTest.cs
+++ b/src/kOS.Safe.Test/Persistence/GlobalPathTest.cs
@@ -67,5 +67,35 @@ namespace kOS.Safe.Test.Persistence
         {
             GlobalPath.FromString("othervolume:/test/../../");
         }
+
+        [Test]
+        public void CanChangeExtension()
+        {
+            GlobalPath path = GlobalPath.FromString("othervolume:123");
+            GlobalPath newPath = path.ChangeExtension("txt");
+            Assert.AreEqual("othervolume", newPath.VolumeId);
+            Assert.AreEqual(1, newPath.Length);
+            Assert.AreEqual("123.txt", newPath.Name);
+
+            path = GlobalPath.FromString("othervolume:/dir/file.jpg");
+            newPath = path.ChangeExtension("txt");
+            Assert.AreEqual("othervolume", newPath.VolumeId);
+            Assert.AreEqual(2, newPath.Length);
+            Assert.AreEqual("file.txt", newPath.Name);
+
+            path = GlobalPath.FromString("othervolume:/dir/complex.file.name.");
+            newPath = path.ChangeExtension("txt");
+            Assert.AreEqual("othervolume", newPath.VolumeId);
+            Assert.AreEqual(2, newPath.Length);
+            Assert.AreEqual("complex.file.name.txt", newPath.Name);
+        }
+
+        [Test]
+        [ExpectedException(typeof(KOSInvalidPathException))]
+        public void CanHandleChangingExtensionOfRootPaths()
+        {
+            GlobalPath path = GlobalPath.FromString("othervolume:");
+            path.ChangeExtension("txt");
+        }
     }
 }

--- a/src/kOS.Safe.Test/Persistence/GlobalPathTest.cs
+++ b/src/kOS.Safe.Test/Persistence/GlobalPathTest.cs
@@ -83,11 +83,11 @@ namespace kOS.Safe.Test.Persistence
             Assert.AreEqual(2, newPath.Length);
             Assert.AreEqual("file.txt", newPath.Name);
 
-            path = GlobalPath.FromString("othervolume:/dir/complex.file.name.");
+            path = GlobalPath.FromString("othervolume:/dir/complex.file..name..");
             newPath = path.ChangeExtension("txt");
             Assert.AreEqual("othervolume", newPath.VolumeId);
             Assert.AreEqual(2, newPath.Length);
-            Assert.AreEqual("complex.file.name.txt", newPath.Name);
+            Assert.AreEqual("complex.file..name..txt", newPath.Name);
         }
 
         [Test]

--- a/src/kOS.Safe.Test/Persistence/GlobalPathTest.cs
+++ b/src/kOS.Safe.Test/Persistence/GlobalPathTest.cs
@@ -70,6 +70,22 @@ namespace kOS.Safe.Test.Persistence
         }
 
         [Test]
+        public void CanChangeName()
+        {
+            GlobalPath path = GlobalPath.FromString("othervolume:123");
+            GlobalPath newPath = path.ChangeName("abc");
+            Assert.AreEqual("othervolume", newPath.VolumeId);
+            Assert.AreEqual(1, newPath.Length);
+            Assert.AreEqual("abc", newPath.Name);
+
+            path = GlobalPath.FromString("othervolume:/dir/file.jpg");
+            newPath = path.ChangeName("new.txt");
+            Assert.AreEqual("othervolume", newPath.VolumeId);
+            Assert.AreEqual(2, newPath.Length);
+            Assert.AreEqual("new.txt", newPath.Name);
+        }
+
+        [Test]
         public void CanChangeExtension()
         {
             GlobalPath path = GlobalPath.FromString("othervolume:123");

--- a/src/kOS.Safe.Test/Persistence/GlobalPathTest.cs
+++ b/src/kOS.Safe.Test/Persistence/GlobalPathTest.cs
@@ -97,5 +97,20 @@ namespace kOS.Safe.Test.Persistence
             GlobalPath path = GlobalPath.FromString("othervolume:");
             path.ChangeExtension("txt");
         }
+
+        [Test]
+        public void CanCombine()
+        {
+            GlobalPath path = GlobalPath.FromString("othervolume:123");
+            GlobalPath newPath = path.Combine("456", "789");
+            Assert.AreEqual("othervolume", newPath.VolumeId);
+            Assert.AreEqual(3, newPath.Length);
+            Assert.AreEqual("789", newPath.Name);
+
+            newPath = path.Combine("..", "abc");
+            Assert.AreEqual("othervolume", newPath.VolumeId);
+            Assert.AreEqual(1, newPath.Length);
+            Assert.AreEqual("abc", newPath.Name);
+        }
     }
 }

--- a/src/kOS.Safe.Test/Persistence/GlobalPathTest.cs
+++ b/src/kOS.Safe.Test/Persistence/GlobalPathTest.cs
@@ -57,6 +57,7 @@ namespace kOS.Safe.Test.Persistence
         {
             GlobalPath path = GlobalPath.FromString("othervolume:");
             Assert.AreEqual("othervolume", path.VolumeId);
+            Assert.IsEmpty(path.Name);
             Assert.AreEqual(0, path.Depth);
             Assert.AreEqual(0, path.Length);
         }
@@ -111,6 +112,22 @@ namespace kOS.Safe.Test.Persistence
             Assert.AreEqual("othervolume", newPath.VolumeId);
             Assert.AreEqual(1, newPath.Length);
             Assert.AreEqual("abc", newPath.Name);
+        }
+
+        [Test]
+        [ExpectedException(typeof(KOSInvalidPathException))]
+        public void CanFailToCombineSegmentsWithSlashes()
+        {
+            GlobalPath path = GlobalPath.FromString("othervolume:123");
+            path.Combine("456/abc", "789");
+        }
+
+        [Test]
+        [ExpectedException(typeof(KOSInvalidPathException))]
+        public void CanFailToCombineOutside()
+        {
+            GlobalPath path = GlobalPath.FromString("othervolume:123");
+            path.Combine("..", "..");
         }
     }
 }

--- a/src/kOS.Safe.Test/Persistence/HarddiskTest.cs
+++ b/src/kOS.Safe.Test/Persistence/HarddiskTest.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using NUnit.Framework;
+using kOS.Safe.Persistence;
+
+namespace kOS.Safe.Test.Persistence
+{
+    [TestFixture]
+    public class HarddiskTest : VolumeTest
+    {
+
+        protected override int ExpectedCapacity {
+            get {
+                return 5000;
+            }
+        }
+
+        protected override bool ExpectedRenameable {
+            get {
+                return true;
+            }
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            TestVolume = new Harddisk(ExpectedCapacity);
+        }
+
+    }
+}
+

--- a/src/kOS.Safe.Test/Persistence/HarddiskToArchiveCopyAndMoveTest.cs
+++ b/src/kOS.Safe.Test/Persistence/HarddiskToArchiveCopyAndMoveTest.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace kOS.Safe.Test.Persistence
+{
+    public class HarddiskToArchiveCopyAndMoveTest : ArchiveAndHarddiskCopyAndMoveTest
+    {
+        public override kOS.Safe.Persistence.Volume SourceVolume {
+            get {
+                return harddisk;
+            }
+        }
+
+        public override kOS.Safe.Persistence.Volume TargetVolume {
+            get {
+                return archive;
+            }
+        }
+    }
+}
+

--- a/src/kOS.Safe.Test/Persistence/HarddiskToHarddiskCopyAndMoveTest.cs
+++ b/src/kOS.Safe.Test/Persistence/HarddiskToHarddiskCopyAndMoveTest.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using kOS.Safe.Persistence;
+using NUnit.Framework;
+
+namespace kOS.Safe.Test.Persistence
+{
+    [TestFixture]
+    public class HarddiskToHarddiskCopyAndMoveTest : CopyAndMoveTest
+    {
+        protected Harddisk harddisk1, harddisk2;
+
+        public HarddiskToHarddiskCopyAndMoveTest()
+        {
+            harddisk1 = new Harddisk(1000);
+            harddisk2 = new Harddisk(1000);
+        }
+
+        public override Volume SourceVolume {
+            get {
+                return harddisk1;
+            }
+        }
+        public override Volume TargetVolume {
+            get {
+                return harddisk2;
+            }
+        }
+    }
+}
+

--- a/src/kOS.Safe.Test/Persistence/VolumePathTest.cs
+++ b/src/kOS.Safe.Test/Persistence/VolumePathTest.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using NUnit.Framework;
+using kOS.Safe.Persistence;
+
+namespace kOS.Safe.Test.Persistence
+{
+    [TestFixture]
+    public class VolumePathTest
+    {
+        [Test]
+        [ExpectedException(typeof(KOSInvalidPathException))]
+        public void CanHandleEmptyPath()
+        {
+            VolumePath.FromString("");
+        }
+
+        [Test]
+        public void CanHandleRootPath()
+        {
+            VolumePath path = VolumePath.FromString("/");
+            Assert.AreEqual(0, path.Length);
+            Assert.AreEqual(0, path.Depth);
+        }
+
+        [Test]
+        public void CanHandleSimplePath()
+        {
+            VolumePath path = VolumePath.FromString("/identifier");
+            Assert.AreEqual(1, path.Length);
+            Assert.AreEqual(1, path.Depth);
+        }
+
+        [Test]
+        [ExpectedException(typeof(KOSInvalidPathException))]
+        public void CanHandleAbsolutePathWithParent()
+        {
+            VolumePath parent = VolumePath.FromString("/parent");
+            VolumePath.FromString("/identifier", parent);
+        }
+
+        [Test]
+        public void CanHandleTwoDots()
+        {
+            VolumePath parent = VolumePath.FromString("/parent/deeper/and_deeper");
+            VolumePath path = VolumePath.FromString("../../", parent);
+            Assert.AreEqual(1, path.Depth);
+            Assert.AreEqual(1, path.Length);
+        }
+
+        [Test]
+        [ExpectedException(typeof(KOSInvalidPathException))]
+        public void CanHandlePathsThatPointOutside1()
+        {
+            VolumePath.FromString("/..");
+        }
+
+        [Test]
+        [ExpectedException(typeof(KOSInvalidPathException))]
+        public void CanHandlePathsThatPointOutside2()
+        {
+            VolumePath.FromString("/../test/test/test");
+        }
+    }
+}
+

--- a/src/kOS.Safe.Test/Persistence/VolumePathTest.cs
+++ b/src/kOS.Safe.Test/Persistence/VolumePathTest.cs
@@ -8,10 +8,13 @@ namespace kOS.Safe.Test.Persistence
     public class VolumePathTest
     {
         [Test]
-        [ExpectedException(typeof(KOSInvalidPathException))]
         public void CanHandleEmptyPath()
         {
-            VolumePath.FromString("");
+            VolumePath path = VolumePath.FromString("");
+            Assert.AreEqual(0, path.Length);
+            Assert.AreEqual(0, path.Depth);
+            Assert.AreEqual(string.Empty, path.Name);
+            Assert.AreEqual(string.Empty, path.Extension);
         }
 
         [Test]
@@ -20,8 +23,8 @@ namespace kOS.Safe.Test.Persistence
             VolumePath path = VolumePath.FromString("/");
             Assert.AreEqual(0, path.Length);
             Assert.AreEqual(0, path.Depth);
-            Assert.IsNull(path.Name);
-            Assert.IsNull(path.Extension);
+            Assert.AreEqual(string.Empty, path.Name);
+            Assert.AreEqual(string.Empty, path.Extension);
         }
 
         [Test]

--- a/src/kOS.Safe.Test/Persistence/VolumePathTest.cs
+++ b/src/kOS.Safe.Test/Persistence/VolumePathTest.cs
@@ -20,6 +20,8 @@ namespace kOS.Safe.Test.Persistence
             VolumePath path = VolumePath.FromString("/");
             Assert.AreEqual(0, path.Length);
             Assert.AreEqual(0, path.Depth);
+            Assert.IsNull(path.Name);
+            Assert.IsNull(path.Extension);
         }
 
         [Test]

--- a/src/kOS.Safe.Test/Persistence/VolumePathTest.cs
+++ b/src/kOS.Safe.Test/Persistence/VolumePathTest.cs
@@ -28,6 +28,15 @@ namespace kOS.Safe.Test.Persistence
         }
 
         [Test]
+        public void CanHandleMultipleSlashes()
+        {
+            VolumePath path = VolumePath.FromString("//test//test2/");
+            Assert.AreEqual(2, path.Length);
+            Assert.AreEqual(2, path.Depth);
+            Assert.AreEqual("test2", path.Name);
+        }
+
+        [Test]
         public void CanHandleSimplePath()
         {
             VolumePath path = VolumePath.FromString("/identifier");

--- a/src/kOS.Safe.Test/Persistence/VolumeTest.cs
+++ b/src/kOS.Safe.Test/Persistence/VolumeTest.cs
@@ -223,6 +223,12 @@ namespace kOS.Safe.Test
         }
 
         [Test]
+        public void CanHandleOpeningNonExistingFiles()
+        {
+            Assert.IsNull(TestVolume.Open(VolumePath.FromString("/idonotexist")));
+        }
+
+        [Test]
         public void CanDeleteFiles()
         {
             string parent1 = "/parent1";
@@ -231,7 +237,7 @@ namespace kOS.Safe.Test
             TestVolume.CreateFile(VolumePath.FromString(file1));
             TestVolume.CreateFile(VolumePath.FromString(file2));
 
-            TestVolume.Delete(VolumePath.FromString(file1));
+            Assert.IsTrue(TestVolume.Delete(VolumePath.FromString(file1)));
 
             VolumeDirectory dir = TestVolume.Open(VolumePath.FromString(parent1)) as VolumeDirectory;
             Assert.AreEqual(1, dir.List().Count);

--- a/src/kOS.Safe.Test/Persistence/VolumeTest.cs
+++ b/src/kOS.Safe.Test/Persistence/VolumeTest.cs
@@ -220,6 +220,20 @@ namespace kOS.Safe.Test
 
             Assert.AreEqual(contentLength, volumeFile.Size);
             Assert.AreEqual(content, volumeFile.ReadAll().String);
+
+            // we should be able to save the same file again
+            Assert.IsTrue(TestVolume.Save(volumeFile) != null);
+        }
+
+        [Test]
+        [ExpectedException(typeof(KOSPersistenceException))]
+        public void CanFailWhenSavingFileOverDirectory()
+        {
+            string parent1 = "/parent1";
+            string file1 = parent1 + "/sub1";
+
+            TestVolume.CreateDirectory(VolumePath.FromString(file1));
+            TestVolume.Save(VolumePath.FromString(file1), new FileContent());
         }
 
         [Test]

--- a/src/kOS.Safe.Test/Persistence/VolumeTest.cs
+++ b/src/kOS.Safe.Test/Persistence/VolumeTest.cs
@@ -75,7 +75,8 @@ namespace kOS.Safe.Test
         }
 
         [Test]
-        public void CanCreateDirectoryOverExistingDirectory()
+        [ExpectedException(typeof(KOSPersistenceException))]
+        public void CanFailWhenCreatingDirectoryOverExistingDirectory()
         {
             string parent = "/parent1";
             string dir = parent + "/sub1";
@@ -161,6 +162,16 @@ namespace kOS.Safe.Test
             Assert.IsInstanceOf<VolumeFile>(dir.List()["sub3"]);
         }
 
+        [Test]
+        [ExpectedException(typeof(KOSPersistenceException))]
+        public void CanFailWhenCreatingFileOverExistingFile()
+        {
+            string parent = "/parent1";
+            string file = parent + "/file";
+
+            TestVolume.CreateFile(VolumePath.FromString(file));
+            TestVolume.CreateFile(VolumePath.FromString(file));
+        }
 
         [Test]
         [ExpectedException(typeof(KOSPersistenceException))]

--- a/src/kOS.Safe.Test/Persistence/VolumeTest.cs
+++ b/src/kOS.Safe.Test/Persistence/VolumeTest.cs
@@ -1,0 +1,244 @@
+﻿using System;
+using NUnit.Framework;
+using System.IO;
+using kOS.Safe.Persistence;
+using kOS.Safe.Utilities;
+using kOS.Safe.Exceptions;
+using System.Text;
+
+namespace kOS.Safe.Test
+{
+    public abstract class VolumeTest
+    {
+        public Volume TestVolume { get; set; }
+        protected abstract int ExpectedCapacity { get; }
+        protected abstract bool ExpectedRenameable { get; }
+
+        [SetUp]
+        public void SetupLogger()
+        {
+            SafeHouse.Logger = new TestLogger();
+        }
+
+
+        [Test]
+        public void CanReturnCapacity()
+        {
+            Assert.AreEqual(ExpectedCapacity, TestVolume.Capacity);
+        }
+
+        [Test]
+        public void CanReturnRenameable()
+        {
+            Assert.AreEqual(ExpectedRenameable, TestVolume.Renameable);
+        }
+
+        [Test]
+        public void CanCreateDirectories()
+        {
+            string dir1 = "/testdir", dir2 = "/abc", dir3 = "/abc2", dir4 = "/abc/subdirectory";
+            Assert.AreEqual(0, TestVolume.Root.List().Count);
+
+            TestVolume.CreateDirectory(VolumePath.FromString(dir1));
+            TestVolume.CreateDirectory(VolumePath.FromString(dir2));
+            TestVolume.CreateDirectory(VolumePath.FromString(dir3));
+            TestVolume.CreateDirectory(VolumePath.FromString(dir4));
+
+            Assert.AreEqual(3, TestVolume.Root.List().Count);
+            Assert.AreEqual(dir2, TestVolume.Root.List()["abc"].Path.ToString());
+            Assert.AreEqual(dir3, TestVolume.Root.List()["abc2"].Path.ToString());
+            Assert.AreEqual(dir1, TestVolume.Root.List()["testdir"].Path.ToString());
+
+            Assert.AreEqual(1, (TestVolume.Root.List()["abc"] as VolumeDirectory).List().Values.Count);
+            Assert.AreEqual(dir4, (TestVolume.Root.List()["abc"] as VolumeDirectory).List()["subdirectory"].Path.ToString());
+        }
+
+        [Test]
+        public void CanCreateSubdirectories()
+        {
+            string parent1 = "/parent1", parent2 = "/parent2";
+            string dir1 = parent1 + "/sub1", dir2 = parent1 + "/sub2", dir3 = parent2 + "/sub3";
+            Assert.AreEqual(0, TestVolume.Root.List().Count);
+
+            TestVolume.CreateDirectory(VolumePath.FromString(dir1));
+            TestVolume.CreateDirectory(VolumePath.FromString(dir2));
+            TestVolume.CreateDirectory(VolumePath.FromString(dir3));
+
+            Assert.AreEqual(2, TestVolume.Root.List().Count);
+            Assert.AreEqual(parent1, TestVolume.Root.List()["parent1"].Path.ToString());
+            Assert.AreEqual(parent2, TestVolume.Root.List()["parent2"].Path.ToString());
+
+            VolumeDirectory dir = TestVolume.Open(VolumePath.FromString(parent1)) as VolumeDirectory;
+            Assert.AreEqual(2, dir.List().Count);
+            Assert.AreEqual(dir1, dir.List()["sub1"].Path.ToString());
+            Assert.AreEqual(dir2, dir.List()["sub2"].Path.ToString());
+        }
+
+        [Test]
+        public void CanCreateDirectoryOverExistingDirectory()
+        {
+            string parent = "/parent1";
+            string dir = parent + "/sub1";
+
+            TestVolume.CreateDirectory(VolumePath.FromString(dir));
+            TestVolume.CreateDirectory(VolumePath.FromString(dir));
+        }
+
+        [Test]
+        [ExpectedException(typeof(KOSPersistenceException))]
+        public void CanFailWhenCreatingDirectoryOverFile()
+        {
+            string parent1 = "/parent1";
+            string file1 = parent1 + "/sub1";
+
+            TestVolume.CreateFile(VolumePath.FromString(file1));
+            TestVolume.CreateDirectory(VolumePath.FromString(file1));
+        }
+
+        [Test]
+        [ExpectedException(typeof(KOSInvalidPathException))]
+        public void CanFailWhenCreatingDirectoryWithNegativeDepth()
+        {
+            string dir = "/../test";
+
+            TestVolume.CreateDirectory(VolumePath.FromString(dir));
+        }
+
+        [Test]
+        public void CanDeleteDirectories()
+        {
+            string parent1 = "/parent1", parent2 = "/parent2";
+            string dir1 = parent1 + "/sub1", dir2 = parent1 + "/sub2", dir3 = parent2 + "/sub3";
+
+            TestVolume.CreateDirectory(VolumePath.FromString(dir1));
+            TestVolume.CreateDirectory(VolumePath.FromString(dir2));
+            TestVolume.CreateDirectory(VolumePath.FromString(dir3));
+
+            VolumeDirectory parent = TestVolume.Open(VolumePath.FromString(parent1)) as VolumeDirectory;
+
+            TestVolume.Delete(VolumePath.FromString(dir1));
+            Assert.AreEqual(1, parent.List().Count);
+            Assert.AreEqual(dir2, parent.List()["sub2"].Path.ToString());
+
+            TestVolume.Delete(VolumePath.FromString(parent2));
+            Assert.AreEqual(1, TestVolume.Root.List().Count);
+            Assert.AreEqual(parent1, TestVolume.Root.List()["parent1"].Path.ToString());
+        }
+
+        [Test]
+        public void CanDeleteNonExistingDirectories()
+        {
+            VolumePath path = VolumePath.FromString("/abc");
+            TestVolume.CreateDirectory(path);
+            TestVolume.Delete(path);
+            TestVolume.Delete(path);
+        }
+
+        [Test]
+        public void CanCreateFiles()
+        {
+            string parent1 = "/parent1", parent2 = "/parent2";
+            string file1 = parent1 + "/sub1", file2 = parent1 + "/sub2", file3 = parent2 + "/sub3";
+
+            TestVolume.CreateFile(VolumePath.FromString(file1));
+            TestVolume.CreateFile(VolumePath.FromString(file2));
+            TestVolume.CreateFile(VolumePath.FromString(file3));
+
+            Assert.AreEqual(2, TestVolume.Root.List().Count);
+            Assert.AreEqual(parent1, TestVolume.Root.List()["parent1"].Path.ToString());
+            Assert.AreEqual(parent2, TestVolume.Root.List()["parent2"].Path.ToString());
+
+            VolumeDirectory dir = TestVolume.Open(VolumePath.FromString(parent1)) as VolumeDirectory;
+            Assert.AreEqual(2, dir.List().Count);
+            Assert.AreEqual(file1, dir.List()["sub1"].Path.ToString());
+            Assert.IsInstanceOf<VolumeFile>(dir.List()["sub1"]);
+            Assert.AreEqual(file2, dir.List()["sub2"].Path.ToString());
+            Assert.IsInstanceOf<VolumeFile>(dir.List()["sub2"]);
+
+            dir = TestVolume.Open(VolumePath.FromString(parent2)) as VolumeDirectory;
+            Assert.AreEqual(1, dir.List().Count);
+            Assert.AreEqual(file3, dir.List()["sub3"].Path.ToString());
+            Assert.IsInstanceOf<VolumeFile>(dir.List()["sub3"]);
+        }
+
+
+        [Test]
+        [ExpectedException(typeof(KOSPersistenceException))]
+        public void CanFailWhenCreatingFileOverDirectory()
+        {
+            string parent1 = "/parent1";
+            string file1 = parent1 + "/sub1";
+
+            TestVolume.CreateDirectory(VolumePath.FromString(file1));
+            TestVolume.CreateFile(VolumePath.FromString(file1));
+        }
+
+        [Test]
+        [ExpectedException(typeof(KOSInvalidPathException))]
+        public void CanFailWhenCreatingFileWithNegativeDepth()
+        {
+            string dir = "/../test";
+
+            TestVolume.CreateFile(VolumePath.FromString(dir));
+        }
+
+        [Test]
+        public void CanReadAndWriteFiles()
+        {
+            string dir = "/content_parent/content_test";
+            string content = "some test content!@#$;\n\rtaenstałąż";
+            int contentLength = Encoding.UTF8.GetBytes(content).Length;
+
+            VolumeFile volumeFile = TestVolume.CreateFile(VolumePath.FromString(dir));
+
+            Assert.AreEqual(0, volumeFile.ReadAll().Bytes.Length);
+            Assert.AreEqual("", volumeFile.ReadAll().String);
+
+            Assert.IsTrue(volumeFile.Write(content));
+            Assert.AreEqual(FileCategory.ASCII, volumeFile.ReadAll().Category);
+
+            Assert.AreEqual(contentLength, TestVolume.Size);
+
+            if (ExpectedCapacity != Volume.INFINITE_CAPACITY)
+            {
+                Assert.AreEqual(ExpectedCapacity - contentLength, TestVolume.FreeSpace);
+            } else
+            {
+                Assert.AreEqual(Volume.INFINITE_CAPACITY, TestVolume.FreeSpace);
+            }
+
+            Assert.AreEqual(contentLength, volumeFile.Size);
+            Assert.AreEqual(content, volumeFile.ReadAll().String);
+        }
+
+        [Test]
+        public void CanDeleteFiles()
+        {
+            string parent1 = "/parent1";
+            string file1 = parent1 + "/sub1", file2 = parent1 + "/sub2";
+
+            TestVolume.CreateFile(VolumePath.FromString(file1));
+            TestVolume.CreateFile(VolumePath.FromString(file2));
+
+            TestVolume.Delete(VolumePath.FromString(file1));
+
+            VolumeDirectory dir = TestVolume.Open(VolumePath.FromString(parent1)) as VolumeDirectory;
+            Assert.AreEqual(1, dir.List().Count);
+            Assert.AreEqual(file2, dir.List()["sub2"].Path.ToString());
+            Assert.IsInstanceOf<VolumeFile>(dir.List()["sub2"]);
+        }
+
+        [Test]
+        public void CanDeleteNonExistingFiles()
+        {
+            VolumePath path = VolumePath.FromString("/abc");
+            TestVolume.CreateFile(path);
+
+            // Delete the file twice
+            TestVolume.Delete(path);
+            TestVolume.Delete(path);
+        }
+
+    }
+}
+

--- a/src/kOS.Safe.Test/Persistence/VolumeTest.cs
+++ b/src/kOS.Safe.Test/Persistence/VolumeTest.cs
@@ -143,6 +143,14 @@ namespace kOS.Safe.Test
         }
 
         [Test]
+        [ExpectedException(typeof(KOSPersistenceException))]
+        public void CanFailWhenTryingToDeleteRootDirectory()
+        {
+            VolumePath path = VolumePath.FromString("/");
+            TestVolume.Delete(path);
+        }
+
+        [Test]
         public void CanCreateFiles()
         {
             string parent1 = "/parent1", parent2 = "/parent2";

--- a/src/kOS.Safe.Test/Persistence/VolumeTest.cs
+++ b/src/kOS.Safe.Test/Persistence/VolumeTest.cs
@@ -296,10 +296,9 @@ namespace kOS.Safe.Test
             TestVolume.CreateFile(path);
 
             // Delete the file twice
-            TestVolume.Delete(path);
-            TestVolume.Delete(path);
+            Assert.IsTrue(TestVolume.Delete(path));
+            Assert.IsFalse(TestVolume.Delete(path));
         }
 
     }
 }
-

--- a/src/kOS.Safe.Test/Persistence/VolumeTest.cs
+++ b/src/kOS.Safe.Test/Persistence/VolumeTest.cs
@@ -20,7 +20,6 @@ namespace kOS.Safe.Test
             SafeHouse.Logger = new TestLogger();
         }
 
-
         [Test]
         public void CanReturnCapacity()
         {
@@ -295,6 +294,21 @@ namespace kOS.Safe.Test
             Assert.AreEqual(1, dir.List().Count);
             Assert.AreEqual(file2, dir.List()["sub2"].Path.ToString());
             Assert.IsInstanceOf<VolumeFile>(dir.List()["sub2"]);
+
+            TestVolume.CreateFile(VolumePath.FromString(file2 + ".ks"));
+            Assert.IsTrue(TestVolume.Delete(VolumePath.FromString(file2 + ".ks")));
+            Assert.AreEqual(1, dir.List().Count);
+            Assert.AreEqual(file2, dir.List()["sub2"].Path.ToString());
+            Assert.IsInstanceOf<VolumeFile>(dir.List()["sub2"]);
+
+            TestVolume.CreateFile(VolumePath.FromString(file2 + ".ks"));
+            Assert.IsTrue(TestVolume.Delete(VolumePath.FromString(file2)));
+            Assert.AreEqual(1, dir.List().Count);
+            Assert.AreEqual(file2 + ".ks", dir.List()["sub2.ks"].Path.ToString());
+            Assert.IsInstanceOf<VolumeFile>(dir.List()["sub2.ks"]);
+
+            Assert.IsTrue(TestVolume.Delete(VolumePath.FromString(file2)));
+            Assert.AreEqual(0, dir.List().Count);
         }
 
         [Test]

--- a/src/kOS.Safe.Test/Persistence/VolumeTest.cs
+++ b/src/kOS.Safe.Test/Persistence/VolumeTest.cs
@@ -87,6 +87,13 @@ namespace kOS.Safe.Test
 
         [Test]
         [ExpectedException(typeof(KOSPersistenceException))]
+        public void CanFailWhenCreatingDirectoryOverRootDirectory()
+        {
+            TestVolume.CreateDirectory(VolumePath.FromString("/"));
+        }
+
+        [Test]
+        [ExpectedException(typeof(KOSPersistenceException))]
         public void CanFailWhenCreatingDirectoryOverFile()
         {
             string parent1 = "/parent1";
@@ -139,7 +146,7 @@ namespace kOS.Safe.Test
         public void CanCreateFiles()
         {
             string parent1 = "/parent1", parent2 = "/parent2";
-            string file1 = parent1 + "/sub1", file2 = parent1 + "/sub2", file3 = parent2 + "/sub3";
+            string file1 = parent1 + "/sub1/file", file2 = parent1 + "/sub2", file3 = parent2 + "/sub3";
 
             TestVolume.CreateFile(VolumePath.FromString(file1));
             TestVolume.CreateFile(VolumePath.FromString(file2));
@@ -151,10 +158,15 @@ namespace kOS.Safe.Test
 
             VolumeDirectory dir = TestVolume.Open(VolumePath.FromString(parent1)) as VolumeDirectory;
             Assert.AreEqual(2, dir.List().Count);
-            Assert.AreEqual(file1, dir.List()["sub1"].Path.ToString());
-            Assert.IsInstanceOf<VolumeFile>(dir.List()["sub1"]);
+            Assert.AreEqual("/parent1/sub1", dir.List()["sub1"].Path.ToString());
+            Assert.IsInstanceOf<VolumeDirectory>(dir.List()["sub1"]);
             Assert.AreEqual(file2, dir.List()["sub2"].Path.ToString());
             Assert.IsInstanceOf<VolumeFile>(dir.List()["sub2"]);
+
+            dir = TestVolume.Open(VolumePath.FromString("/parent1/sub1")) as VolumeDirectory;
+            Assert.AreEqual(1, dir.List().Count);
+            Assert.AreEqual("/parent1/sub1/file", dir.List()["file"].Path.ToString());
+            Assert.IsInstanceOf<VolumeFile>(dir.List()["file"]);
 
             dir = TestVolume.Open(VolumePath.FromString(parent2)) as VolumeDirectory;
             Assert.AreEqual(1, dir.List().Count);
@@ -175,6 +187,17 @@ namespace kOS.Safe.Test
 
         [Test]
         [ExpectedException(typeof(KOSPersistenceException))]
+        public void CanFailWhenCreatingFileInASubdirectoryThatIsAFile()
+        {
+            string parent = "/parent1";
+            string file = parent + "/file";
+
+            TestVolume.CreateFile(VolumePath.FromString(parent));
+            TestVolume.CreateFile(VolumePath.FromString(file));
+        }
+
+        [Test]
+        [ExpectedException(typeof(KOSPersistenceException))]
         public void CanFailWhenCreatingFileOverDirectory()
         {
             string parent1 = "/parent1";
@@ -182,6 +205,13 @@ namespace kOS.Safe.Test
 
             TestVolume.CreateDirectory(VolumePath.FromString(file1));
             TestVolume.CreateFile(VolumePath.FromString(file1));
+        }
+
+        [Test]
+        [ExpectedException(typeof(KOSPersistenceException))]
+        public void CanFailWhenCreatingFileOverRootDirectory()
+        {
+            TestVolume.CreateFile(VolumePath.FromString("/"));
         }
 
         [Test]
@@ -222,7 +252,7 @@ namespace kOS.Safe.Test
             Assert.AreEqual(content, volumeFile.ReadAll().String);
 
             // we should be able to save the same file again
-            Assert.IsTrue(TestVolume.Save(volumeFile) != null);
+            Assert.IsTrue(TestVolume.SaveFile(volumeFile) != null);
         }
 
         [Test]
@@ -233,7 +263,7 @@ namespace kOS.Safe.Test
             string file1 = parent1 + "/sub1";
 
             TestVolume.CreateDirectory(VolumePath.FromString(file1));
-            TestVolume.Save(VolumePath.FromString(file1), new FileContent());
+            TestVolume.SaveFile(VolumePath.FromString(file1), new FileContent());
         }
 
         [Test]

--- a/src/kOS.Safe.Test/Serialization/FormatterTest.cs
+++ b/src/kOS.Safe.Test/Serialization/FormatterTest.cs
@@ -98,12 +98,12 @@ namespace kOS.Safe.Test.Serialization
 
         private string Serialize(IDumper o)
         {
-            return new SafeSerializationMgr().Serialize(o, FormatWriter);
+            return new SafeSerializationMgr(null).Serialize(o, FormatWriter);
         }
 
         private IDumper Deserialize(string s)
         {
-            return new SafeSerializationMgr().Deserialize(s, FormatReader);
+            return new SafeSerializationMgr(null).Deserialize(s, FormatReader);
         }
     }
 }

--- a/src/kOS.Safe.Test/Serialization/JSONFormatterTest.cs
+++ b/src/kOS.Safe.Test/Serialization/JSONFormatterTest.cs
@@ -23,6 +23,5 @@ namespace kOS.Safe.Test.Serialization
                 return JsonFormatter.WriterInstance;
             }
         }
-
     }
 }

--- a/src/kOS.Safe.Test/Serialization/TerminalFormatterTest.cs
+++ b/src/kOS.Safe.Test/Serialization/TerminalFormatterTest.cs
@@ -36,7 +36,7 @@ namespace kOS.Safe.Test.Serialization
 
         private string Serialize(SerializableStructure o)
         {
-            return new SafeSerializationMgr().Serialize(o, TerminalFormatter.Instance, false);
+            return new SafeSerializationMgr(null).Serialize(o, TerminalFormatter.Instance, false);
         }
     }
 }

--- a/src/kOS.Safe.Test/kOS.Safe.Test.csproj
+++ b/src/kOS.Safe.Test/kOS.Safe.Test.csproj
@@ -75,6 +75,9 @@
     <Compile Include="Communication\FakeCurrentTimeProvider.cs" />
     <Compile Include="Persistence\VolumePathTest.cs" />
     <Compile Include="Persistence\GlobalPathTest.cs" />
+    <Compile Include="Persistence\ArchiveTest.cs" />
+    <Compile Include="Persistence\HarddiskTest.cs" />
+    <Compile Include="Persistence\VolumeTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\kOS.Safe\kOS.Safe.csproj">

--- a/src/kOS.Safe.Test/kOS.Safe.Test.csproj
+++ b/src/kOS.Safe.Test/kOS.Safe.Test.csproj
@@ -73,6 +73,8 @@
     <Compile Include="Serialization\FormatterTest.cs" />
     <Compile Include="Communication\MessageQueueTest.cs" />
     <Compile Include="Communication\FakeCurrentTimeProvider.cs" />
+    <Compile Include="Persistence\VolumePathTest.cs" />
+    <Compile Include="Persistence\GlobalPathTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\kOS.Safe\kOS.Safe.csproj">
@@ -94,6 +96,7 @@
   <ItemGroup>
     <Folder Include="Serialization\" />
     <Folder Include="Communication\" />
+    <Folder Include="Persistence\" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="ProfilingSessions\Session20160127_233127.sdps" />

--- a/src/kOS.Safe.Test/kOS.Safe.Test.csproj
+++ b/src/kOS.Safe.Test/kOS.Safe.Test.csproj
@@ -78,6 +78,11 @@
     <Compile Include="Persistence\ArchiveTest.cs" />
     <Compile Include="Persistence\HarddiskTest.cs" />
     <Compile Include="Persistence\VolumeTest.cs" />
+    <Compile Include="Persistence\CopyAndMoveTest.cs" />
+    <Compile Include="Persistence\HarddiskToArchiveCopyAndMoveTest.cs" />
+    <Compile Include="Persistence\HarddiskToHarddiskCopyAndMoveTest.cs" />
+    <Compile Include="Persistence\ArchiveAndHarddiskCopyAndMoveTest.cs" />
+    <Compile Include="Persistence\ArchiveToHarddiskCopyAndMoveTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\kOS.Safe\kOS.Safe.csproj">

--- a/src/kOS.Safe/Compilation/CodePart.cs
+++ b/src/kOS.Safe/Compilation/CodePart.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
 using System;
+using kOS.Safe.Persistence;
 
 namespace kOS.Safe.Compilation
 {
     public class CodePart
     {
-        public CodePart(string fromFile = "")
+        public CodePart()
         {
             FunctionsCode = new List<Opcode>(); 
             InitializationCode = new List<Opcode>();
@@ -25,18 +26,18 @@ namespace kOS.Safe.Compilation
             return mergedCode;
         }
 
-        public void AssignSourceName(string sourceName)
+        public void AssignSourceName(GlobalPath filePath)
         {
-            AssignSourceNameToSection(sourceName.ToLower(), FunctionsCode);
-            AssignSourceNameToSection(sourceName.ToLower(), InitializationCode);
-            AssignSourceNameToSection(sourceName.ToLower(), MainCode);
+            AssignSourcePathToSection(filePath, FunctionsCode);
+            AssignSourcePathToSection(filePath, InitializationCode);
+            AssignSourcePathToSection(filePath, MainCode);
         }
 
-        private void AssignSourceNameToSection(string sourceName, IEnumerable<Opcode> section)
+        private void AssignSourcePathToSection(GlobalPath filePath, IEnumerable<Opcode> section)
         {
             foreach (Opcode opcode in section)
             {
-                opcode.SourceName = string.Intern(sourceName.ToLower()); // Intern ensures we don't waste space storing the filename again and again per opcode.
+                opcode.SourcePath = filePath;
             }
         }
 

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -2954,7 +2954,7 @@ namespace kOS.Safe.Compilation.KS
             }
             AddOpcode(new OpcodeCall("load()"));
             AddOpcode(new OpcodePop()); // all functions now return a value even if it's a dummy we ignore.
-       }
+        }
 
         private void VisitSwitchStatement(ParseNode node)
         {
@@ -2974,7 +2974,7 @@ namespace kOS.Safe.Compilation.KS
             AddOpcode(new OpcodePush(node.Nodes[2].Token.Type == TokenType.FROM ? "from" : "to"));
 
             VisitNode(node.Nodes[3]);
-            AddOpcode(new OpcodeCall("copy()"));
+            AddOpcode(new OpcodeCall("copy_deprecated()"));
             AddOpcode(new OpcodePop()); // all functions now return a value even if it's a dummy we ignore.
         }
 
@@ -2984,21 +2984,32 @@ namespace kOS.Safe.Compilation.KS
             int oldNameIndex = 2;
             int newNameIndex = 4;
 
+            bool renameFile = false;
+
             AddOpcode(new OpcodePush(new KOSArgMarkerType()));
             if (node.Nodes.Count == 5)
             {
                 oldNameIndex--;
                 newNameIndex--;
                 AddOpcode(new OpcodePush("file"));
+                renameFile = true;
             }
             else
             {
-                AddOpcode(new OpcodePush(node.Nodes[1].Token.Type == TokenType.FILE ? "file" : "volume"));
+                renameFile = node.Nodes[1].Token.Type == TokenType.FILE;
+                AddOpcode(new OpcodePush(renameFile ? "file" : "volume"));
             }
 
             VisitNode(node.Nodes[oldNameIndex]);
             VisitNode(node.Nodes[newNameIndex]);
-            AddOpcode(new OpcodeCall("rename()"));
+
+            if (renameFile)
+            {
+                AddOpcode(new OpcodeCall("rename_file_deprecated()"));
+            } else
+            {
+                AddOpcode(new OpcodeCall("rename_volume_deprecated()"));
+            }
             AddOpcode(new OpcodePop()); // all functions now return a value even if it's a dummy we ignore.
         }
 
@@ -3013,7 +3024,7 @@ namespace kOS.Safe.Compilation.KS
             else
                 AddOpcode(new OpcodePush(null));
 
-            AddOpcode(new OpcodeCall("delete()"));
+            AddOpcode(new OpcodeCall("delete_deprecated()"));
             AddOpcode(new OpcodePop()); // all functions now return a value even if it's a dummy we ignore.
         }
 

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -3022,7 +3022,7 @@ namespace kOS.Safe.Compilation.KS
             if (node.Nodes.Count == 5)
                 VisitNode(node.Nodes[3]);
 
-            AddOpcode(new OpcodeCall("delete()"));
+            AddOpcode(new OpcodeCall("delete_deprecated()"));
             AddOpcode(new OpcodePop()); // all functions now return a value even if it's a dummy we ignore.
         }
 

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -3021,10 +3021,8 @@ namespace kOS.Safe.Compilation.KS
 
             if (node.Nodes.Count == 5)
                 VisitNode(node.Nodes[3]);
-            else
-                AddOpcode(new OpcodePush(null));
 
-            AddOpcode(new OpcodeCall("delete_deprecated()"));
+            AddOpcode(new OpcodeCall("delete()"));
             AddOpcode(new OpcodePop()); // all functions now return a value even if it's a dummy we ignore.
         }
 

--- a/src/kOS.Safe/Compilation/KS/Context.cs
+++ b/src/kOS.Safe/Compilation/KS/Context.cs
@@ -1,4 +1,5 @@
 using System;
+using kOS.Safe.Persistence;
 
 namespace kOS.Safe.Compilation.KS
 {
@@ -9,7 +10,7 @@ namespace kOS.Safe.Compilation.KS
         public SubprogramCollection Subprograms { get; private set; }
         public int NumCompilesSoFar {get; set;}
         public int LabelIndex { get; set; }
-        public string LastSourceName { get; set; }
+        public GlobalPath LastSourcePath { get; set; }
         
         // This has to live inside context because of the fact that more than one program
         // can be compiled into the same memory space.  If it was reset to zero by the
@@ -24,7 +25,7 @@ namespace kOS.Safe.Compilation.KS
             Triggers = new TriggerCollection();
             Subprograms = new SubprogramCollection();
             LabelIndex = 0;
-            LastSourceName = "";
+            LastSourcePath = GlobalPath.EMPTY;
             MaxScopeIdSoFar = 0;
             NumCompilesSoFar = 0;
         }

--- a/src/kOS.Safe/Compilation/KS/KSScript.cs
+++ b/src/kOS.Safe/Compilation/KS/KSScript.cs
@@ -1,5 +1,6 @@
 using kOS.Safe.Exceptions;
 using System.Collections.Generic;
+using kOS.Safe.Persistence;
 
 namespace kOS.Safe.Compilation.KS
 {
@@ -17,7 +18,7 @@ namespace kOS.Safe.Compilation.KS
             contexts = new Dictionary<string, Context>();
         }
 
-        public override List<CodePart> Compile(string filePath, int startLineNum, string scriptText, string contextId, CompilerOptions options)
+        public override List<CodePart> Compile(GlobalPath filePath, int startLineNum, string scriptText, string contextId, CompilerOptions options)
         {
             var parts = new List<CodePart>();
             ParseTree parseTree = parser.Parse(scriptText);
@@ -84,12 +85,12 @@ namespace kOS.Safe.Compilation.KS
             }
         }
 
-        private void AssignSourceId(IEnumerable<CodePart> parts, string fileName)
+        private void AssignSourceId(IEnumerable<CodePart> parts, GlobalPath filePath)
         {
-            currentContext.LastSourceName = fileName;
+            currentContext.LastSourcePath = filePath;
             foreach (CodePart part in parts)
             {
-                part.AssignSourceName(currentContext.LastSourceName);
+                part.AssignSourceName(currentContext.LastSourcePath);
             }
         }
 

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -7,6 +7,7 @@ using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Execution;
 using kOS.Safe.Exceptions;
 using kOS.Safe.Utilities;
+using kOS.Safe.Persistence;
 
 namespace kOS.Safe.Compilation
 {
@@ -231,7 +232,7 @@ namespace kOS.Safe.Compilation
 
         public string Label {get{return label;} set {label = value;} }
         public virtual string DestinationLabel {get;set;}
-        public string SourceName;
+        public GlobalPath SourcePath;
 
         public short SourceLine { get; set; } // line number in the source code that this was compiled from.
         public short SourceColumn { get; set; }  // column number of the token nearest the cause of this Opcode.

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -652,7 +652,7 @@ namespace kOS.Safe.Compilation
             }
             else
             {
-                throw new KOSDeprecationException("0.17","UNSET ALL", "<not supported anymore now that we have nested scoping>", "");
+                throw new KOSDeprecationException("0.17","UNSET ALL", "<not supported anymore now that we have nested scoping>");
             }
         }
     }

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -652,7 +652,7 @@ namespace kOS.Safe.Compilation
             }
             else
             {
-                throw new KOSDeprecationException("0.17","UNSET ALL", "<not supported anymore now that we have nested scoping>");
+                throw new KOSDeprecationException("0.17","UNSET ALL", "<not supported anymore now that we have nested scoping>", "");
             }
         }
     }

--- a/src/kOS.Safe/Compilation/ProgramBuilder.cs
+++ b/src/kOS.Safe/Compilation/ProgramBuilder.cs
@@ -163,7 +163,7 @@ namespace kOS.Safe.Compilation
                     }
                     else
                         newOp = new OpcodePush(destinationIndex);
-                    newOp.SourceName = opcode.SourceName;
+                    newOp.SourcePath = opcode.SourcePath;
                     newOp.SourceLine = opcode.SourceLine;
                     newOp.SourceColumn = opcode.SourceColumn;
                     newOp.Label = opcode.Label;

--- a/src/kOS.Safe/Compilation/Script.cs
+++ b/src/kOS.Safe/Compilation/Script.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using kOS.Safe.Persistence;
 
 namespace kOS.Safe.Compilation
 {
@@ -23,7 +24,7 @@ namespace kOS.Safe.Compilation
         /// corresponds to line (what) of the more global something, for reporting numbers on errors.</param>
         /// <param name="scriptText">The text to be compiled.</param>
         /// <returns>The CodeParts made from the scriptText</returns>
-        public virtual List<CodePart> Compile(string filePath, int startLineNum, string scriptText)
+        public virtual List<CodePart> Compile(GlobalPath filePath, int startLineNum, string scriptText)
         {
             return Compile(filePath, startLineNum, scriptText, string.Empty);
         }
@@ -41,7 +42,7 @@ namespace kOS.Safe.Compilation
         /// <param name="scriptText">The text to be compiled.</param>
         /// <param name="contextId">The name of the runtime context (i.e. "interpreter").</param>
         /// <returns>The CodeParts made from the scriptText</returns>
-        public virtual List<CodePart> Compile(string filePath, int startLineNum, string scriptText, string contextId)
+        public virtual List<CodePart> Compile(GlobalPath filePath, int startLineNum, string scriptText, string contextId)
         {
             return Compile(filePath, startLineNum, scriptText, contextId, new CompilerOptions());
         }
@@ -60,7 +61,7 @@ namespace kOS.Safe.Compilation
         /// <param name="contextId">The name of the runtime context (i.e. "interpreter").</param>
         /// <param name="options">settings for the compile</param>
         /// <returns>The CodeParts made from the scriptText</returns>
-        public abstract List<CodePart> Compile(string filePath, int startLineNum, string scriptText, string contextId, CompilerOptions options);
+        public abstract List<CodePart> Compile(GlobalPath filePath, int startLineNum, string scriptText, string contextId, CompilerOptions options);
 
         public abstract void ClearContext(string contextId);
 

--- a/src/kOS.Safe/Encapsulation/EnumerableValue.cs
+++ b/src/kOS.Safe/Encapsulation/EnumerableValue.cs
@@ -44,7 +44,7 @@ namespace kOS.Safe.Encapsulation
 
         public override string ToString()
         {
-            return new SafeSerializationMgr().ToString(this);
+            return new SafeSerializationMgr(null).ToString(this);
         }
 
         public override Dump Dump()

--- a/src/kOS.Safe/Encapsulation/Lexicon.cs
+++ b/src/kOS.Safe/Encapsulation/Lexicon.cs
@@ -266,7 +266,7 @@ namespace kOS.Safe.Encapsulation
 
         public override string ToString()
         {
-            return new SafeSerializationMgr().ToString(this);
+            return new SafeSerializationMgr(null).ToString(this);
         }
 
         public override Dump Dump()

--- a/src/kOS.Safe/Encapsulation/TerminalStruct.cs
+++ b/src/kOS.Safe/Encapsulation/TerminalStruct.cs
@@ -5,7 +5,7 @@ namespace kOS.Safe.Encapsulation
     [kOS.Safe.Utilities.KOSNomenclature("Terminal")]
     public class TerminalStruct : Structure
     {
-        private readonly SharedObjects shared;
+        private readonly SafeSharedObjects shared;
 
         // Some sanity values to prevent the terminal display from getting garbled up:
         // They may have to change after experimentation.
@@ -23,14 +23,14 @@ namespace kOS.Safe.Encapsulation
         //
         // protected bool IsOpen { get { return shared.Window.IsOpen(); } set {if (value) shared.Window.Open(); else shared.Window.Close(); } }
 
-        public TerminalStruct(SharedObjects shared)
+        public TerminalStruct(SafeSharedObjects shared)
         {
             this.shared = shared;
 
             InitializeSuffixes();
         }
 
-        protected internal SharedObjects Shared
+        protected internal SafeSharedObjects Shared
         {
             get { return shared; }
         }

--- a/src/kOS.Safe/Exceptions/KOSAtmosphereDeprecationException.cs
+++ b/src/kOS.Safe/Exceptions/KOSAtmosphereDeprecationException.cs
@@ -2,7 +2,7 @@ namespace kOS.Safe.Exceptions
 {
     public class KOSAtmosphereDeprecationException : KOSDeprecationException
     {
-        public KOSAtmosphereDeprecationException(string version, string oldUsage, string newUsage) : base(version, oldUsage, newUsage)
+        public KOSAtmosphereDeprecationException(string version, string oldUsage, string newUsage, string url) : base(version, oldUsage, newUsage, url)
         {
         }
 

--- a/src/kOS.Safe/Exceptions/KOSAtmosphereDeprecationException.cs
+++ b/src/kOS.Safe/Exceptions/KOSAtmosphereDeprecationException.cs
@@ -2,7 +2,7 @@ namespace kOS.Safe.Exceptions
 {
     public class KOSAtmosphereDeprecationException : KOSDeprecationException
     {
-        public KOSAtmosphereDeprecationException(string version, string oldUsage, string newUsage, string url) : base(version, oldUsage, newUsage, url)
+        public KOSAtmosphereDeprecationException(string version, string oldUsage, string newUsage) : base(version, oldUsage, newUsage)
         {
         }
 

--- a/src/kOS.Safe/Exceptions/KOSDeprecationException.cs
+++ b/src/kOS.Safe/Exceptions/KOSDeprecationException.cs
@@ -6,7 +6,7 @@ namespace kOS.Safe.Exceptions
     {
         protected static string TerseMessageFmt = "As of kOS {0}, {1} is obsolete and has been replaced with {2}";
 
-        public KOSDeprecationException(string version, string oldUsage,string newUsage) :
+        public KOSDeprecationException(string version, string oldUsage,string newUsage, string url) :
             base( String.Format(TerseMessageFmt, version, oldUsage, newUsage) )
         {
         }

--- a/src/kOS.Safe/Exceptions/KOSDeprecationException.cs
+++ b/src/kOS.Safe/Exceptions/KOSDeprecationException.cs
@@ -6,7 +6,7 @@ namespace kOS.Safe.Exceptions
     {
         protected static string TerseMessageFmt = "As of kOS {0}, {1} is obsolete and has been replaced with {2}";
 
-        public KOSDeprecationException(string version, string oldUsage,string newUsage, string url) :
+        public KOSDeprecationException(string version, string oldUsage,string newUsage) :
             base( String.Format(TerseMessageFmt, version, oldUsage, newUsage) )
         {
         }

--- a/src/kOS.Safe/Exceptions/KOSInvalidPathException.cs
+++ b/src/kOS.Safe/Exceptions/KOSInvalidPathException.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using kOS.Safe.Exceptions;
+
+namespace kOS.Safe
+{
+    public class KOSInvalidPathException : KOSException
+    {
+        private string pathString;
+
+        public KOSInvalidPathException(string message, string pathString) : base(message + " (" + pathString + ")")
+        {
+            this.pathString = pathString;
+        }
+
+        public new string VerboseMessage
+        {
+            get { return base.Message + ": '" + pathString + "'. This error occurred while trying to access a kOS Volume"; }
+        }
+    }
+}
+

--- a/src/kOS.Safe/Exceptions/KOSPatchesDeprecationException.cs
+++ b/src/kOS.Safe/Exceptions/KOSPatchesDeprecationException.cs
@@ -8,7 +8,7 @@
         protected static string Url { get{return "TODO for v0.15 - Go back and fill in after docs are updated";}}
         
         public KOSPatchesDeprecationException() : 
-            base(Version, OldUsage, NewUsage, Url)
+            base(Version, OldUsage, NewUsage)
         {
         }
 

--- a/src/kOS.Safe/Exceptions/KOSPatchesDeprecationException.cs
+++ b/src/kOS.Safe/Exceptions/KOSPatchesDeprecationException.cs
@@ -8,7 +8,7 @@
         protected static string Url { get{return "TODO for v0.15 - Go back and fill in after docs are updated";}}
         
         public KOSPatchesDeprecationException() : 
-            base(Version, OldUsage, NewUsage)
+            base(Version, OldUsage, NewUsage, Url)
         {
         }
 

--- a/src/kOS.Safe/Exceptions/KOSPersistenceException.cs
+++ b/src/kOS.Safe/Exceptions/KOSPersistenceException.cs
@@ -4,7 +4,11 @@ namespace kOS.Safe.Exceptions
 {
     public class KOSPersistenceException : Exception
     {
-        public KOSPersistenceException(string message):base(message)
+        public KOSPersistenceException(string message) : base(message)
+        {
+        }
+
+        public KOSPersistenceException(string message, Exception cause) : base(message, cause)
         {
         }
 

--- a/src/kOS.Safe/Execution/CPU.cs
+++ b/src/kOS.Safe/Execution/CPU.cs
@@ -25,7 +25,8 @@ namespace kOS.Safe.Execution
         private readonly VariableScope globalVariables;
         private Status currentStatus;
         private double currentTime;
-        private readonly SharedObjects shared;
+        private double timeWaitUntil;
+        private readonly SafeSharedObjects shared;
         private readonly List<ProgramContext> contexts;
         private ProgramContext currentContext;
         private VariableScope savedPointers;
@@ -64,7 +65,7 @@ namespace kOS.Safe.Execution
         
         public List<string> ProfileResult { get; private set; }
 
-        public CPU(SharedObjects shared)
+        public CPU(SafeSharedObjects shared)
         {
             this.shared = shared;
             this.shared.Cpu = this;

--- a/src/kOS.Safe/Execution/InternalPath.cs
+++ b/src/kOS.Safe/Execution/InternalPath.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using kOS.Safe.Persistence;
+
+namespace kOS.Safe.Execution
+{
+    public abstract class InternalPath : GlobalPath
+    {
+        public InternalPath() : base("kOS")
+        {
+
+        }
+
+        public abstract string Line(int line);
+    }
+}

--- a/src/kOS.Safe/Execution/ProgramContext.cs
+++ b/src/kOS.Safe/Execution/ProgramContext.cs
@@ -221,7 +221,7 @@ namespace kOS.Safe.Execution
                 {
                     string thisLine = string.Format(
                         formatStr,
-                        Program[index].SourceName,
+                        Program[index].SourcePath,
                         Program[index].SourceLine,
                         Program[index].SourceColumn,
                         index,

--- a/src/kOS.Safe/Module/IProcessor.cs
+++ b/src/kOS.Safe/Module/IProcessor.cs
@@ -9,7 +9,7 @@ namespace kOS.Safe.Module
         /// <summary>
         /// Gets or sets the boot file path. Has to be a valid path or null.
         /// </summary>
-        VolumePath BootFilePath { get; set; }
+        GlobalPath BootFilePath { get; }
 
         bool CheckCanBoot();
         string Tag { get; }

--- a/src/kOS.Safe/Module/IProcessor.cs
+++ b/src/kOS.Safe/Module/IProcessor.cs
@@ -1,9 +1,15 @@
+using kOS.Safe.Persistence;
+
 namespace kOS.Safe.Module
 {
     public interface IProcessor
     {
         void SetMode(ProcessorModes newProcessorMode);
-        string BootFilename { get; set; }
+
+        /// <summary>
+        /// Gets or sets the boot file path. Has to be a valid path or null.
+        /// </summary>
+        VolumePath BootFilePath { get; set; }
 
         bool CheckCanBoot();
         string Tag { get; }

--- a/src/kOS.Safe/Persistence/Archive.cs
+++ b/src/kOS.Safe/Persistence/Archive.cs
@@ -61,7 +61,7 @@ namespace kOS.Safe.Persistence
                 var fileSystemInfo = Search(path, ksmDefault);
 
                 if (fileSystemInfo == null) {
-                    return null;
+                    throw new KOSPersistenceException("Could not open path: " + path);;
                 } else if (fileSystemInfo is FileInfo)
                 {
                     VolumePath filePath = VolumePath.FromString(fileSystemInfo.FullName.Substring(ArchiveFolder.Length));
@@ -81,12 +81,17 @@ namespace kOS.Safe.Persistence
         {
             string archivePath = GetArchivePath(path);
 
+            if (Directory.Exists(archivePath))
+            {
+                throw new KOSPersistenceException("Already exists: " + path);
+            }
+
             try
             {
                 Directory.CreateDirectory(archivePath);
             } catch (IOException)
             {
-                throw new KOSPersistenceException("Already exists: " + path);
+                throw new KOSPersistenceException("Could not create directory: " + path);
             }
 
             return new ArchiveDirectory(this, path);
@@ -95,6 +100,11 @@ namespace kOS.Safe.Persistence
         public override VolumeFile CreateFile(VolumePath path)
         {
             string archivePath = GetArchivePath(path);
+
+            if (File.Exists(archivePath))
+            {
+                throw new KOSPersistenceException("Already exists: " + path);
+            }
 
             Directory.CreateDirectory(GetArchivePath(path.GetParent()));
 

--- a/src/kOS.Safe/Persistence/Archive.cs
+++ b/src/kOS.Safe/Persistence/Archive.cs
@@ -159,7 +159,7 @@ namespace kOS.Safe.Persistence
             return true;
         }
 
-        public override VolumeFile SaveFile(VolumePath path, FileContent content)
+        public override VolumeFile SaveFile(VolumePath path, FileContent content, bool verifyFreeSpace = true)
         {
             Directory.CreateDirectory(ArchiveFolder);
 

--- a/src/kOS.Safe/Persistence/Archive.cs
+++ b/src/kOS.Safe/Persistence/Archive.cs
@@ -60,6 +60,8 @@ namespace kOS.Safe.Persistence
             {
                 Directory.Delete(ArchiveFolder, true);
             }
+
+            Directory.CreateDirectory(ArchiveFolder);
         }
 
         public override VolumeItem Open(VolumePath path, bool ksmDefault = false)
@@ -143,6 +145,11 @@ namespace kOS.Safe.Persistence
 
         public override bool Delete(VolumePath path, bool ksmDefault = false)
         {
+            if (path.Depth == 0)
+            {
+                throw new KOSPersistenceException("Can't delete root directory");
+            }
+
             var fileSystemInfo = Search(path, ksmDefault);
 
             if (fileSystemInfo == null)

--- a/src/kOS.Safe/Persistence/Archive.cs
+++ b/src/kOS.Safe/Persistence/Archive.cs
@@ -145,9 +145,16 @@ namespace kOS.Safe.Persistence
         {
             Directory.CreateDirectory(ArchiveFolder);
 
+            string archivePath = GetArchivePath(path);
+            FileAttributes attr = File.GetAttributes(archivePath);
+            if ((attr & FileAttributes.Directory) == FileAttributes.Directory)
+            {
+                throw new KOSPersistenceException("Can't save file over a directory: " + path);
+            }
+
             byte[] fileBody = ConvertToWindowsNewlines(content.Bytes);
 
-            using (var outfile = new BinaryWriter(File.Open(GetArchivePath(path), FileMode.Create)))
+            using (var outfile = new BinaryWriter(File.Open(archivePath, FileMode.Create)))
             {
                 outfile.Write(fileBody);
             }

--- a/src/kOS.Safe/Persistence/Archive.cs
+++ b/src/kOS.Safe/Persistence/Archive.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using kOS.Safe.Exceptions;
 
 namespace kOS.Safe.Persistence
 {
@@ -11,138 +12,137 @@ namespace kOS.Safe.Persistence
     public class Archive : Volume
     {
         public const string ArchiveName = "Archive";
+        public ArchiveDirectory RootArchiveDirectory { get; private set; }
 
-        private static string ArchiveFolder
-        {
-            get { return SafeHouse.ArchiveFolder; }
+        private static string ArchiveFolder { get; set; }
+
+        public override VolumeDirectory Root {
+            get {
+                return RootArchiveDirectory;
+            }
         }
 
-        public Archive()
+        public Archive(string archiveFolder)
+        {
+            ArchiveFolder = archiveFolder;
+            CreateArchiveDirectory();
+            Renameable = false;
+            InitializeName(ArchiveName);
+
+            RootArchiveDirectory = new ArchiveDirectory(this, VolumePath.EMPTY);
+        }
+
+        private void CreateArchiveDirectory()
         {
             Directory.CreateDirectory(ArchiveFolder);
-            Renameable = false;
-            Name = ArchiveName;
         }
 
-        public override float RequiredPower()
+        public string GetArchivePath(VolumePath path)
         {
-            const int MULTIPLIER = 5;
-            const float POWER_REQUIRED = BASE_POWER * MULTIPLIER;
+            if (path.PointsOutside)
+            {
+                throw new KOSInvalidPathException("Path refers to parent directory", path.ToString());
+            }
 
-            return POWER_REQUIRED;
+            string mergedPath = ArchiveFolder;
+
+            foreach (string segment in path.Segments)
+            {
+                mergedPath = Path.Combine(mergedPath, segment);
+            }
+
+            return mergedPath;
         }
 
-        public override VolumeFile Open(string name, bool ksmDefault = false)
+        public override VolumeItem Open(VolumePath path, bool ksmDefault = false)
         {
             try
             {
-                var fileInfo = FileSearch(name, ksmDefault);
-                if (fileInfo == null)
-                {
-                    return null;
-                }
+                var fileSystemInfo = Search(path, ksmDefault);
 
-                return new ArchiveFile(fileInfo);
+                if (fileSystemInfo == null) {
+                    return null;
+                } else if (fileSystemInfo is FileInfo)
+                {
+                    VolumePath filePath = VolumePath.FromString(fileSystemInfo.FullName.Substring(ArchiveFolder.Length));
+                    return new ArchiveFile(this, fileSystemInfo as FileInfo, filePath);
+                } else {
+                    // we can use 'path' here, default extensions are not added to directories
+                    return new ArchiveDirectory(this, path);
+                }
             }
             catch (Exception e)
             {
-                SafeHouse.Logger.Log(e);
-                return null;
+                throw new KOSPersistenceException("Could not open path: " + path, e);
             }
         }
 
-        public override bool Delete(string name)
+        public override VolumeDirectory CreateDirectory(VolumePath path)
         {
-            var fullPath = FileSearch(name);
-            if (fullPath == null)
+            string archivePath = GetArchivePath(path);
+
+            try
+            {
+                Directory.CreateDirectory(archivePath);
+            } catch (IOException)
+            {
+                throw new KOSPersistenceException("Already exists: " + path);
+            }
+
+            return new ArchiveDirectory(this, path);
+        }
+
+        public override VolumeFile CreateFile(VolumePath path)
+        {
+            string archivePath = GetArchivePath(path);
+
+            Directory.CreateDirectory(GetArchivePath(path.GetParent()));
+
+            try {
+                File.Create(archivePath).Dispose();
+            } catch (UnauthorizedAccessException)
+            {
+                throw new KOSPersistenceException("Could not create file: " + path);
+            }
+
+            return Open(path) as VolumeFile;
+        }
+
+        public override bool Exists(VolumePath path, bool ksmDefault = false)
+        {
+            return Search(path, ksmDefault) != null;
+        }
+
+        public override bool Delete(VolumePath path, bool ksmDefault = false)
+        {
+            var fileSystemInfo = Search(path, ksmDefault);
+
+            if (fileSystemInfo == null)
             {
                 return false;
+            } else if (fileSystemInfo is FileInfo)
+            {
+                File.Delete(fileSystemInfo.FullName);
+            } else
+            {
+                Directory.Delete(fileSystemInfo.FullName, true);
             }
-            File.Delete(fullPath.FullName);
+
             return true;
         }
 
-        public override bool RenameFile(string name, string newName)
-        {
-            try
-            {
-                var fullSourcePath = FileSearch(name);
-                if (fullSourcePath == null)
-                {
-                    return false;
-                }
-
-                string destinationPath = string.Format(ArchiveFolder + newName);
-                if (!Path.HasExtension(newName))
-                {
-                    destinationPath += fullSourcePath.Extension;
-                }
-
-                File.Move(fullSourcePath.FullName, destinationPath);
-                return true;
-            }
-            catch (Exception)
-            {
-                return false;
-            }
-        }
-
-        public override VolumeFile Create(string name)
-        {
-            string filePath = Path.Combine(ArchiveFolder, name);
-            if (File.Exists(filePath))
-            {
-                throw new KOSFileException("File already exists: " + name);
-            }
-
-            using (File.Create(filePath))
-            {
-                // Do Nothing
-            }
-
-            return new ArchiveFile(FileSearch(name));
-        }
-
-        public override VolumeFile Save(string name, FileContent content)
+        public override VolumeFile Save(VolumePath path, FileContent content)
         {
             Directory.CreateDirectory(ArchiveFolder);
 
             byte[] fileBody = ConvertToWindowsNewlines(content.Bytes);
 
-            using (var outfile = new BinaryWriter(File.Open(Path.Combine(ArchiveFolder, name), FileMode.Create)))
+            using (var outfile = new BinaryWriter(File.Open(GetArchivePath(path), FileMode.Create)))
             {
                 outfile.Write(fileBody);
             }
 
-            return new ArchiveFile(FileSearch(name));
-        }
-
-        public override Dictionary<string, VolumeFile> FileList
-        {
-            get
-            {
-                var listFiles = Directory.GetFiles(ArchiveFolder);
-                var filterHid = listFiles.Where(f => (File.GetAttributes(f) & FileAttributes.Hidden) != 0);
-                var filterSys = listFiles.Where(f => (File.GetAttributes(f) & FileAttributes.System) != 0);
-
-                var visFiles = listFiles.Except(filterSys).Except(filterHid);
-                var kosFiles = visFiles.Except(Directory.GetFiles(ArchiveFolder, ".*"));
-                return kosFiles.Select(file => new FileInfo(file)).Select(sysFileInfo => new ArchiveFile(sysFileInfo)).
-                    Cast<VolumeFile>().ToDictionary(f => f.Name, f => f);
-            }
-        }
-
-        public override long Size
-        {
-            get
-            {
-                return FileList.Values.Sum(i => i.Size);
-            }
-        }
-
-        public override bool Exists(string name)
-        {
-            return FileSearch(name) != null;
+            return Open(path) as VolumeFile;
         }
 
         public static byte[] ConvertToWindowsNewlines(byte[] bytes)
@@ -175,19 +175,34 @@ namespace kOS.Safe.Persistence
             return bytes;
         }
 
+        public override float RequiredPower()
+        {
+            const int MULTIPLIER = 5;
+            const float POWER_REQUIRED = BASE_POWER * MULTIPLIER;
+
+            return POWER_REQUIRED;
+        }
+
         /// <summary>
         /// Get the file from the OS.
         /// </summary>
         /// <param name="name">filename to look for</param>
         /// <param name="ksmDefault">if true, it prefers to use the KSM filename over the KS.  The default is to prefer KS.</param>
         /// <returns>the full fileinfo of the filename if found</returns>
-        private FileInfo FileSearch(string name, bool ksmDefault = false)
+        private FileSystemInfo Search(VolumePath volumePath, bool ksmDefault)
         {
-            var path = Path.Combine(ArchiveFolder, name);
+            var path = GetArchivePath(volumePath);
+
+            if (Directory.Exists(path))
+            {
+                return new DirectoryInfo(path);
+            }
+
             if (File.Exists(path))
             {
                 return new FileInfo(path);
             }
+
             var kerboscriptFile = new FileInfo(PersistenceUtilities.CookedFilename(path, KERBOSCRIPT_EXTENSION, true));
             var kosMlFile = new FileInfo(PersistenceUtilities.CookedFilename(path, KOS_MACHINELANGUAGE_EXTENSION, true));
 

--- a/src/kOS.Safe/Persistence/Archive.cs
+++ b/src/kOS.Safe/Persistence/Archive.cs
@@ -24,7 +24,7 @@ namespace kOS.Safe.Persistence
 
         public Archive(string archiveFolder)
         {
-            ArchiveFolder = archiveFolder;
+            ArchiveFolder = Path.GetFullPath(archiveFolder).TrimEnd(VolumePath.PathSeparator);
             CreateArchiveDirectory();
             Renameable = false;
             InitializeName(ArchiveName);
@@ -61,7 +61,7 @@ namespace kOS.Safe.Persistence
                 var fileSystemInfo = Search(path, ksmDefault);
 
                 if (fileSystemInfo == null) {
-                    throw new KOSPersistenceException("Could not open path: " + path);;
+                    return null;
                 } else if (fileSystemInfo is FileInfo)
                 {
                     VolumePath filePath = VolumePath.FromString(fileSystemInfo.FullName.Substring(ArchiveFolder.Length));

--- a/src/kOS.Safe/Persistence/ArchiveDirectory.cs
+++ b/src/kOS.Safe/Persistence/ArchiveDirectory.cs
@@ -7,6 +7,7 @@ using kOS.Safe.Encapsulation;
 
 namespace kOS.Safe.Persistence
 {
+    [kOS.Safe.Utilities.KOSNomenclature("VolumeDirectory", KOSToCSharp = false)]
     public class ArchiveDirectory : VolumeDirectory
     {
         private Archive archive;

--- a/src/kOS.Safe/Persistence/ArchiveDirectory.cs
+++ b/src/kOS.Safe/Persistence/ArchiveDirectory.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using kOS.Safe.Persistence;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using kOS.Safe.Encapsulation;
+
+namespace kOS.Safe.Persistence
+{
+    public class ArchiveDirectory : VolumeDirectory
+    {
+        private Archive archive;
+        private string archivePath;
+
+        public ArchiveDirectory(Archive archive, VolumePath path) : base(archive, path)
+        {
+            this.archive = archive;
+            this.archivePath = archive.GetArchivePath(path);
+        }
+
+        public override IDictionary<string, VolumeItem> List()
+        {
+            string[] files = Directory.GetFiles(archivePath);
+            var filterHid = files.Where(f => (File.GetAttributes(f) & FileAttributes.Hidden) != 0);
+            var filterSys = files.Where(f => (File.GetAttributes(f) & FileAttributes.System) != 0);
+            var visFiles = files.Except(filterSys).Except(filterHid).ToArray();
+            string[] directories = Directory.GetDirectories(archivePath);
+
+            Array.Sort(directories);
+            Array.Sort(visFiles);
+
+            var result = new Dictionary<string, VolumeItem>();
+
+            foreach (string directory in directories)
+            {
+                string directoryName = System.IO.Path.GetFileName(directory);
+                result.Add(directoryName, new ArchiveDirectory(archive, VolumePath.FromString(directoryName, Path)));
+            }
+
+            foreach (string file in visFiles)
+            {
+                string fileName = System.IO.Path.GetFileName(file);
+                result.Add(fileName, new ArchiveFile(archive, new FileInfo(file), VolumePath.FromString(fileName, Path)));
+            }
+
+            return result;
+        }
+
+        public override int Size {
+            get {
+                return List().Values.Aggregate(0, (acc, x) => acc + x.Size);
+            }
+        }
+    }
+}
+

--- a/src/kOS.Safe/Persistence/ArchiveFile.cs
+++ b/src/kOS.Safe/Persistence/ArchiveFile.cs
@@ -1,16 +1,17 @@
-﻿using kOS.Safe.Persistence;
-using System;
+﻿using System;
 using System.IO;
 
-namespace kOS.Safe.Encapsulation
+namespace kOS.Safe.Persistence
 {
     [kOS.Safe.Utilities.KOSNomenclature("VolumeFile", KOSToCSharp = false)]
     public class ArchiveFile : VolumeFile
     {
         private readonly FileInfo fileInfo;
+
         public override int Size { get { fileInfo.Refresh(); return (int)fileInfo.Length; } }
 
-        public ArchiveFile(FileInfo fileInfo) : base(fileInfo.Name)
+        public ArchiveFile(Archive archive, FileInfo fileInfo, VolumePath path)
+            : base(archive, path)
         {
             this.fileInfo = fileInfo;
         }

--- a/src/kOS.Safe/Persistence/FileContent.cs
+++ b/src/kOS.Safe/Persistence/FileContent.cs
@@ -126,6 +126,16 @@ namespace kOS.Safe.Persistence
             return GetEnumerator();
         }
 
+        public override bool Equals(object obj)
+        {
+            return obj is FileContent && Bytes.Equals((obj as FileContent).Bytes);
+        }
+
+        public override int GetHashCode()
+        {
+            return Bytes.GetHashCode();
+        }
+
         public override string ToString()
         {
             return "File content";

--- a/src/kOS.Safe/Persistence/FileContent.cs
+++ b/src/kOS.Safe/Persistence/FileContent.cs
@@ -57,9 +57,7 @@ namespace kOS.Safe.Persistence
 
         public override Dump Dump()
         {
-            Dump dump = new Dump { { DumpContent, PersistenceUtilities.EncodeBase64(Bytes) } };
-
-            return dump;
+            return new Dump { { DumpContent, PersistenceUtilities.EncodeBase64(Bytes) } };
         }
 
         public override void LoadDump(Dump dump)

--- a/src/kOS.Safe/Persistence/FileContent.cs
+++ b/src/kOS.Safe/Persistence/FileContent.cs
@@ -15,8 +15,8 @@ namespace kOS.Safe.Persistence
     public class FileContent : SerializableStructure, IEnumerable<string>
     {
         private static readonly Encoding fileEncoding = Encoding.UTF8;
-        private const string DUMP_CONTENT = "content";
-        public const string NEW_LINE = "\n";
+        private const string DumpContent = "content";
+        public const string NewLine = "\n";
 
         public byte[] Bytes { get; private set; }
         public string String { get { return fileEncoding.GetString(Bytes); } }
@@ -57,14 +57,14 @@ namespace kOS.Safe.Persistence
 
         public override Dump Dump()
         {
-            Dump dump = new Dump { { DUMP_CONTENT, PersistenceUtilities.EncodeBase64(Bytes) } };
+            Dump dump = new Dump { { DumpContent, PersistenceUtilities.EncodeBase64(Bytes) } };
 
             return dump;
         }
 
         public override void LoadDump(Dump dump)
         {
-            string contentString = dump[DUMP_CONTENT] as string;
+            string contentString = dump[DumpContent] as string;
 
             if (contentString == null)
             {
@@ -74,9 +74,9 @@ namespace kOS.Safe.Persistence
             Bytes = PersistenceUtilities.DecodeBase64ToBinary(contentString);
         }
 
-        public List<CodePart> AsParts(string name, string prefix)
+        public List<CodePart> AsParts(GlobalPath path, string prefix)
         {
-            return CompiledObject.UnPack(name, prefix, Bytes);
+            return CompiledObject.UnPack(path, prefix, Bytes);
         }
 
         public static byte[] EncodeString(string content)
@@ -104,7 +104,7 @@ namespace kOS.Safe.Persistence
 
         public void WriteLn(string content)
         {
-            Write(content + NEW_LINE);
+            Write(content + NewLine);
         }
 
         public void Clear()

--- a/src/kOS.Safe/Persistence/GlobalPath.cs
+++ b/src/kOS.Safe/Persistence/GlobalPath.cs
@@ -82,6 +82,21 @@ namespace kOS.Safe.Persistence
             return new GlobalPath(volumeId, new List<string>(volumePath.Segments));
         }
 
+        public GlobalPath ChangeName(string newName)
+        {
+            if (Segments.Count == 0)
+            {
+                throw new KOSInvalidPathException("This path points to the root directory, you can't change its name",
+                    this.ToString());
+            }
+
+            List<string> newSegments = new List<string>(Segments);
+            newSegments.RemoveAt(newSegments.Count - 1);
+            newSegments.Add(newName);
+
+            return new GlobalPath(VolumeId, newSegments);
+        }
+
         public GlobalPath ChangeExtension(string newExtension)
         {
             if (Segments.Count == 0)

--- a/src/kOS.Safe/Persistence/GlobalPath.cs
+++ b/src/kOS.Safe/Persistence/GlobalPath.cs
@@ -77,9 +77,9 @@ namespace kOS.Safe.Persistence
             return new GlobalPath(VolumeId);
         }
 
-        public static GlobalPath FromVolumePath(VolumePath volumePath, Volume volume)
+        public static GlobalPath FromVolumePath(VolumePath volumePath, string volumeId)
         {
-            return new GlobalPath(volume.Name, new List<string>(volumePath.Segments));
+            return new GlobalPath(volumeId, new List<string>(volumePath.Segments));
         }
 
         public GlobalPath ChangeExtension(string newExtension)

--- a/src/kOS.Safe/Persistence/GlobalPath.cs
+++ b/src/kOS.Safe/Persistence/GlobalPath.cs
@@ -109,7 +109,7 @@ namespace kOS.Safe.Persistence
             return new GlobalPath(VolumeId, newSegments);
         }
 
-        public GlobalPath Combine(params string[] segments)
+        public new GlobalPath Combine(params string[] segments)
         {
             return new GlobalPath(VolumeId, Segments.Concat(segments));
         }

--- a/src/kOS.Safe/Persistence/GlobalPath.cs
+++ b/src/kOS.Safe/Persistence/GlobalPath.cs
@@ -156,11 +156,6 @@ namespace kOS.Safe.Persistence
                 throw new KOSInvalidPathException("GlobalPath should contain a volumeId", pathString);
             }
 
-            if (!pathString.StartsWith(PathSeparator.ToString()))
-            {
-                pathString = PathSeparator + pathString;
-            }
-
             VolumePath path = VolumePath.FromString(pathString);
             return new GlobalPath(volumeName, path);
         }

--- a/src/kOS.Safe/Persistence/GlobalPath.cs
+++ b/src/kOS.Safe/Persistence/GlobalPath.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using System.Collections.Generic;
+using kOS.Safe.Persistence;
+using kOS.Safe.Exceptions;
+using System.Linq;
+
+namespace kOS.Safe.Persistence
+{
+    /// <summary>
+    /// Represents the location of a directory or a file inside a kOS. It contains a volumeId and a VolumePath.
+    /// </summary>
+    /// <seealso cref="VolumePath"/>
+    public class GlobalPath : VolumePath
+    {
+        private const string CurrentDirectoryPath = ".";
+        public const string VolumeIdentifierRegexString = @"\A(?<id>[\w\.]+):(?<rest>.*)\Z";
+        private static Regex volumeIdentifierRegex = new Regex(VolumeIdentifierRegexString);
+
+        public static new GlobalPath EMPTY = new GlobalPath("$$empty$$", VolumePath.EMPTY);
+
+        public object VolumeId { get; private set; }
+
+        private GlobalPath(object volumeId, VolumePath path) : this(volumeId, new List<string>(path.Segments))
+        {
+
+        }
+
+        private GlobalPath(object volumeId, List<string> segments) : base(new List<string>(segments))
+        {
+            VolumeId = ValidateVolumeId(volumeId);
+        }
+
+        private static object ValidateVolumeId(object volumeId)
+        {
+            if (!(volumeId is int || volumeId is string) || (volumeId is string && String.IsNullOrEmpty(volumeId as string)))
+            {
+                throw new KOSException("Invalid volumeId: '" + volumeId + "'");
+            }
+
+            int result;
+            if (volumeId is string && int.TryParse(volumeId as string, out result))
+            {
+                volumeId = result;
+            }
+
+            return volumeId;
+        }
+
+        public static bool HasVolumeId(string pathString)
+        {
+            return volumeIdentifierRegex.Match(pathString).Success;
+        }
+
+        public new GlobalPath GetParent()
+        {
+            if (Depth < 1)
+            {
+                throw new KOSException("This path does not have a parent");
+            }
+
+            return new GlobalPath(VolumeId, new List<string>(Segments.Take(Segments.Count - 1)));
+        }
+
+        public bool IsParent(GlobalPath path)
+        {
+            return VolumeId.Equals(path.VolumeId) && base.IsParent(path);
+        }
+
+        public static GlobalPath FromVolumePath(VolumePath volumePath, Volume volume)
+        {
+            return new GlobalPath(volume.Name, new List<string>(volumePath.Segments));
+        }
+
+        /// <summary>
+        /// Create a GlobalPath from a base path and a relative path.
+        /// </summary>
+        /// <returns>GlobalPath that represents the new path.</returns>
+        /// <param name="pathString">Path string relative to basePath.</param>
+        /// <param name="basePath">Base path.</param>
+        public static GlobalPath FromStringAndBase(string pathString, GlobalPath basePath)
+        {
+            if (IsAbsolute(pathString))
+            {
+                throw new KOSInvalidPathException("Relative path expected", pathString);
+            }
+
+            if (pathString.Equals(CurrentDirectoryPath))
+            {
+                return basePath;
+            }
+
+            List<string> mergedSegments = new List<string>();
+            mergedSegments.AddRange(basePath.Segments);
+            mergedSegments.AddRange(GetSegmentsFromString(pathString));
+
+            return new GlobalPath(basePath.VolumeId, mergedSegments);
+        }
+
+        /// <summary>
+        /// Creates a GlobalPath from string.
+        /// </summary>
+        /// <returns>Path string, must have the following format: volumeId:[/]segment1[/furthersegments]*</returns>
+        /// <param name="pathString">Path string.</param>
+        public static new GlobalPath FromString(string pathString)
+        {
+            string volumeName = null;
+            Match match = volumeIdentifierRegex.Match(pathString);
+
+            if (match.Success) {
+                volumeName = match.Groups["id"].Captures[0].Value;
+                pathString = match.Groups["rest"].Captures[0].Value;
+            } else {
+                throw new KOSInvalidPathException("GlobalPath should contain a volumeId", pathString);
+            }
+
+            if (!pathString.StartsWith(PathSeparator.ToString()))
+            {
+                pathString = PathSeparator + pathString;
+            }
+
+            VolumePath path = VolumePath.FromString(pathString);
+            return new GlobalPath(volumeName, path);
+        }
+
+        public override int GetHashCode()
+        {
+            return 13 * VolumeId.GetHashCode() + base.GetHashCode();
+        }
+
+        public override bool Equals(object other)
+        {
+            GlobalPath otherPath = other as GlobalPath;
+
+            if (otherPath == null)
+            {
+                return false;
+            }
+
+            return VolumeId.Equals(otherPath.VolumeId) && Segments.SequenceEqual(otherPath.Segments);
+        }
+
+        public override string ToString()
+        {
+            return VolumeId + ":" + base.ToString();
+        }
+    }
+}

--- a/src/kOS.Safe/Persistence/GlobalPath.cs
+++ b/src/kOS.Safe/Persistence/GlobalPath.cs
@@ -109,7 +109,7 @@ namespace kOS.Safe.Persistence
             return new GlobalPath(VolumeId, newSegments);
         }
 
-        public GlobalPath Combine(string[] segments)
+        public GlobalPath Combine(params string[] segments)
         {
             return new GlobalPath(VolumeId, Segments.Concat(segments));
         }

--- a/src/kOS.Safe/Persistence/GlobalPath.cs
+++ b/src/kOS.Safe/Persistence/GlobalPath.cs
@@ -22,7 +22,7 @@ namespace kOS.Safe.Persistence
 
         public object VolumeId { get; private set; }
 
-        private GlobalPath(object volumeId)
+        protected GlobalPath(object volumeId)
         {
             VolumeId = ValidateVolumeId(volumeId);
         }

--- a/src/kOS.Safe/Persistence/Harddisk.cs
+++ b/src/kOS.Safe/Persistence/Harddisk.cs
@@ -81,6 +81,11 @@ namespace kOS.Safe.Persistence
         {
             HarddiskDirectory directory = ParentDirectoryForPath(path);
 
+            if (directory == null)
+            {
+                return false;
+            }
+
             return directory.Exists(path.Name, ksmDefault);
         }
 
@@ -91,10 +96,10 @@ namespace kOS.Safe.Persistence
             return directory.Delete(path.Name, ksmDefault);
         }
 
-        public override VolumeFile SaveFile(VolumePath path, FileContent content)
+        public override VolumeFile SaveFile(VolumePath path, FileContent content, bool verifyFreeSpace = true)
         {
             try {
-                if (!IsRoomFor(path, content))
+                if (verifyFreeSpace && !IsRoomFor(path, content))
                 {
                     return null;
                 }

--- a/src/kOS.Safe/Persistence/Harddisk.cs
+++ b/src/kOS.Safe/Persistence/Harddisk.cs
@@ -79,15 +79,19 @@ namespace kOS.Safe.Persistence
 
         public override VolumeFile Save(VolumePath path, FileContent content)
         {
-            if (!IsRoomFor(path, content))
+            try {
+                if (!IsRoomFor(path, content))
+                {
+                    return null;
+                }
+            } catch (KOSPersistenceException)
             {
-                return null;
+                throw new KOSPersistenceException("Can't save file over a directory: " + path);
             }
 
             HarddiskDirectory directory = ParentDirectoryForPath(path);
-            directory.CreateFile(path.Name, content);
 
-            return Open(path) as VolumeFile;
+            return directory.Save(path.Name, content) as VolumeFile;
         }
     }
 }

--- a/src/kOS.Safe/Persistence/Harddisk.cs
+++ b/src/kOS.Safe/Persistence/Harddisk.cs
@@ -46,11 +46,6 @@ namespace kOS.Safe.Persistence
 
             VolumeItem result = directory.Open(path.Name, ksmDefault);
 
-            if (result == null)
-            {
-                throw new KOSPersistenceException("Could not open path: " + path);;
-            }
-
             return result;
         }
 

--- a/src/kOS.Safe/Persistence/Harddisk.cs
+++ b/src/kOS.Safe/Persistence/Harddisk.cs
@@ -40,7 +40,14 @@ namespace kOS.Safe.Persistence
         {
             HarddiskDirectory directory = ParentDirectoryForPath(path);
 
-            return directory.Open(path.Name, ksmDefault);
+            VolumeItem result = directory.Open(path.Name, ksmDefault);
+
+            if (result == null)
+            {
+                throw new KOSPersistenceException("Could not open path: " + path);;
+            }
+
+            return result;
         }
 
         public override VolumeDirectory CreateDirectory(VolumePath path)

--- a/src/kOS.Safe/Persistence/Harddisk.cs
+++ b/src/kOS.Safe/Persistence/Harddisk.cs
@@ -3,141 +3,85 @@ using kOS.Safe.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using kOS.Safe.Exceptions;
 
 namespace kOS.Safe.Persistence
 {
     [kOS.Safe.Utilities.KOSNomenclature("LocalVolume")]
     public sealed class Harddisk : Volume
     {
-        private readonly Dictionary<string, FileContent> files;
+        public HarddiskDirectory RootHarddiskDirectory { get; set; }
 
-        public override Dictionary<string, VolumeFile> FileList
-        {
+        public override VolumeDirectory Root {
             get
             {
-                return files.ToDictionary(arg => arg.Key, arg => (VolumeFile)new HarddiskFile(this, arg.Key));
-            }
-        }
-
-        public override long Size
-        {
-            get
-            {
-                return files.Values.Sum(x => x.Size);
+                return RootHarddiskDirectory;
             }
         }
 
         public Harddisk(int size)
         {
             Capacity = size;
-            files = new Dictionary<string, FileContent>(StringComparer.OrdinalIgnoreCase);
+            RootHarddiskDirectory = new HarddiskDirectory(this, VolumePath.EMPTY);
         }
 
-        public FileContent GetFileContent(string name)
+        private HarddiskDirectory ParentDirectoryForPath(VolumePath path, bool create = false)
         {
-            if (!files.ContainsKey(name))
+            HarddiskDirectory directory = RootHarddiskDirectory;
+            if (path.Depth > 1)
             {
-                throw new KOSFileException("File does not exist: " + name);
+                directory = RootHarddiskDirectory.GetSubdirectory(path.GetParent(), create);
             }
 
-            return files[name];
+            return directory;
         }
 
-        public override VolumeFile Open(string name, bool ksmDefault = false)
+        public override VolumeItem Open(VolumePath path, bool ksmDefault = false)
         {
-            return FileSearch(name, ksmDefault);
+            HarddiskDirectory directory = ParentDirectoryForPath(path);
+
+            return directory.Open(path.Name, ksmDefault);
         }
 
-        public override bool Delete(string name)
+        public override VolumeDirectory CreateDirectory(VolumePath path)
         {
-            var fullPath = FileSearch(name);
-            if (fullPath == null)
-            {
-                return false;
-            }
-            return files.Remove(fullPath.Name);
+            HarddiskDirectory directory = ParentDirectoryForPath(path, true);
+
+            return directory.CreateDirectory(path.Name);
         }
 
-        public override bool RenameFile(string name, string newName)
+        public override VolumeFile CreateFile(VolumePath path)
         {
-            VolumeFile file = Open(name);
-            if (file != null)
-            {
-                // Add the original file content under the new name
-                files.Add(newName, files[file.Name]);
-                // Then remove the old file content under the old name
-                files.Remove(file.Name);
-                return true;
-            }
-            return false;
+            HarddiskDirectory directory = ParentDirectoryForPath(path, true);
+
+            return directory.CreateFile(path.Name);
         }
 
-        public override VolumeFile Create(string name)
+        public override bool Exists(VolumePath path, bool ksmDefault = false)
         {
-            SafeHouse.Logger.Log("Creating file on harddisk " + name);
+            HarddiskDirectory directory = ParentDirectoryForPath(path);
 
-            if (files.ContainsKey(name))
-            {
-                throw new KOSFileException("File already exists: " + name);
-            }
-
-            files[name] = new FileContent();
-
-            SafeHouse.Logger.Log("Created file on harddisk " + name);
-
-            return new HarddiskFile(this, name);
+            return directory.Exists(path.Name, ksmDefault);
         }
 
-        public override VolumeFile Save(string name, FileContent content)
+        public override bool Delete(VolumePath path, bool ksmDefault = false)
         {
-            if (!IsRoomFor(name, content))
+            HarddiskDirectory directory = ParentDirectoryForPath(path);
+
+            return directory.Delete(path.Name, ksmDefault);
+        }
+
+        public override VolumeFile Save(VolumePath path, FileContent content)
+        {
+            if (!IsRoomFor(path, content))
             {
                 return null;
             }
 
-            files[name] = content;
+            HarddiskDirectory directory = ParentDirectoryForPath(path);
+            directory.CreateFile(path.Name, content);
 
-            return new HarddiskFile(this, name);
-        }
-
-        public override bool Exists(string name)
-        {
-            return FileSearch(name) != null;
-        }
-
-        private VolumeFile FileSearch(string name, bool ksmDefault = false)
-        {
-            if (files.ContainsKey(name))
-            {
-                return new HarddiskFile(this, name);
-            }
-            else
-            {
-                var kerboscriptFilename = PersistenceUtilities.CookedFilename(name, KERBOSCRIPT_EXTENSION, true);
-                var kosMlFilename = PersistenceUtilities.CookedFilename(name, KOS_MACHINELANGUAGE_EXTENSION, true);
-                bool kerboscriptFileExists = files.ContainsKey(kerboscriptFilename);
-                bool kosMlFileExists = files.ContainsKey(kosMlFilename);
-                if (kerboscriptFileExists && kosMlFileExists)
-                {
-                    if (ksmDefault)
-                    {
-                        return new HarddiskFile(this, kosMlFilename);
-                    }
-                    else
-                    {
-                        return new HarddiskFile(this, kerboscriptFilename);
-                    }
-                }
-                if (kerboscriptFileExists)
-                {
-                    return new HarddiskFile(this, kerboscriptFilename);
-                }
-                if (kosMlFileExists)
-                {
-                    return new HarddiskFile(this, kosMlFilename);
-                }
-            }
-            return null;
+            return Open(path) as VolumeFile;
         }
     }
 }

--- a/src/kOS.Safe/Persistence/Harddisk.cs
+++ b/src/kOS.Safe/Persistence/Harddisk.cs
@@ -79,6 +79,11 @@ namespace kOS.Safe.Persistence
 
         public override bool Exists(VolumePath path, bool ksmDefault = false)
         {
+            if (path.Depth == 0)
+            {
+                return true;
+            }
+
             HarddiskDirectory directory = ParentDirectoryForPath(path);
 
             if (directory == null)
@@ -91,6 +96,11 @@ namespace kOS.Safe.Persistence
 
         public override bool Delete(VolumePath path, bool ksmDefault = false)
         {
+            if (path.Depth == 0)
+            {
+                throw new KOSPersistenceException("Can't delete root directory");
+            }
+
             HarddiskDirectory directory = ParentDirectoryForPath(path);
 
             return directory.Delete(path.Name, ksmDefault);

--- a/src/kOS.Safe/Persistence/Harddisk.cs
+++ b/src/kOS.Safe/Persistence/Harddisk.cs
@@ -38,6 +38,10 @@ namespace kOS.Safe.Persistence
 
         public override VolumeItem Open(VolumePath path, bool ksmDefault = false)
         {
+            if (path.Depth == 0) {
+                return Root;
+            }
+
             HarddiskDirectory directory = ParentDirectoryForPath(path);
 
             VolumeItem result = directory.Open(path.Name, ksmDefault);

--- a/src/kOS.Safe/Persistence/HarddiskDirectory.cs
+++ b/src/kOS.Safe/Persistence/HarddiskDirectory.cs
@@ -95,7 +95,14 @@ namespace kOS.Safe.Persistence
 
         public bool Delete(string name, bool ksmDefault)
         {
-            return items.Remove(name);
+            var toDelete = Search(name);
+
+            if (toDelete == null)
+            {
+                return false;
+            }
+
+            return items.Remove(toDelete.Name);
         }
 
         public IEnumerator<VolumeItem> GetEnumerator()

--- a/src/kOS.Safe/Persistence/HarddiskDirectory.cs
+++ b/src/kOS.Safe/Persistence/HarddiskDirectory.cs
@@ -105,7 +105,7 @@ namespace kOS.Safe.Persistence
             return items.Remove(toDelete.Name);
         }
 
-        public IEnumerator<VolumeItem> GetEnumerator()
+        public new IEnumerator<VolumeItem> GetEnumerator()
         {
             return List().Values.GetEnumerator();
         }

--- a/src/kOS.Safe/Persistence/HarddiskDirectory.cs
+++ b/src/kOS.Safe/Persistence/HarddiskDirectory.cs
@@ -124,7 +124,7 @@ namespace kOS.Safe.Persistence
 
             if (!Path.IsParent(path))
             {
-                throw new KOSException("This directory does not contain that path: " + path.ToString());
+                throw new KOSException("This directory does not contain path: " + path.ToString());
             }
 
             string subdirectory = path.Segments[Path.Segments.Count];

--- a/src/kOS.Safe/Persistence/HarddiskDirectory.cs
+++ b/src/kOS.Safe/Persistence/HarddiskDirectory.cs
@@ -152,7 +152,7 @@ namespace kOS.Safe.Persistence
         private VolumeItem Search(string name, bool ksmDefault = false)
         {
             object item = items.ContainsKey(name) ? items[name] : null;
-            if (item is byte[])
+            if (item is FileContent)
             {
                 return new HarddiskFile(this, name);
             } else if (item is HarddiskDirectory)

--- a/src/kOS.Safe/Persistence/HarddiskDirectory.cs
+++ b/src/kOS.Safe/Persistence/HarddiskDirectory.cs
@@ -18,6 +18,11 @@ namespace kOS.Safe.Persistence
             items = new Dictionary<string, Structure>(StringComparer.InvariantCultureIgnoreCase);
         }
 
+        public void Clear()
+        {
+            items.Clear();
+        }
+
         public VolumeItem Open(string name, bool ksmDefault = false)
         {
             return Search(name, ksmDefault);
@@ -132,10 +137,10 @@ namespace kOS.Safe.Persistence
 
             if (directory == null)
             {
-                throw new KOSException("Subdirectory does not exist: " + path.ToString());
+                throw new KOSPersistenceException("Directory does not exist: " + path.ToString());
             }
 
-            return directory;
+            return directory.GetSubdirectory(path, create);
         }
 
         public override IDictionary<string, VolumeItem> List()

--- a/src/kOS.Safe/Persistence/HarddiskDirectory.cs
+++ b/src/kOS.Safe/Persistence/HarddiskDirectory.cs
@@ -51,19 +51,7 @@ namespace kOS.Safe.Persistence
 
         public HarddiskDirectory CreateDirectory(string name)
         {
-            try
-            {
-                return CreateDirectory(name, new HarddiskDirectory(Volume as Harddisk, VolumePath.FromString(name, Path)));
-            } catch (KOSPersistenceException e)
-            {
-                if (items[name] is HarddiskDirectory)
-                {
-                    return items[name] as HarddiskDirectory;
-                } else
-                {
-                    throw e;
-                }
-            }
+            return CreateDirectory(name, new HarddiskDirectory(Volume as Harddisk, VolumePath.FromString(name, Path)));
         }
 
         public HarddiskDirectory CreateDirectory(string name, HarddiskDirectory directory)

--- a/src/kOS.Safe/Persistence/HarddiskDirectory.cs
+++ b/src/kOS.Safe/Persistence/HarddiskDirectory.cs
@@ -1,0 +1,196 @@
+﻿using System;
+using System.Collections.Generic;
+using kOS.Safe.Persistence;
+using System.Linq;
+using kOS.Safe.Exceptions;
+using kOS.Safe.Encapsulation;
+using System.Collections;
+
+namespace kOS.Safe.Persistence
+{
+    public class HarddiskDirectory : VolumeDirectory, IEnumerable<VolumeItem>
+    {
+        private Dictionary<string, Structure> items;
+
+        public HarddiskDirectory(Harddisk harddisk, VolumePath path) : base(harddisk, path)
+        {
+            items = new Dictionary<string, Structure>(StringComparer.InvariantCultureIgnoreCase);
+        }
+
+        public VolumeItem Open(string name, bool ksmDefault = false)
+        {
+            return Search(name, ksmDefault);
+        }
+
+        public FileContent GetFileContent(string name)
+        {
+            if (!items.ContainsKey(name) || !(items[name] is FileContent))
+            {
+                throw new KOSFileException("File does not exist: " + name);
+            }
+
+            return items[name] as FileContent;
+        }
+
+        public HarddiskFile CreateFile(string name)
+        {
+            return CreateFile(name, new FileContent());
+        }
+
+        public HarddiskFile CreateFile(string name, FileContent fileContent)
+        {
+            try {
+                items.Add(name, new FileContent(fileContent.Bytes.Clone() as byte[]));
+            } catch (ArgumentException)
+            {
+                throw new KOSPersistenceException("Already exists: " + name);
+            }
+
+            return new HarddiskFile(this, name);
+        }
+
+        public HarddiskDirectory CreateDirectory(string name)
+        {
+            try
+            {
+                return CreateDirectory(name, new HarddiskDirectory(Volume as Harddisk, VolumePath.FromString(name, Path)));
+            } catch (KOSPersistenceException e)
+            {
+                if (items[name] is HarddiskDirectory)
+                {
+                    return items[name] as HarddiskDirectory;
+                } else
+                {
+                    throw e;
+                }
+            }
+        }
+
+        public HarddiskDirectory CreateDirectory(string name, HarddiskDirectory directory)
+        {
+            try
+            {
+                items.Add(name, directory);
+            } catch (ArgumentException)
+            {
+                throw new KOSPersistenceException("Already exists: " + name);
+            }
+
+            return directory;
+        }
+
+        public bool Exists(string name, bool ksmDefault)
+        {
+            return Search(name) != null;
+        }
+
+        public bool Delete(string name, bool ksmDefault)
+        {
+            return items.Remove(name);
+        }
+
+        public IEnumerator<VolumeItem> GetEnumerator()
+        {
+            return List().Values.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public HarddiskDirectory GetSubdirectory(VolumePath path, bool create = false)
+        {
+            if (Path.Equals(path))
+            {
+                return this;
+            }
+
+            if (!Path.IsParent(path))
+            {
+                throw new KOSException("This directory does not contain that path: " + path.ToString());
+            }
+
+            string subdirectory = path.Segments[Path.Segments.Count];
+
+            if (!items.ContainsKey(subdirectory))
+            {
+                if (create)
+                {
+                    CreateDirectory(subdirectory);
+                } else
+                {
+                    return null;
+                }
+            }
+
+            HarddiskDirectory directory = items[subdirectory] as HarddiskDirectory;
+
+            if (directory == null)
+            {
+                throw new KOSException("Subdirectory does not exist: " + path.ToString());
+            }
+
+            return directory;
+        }
+
+        public override IDictionary<string, VolumeItem> List()
+        {
+            var result = new Dictionary<string, VolumeItem>();
+
+            foreach (var pair in items)
+            {
+                if (pair.Value is HarddiskDirectory)
+                {
+                    result.Add(pair.Key, pair.Value as HarddiskDirectory);
+                }
+                else
+                {
+                    result.Add(pair.Key, new HarddiskFile(this, pair.Key));
+                }
+            }
+
+            return result;
+        }
+
+        public override int Size {
+            get {
+                return List().Aggregate(0, (acc, x) => acc + x.Value.Size);
+            }
+        }
+
+
+        private VolumeItem Search(string name, bool ksmDefault = false)
+        {
+            object item = items.ContainsKey(name) ? items[name] : null;
+            if (item is byte[])
+            {
+                return new HarddiskFile(this, name);
+            } else if (item is HarddiskDirectory)
+            {
+                return item as HarddiskDirectory;
+            }
+            else
+            {
+                var kerboscriptFilename = PersistenceUtilities.CookedFilename(name, Volume.KERBOSCRIPT_EXTENSION, true);
+                var kosMlFilename = PersistenceUtilities.CookedFilename(name, Volume.KOS_MACHINELANGUAGE_EXTENSION, true);
+                bool kerboscriptFileExists = items.ContainsKey(kerboscriptFilename) && items[kerboscriptFilename] is FileContent;
+                bool kosMlFileExists = items.ContainsKey(kosMlFilename) && items[kosMlFilename] is FileContent;
+                if (kerboscriptFileExists && kosMlFileExists)
+                {
+                    return ksmDefault ? new HarddiskFile(this, kosMlFilename) : new HarddiskFile(this, kerboscriptFilename);
+                }
+                if (kerboscriptFileExists)
+                {
+                    return new HarddiskFile(this, kerboscriptFilename);
+                }
+                if (kosMlFileExists)
+                {
+                    return new HarddiskFile(this, kosMlFilename);
+                }
+            }
+            return null;
+        }
+    }
+}
+

--- a/src/kOS.Safe/Persistence/HarddiskDirectory.cs
+++ b/src/kOS.Safe/Persistence/HarddiskDirectory.cs
@@ -40,12 +40,11 @@ namespace kOS.Safe.Persistence
 
         public HarddiskFile CreateFile(string name, FileContent fileContent)
         {
-            try {
-                items.Add(name, new FileContent(fileContent.Bytes.Clone() as byte[]));
-            } catch (ArgumentException)
-            {
+            if (items.ContainsKey(name)){
                 throw new KOSPersistenceException("Already exists: " + name);
             }
+
+            items[name] = new FileContent(fileContent.Bytes.Clone() as byte[]);
 
             return new HarddiskFile(this, name);
         }
@@ -66,6 +65,22 @@ namespace kOS.Safe.Persistence
             }
 
             return directory;
+        }
+
+        public VolumeFile Save(string name, FileContent fileContent)
+        {
+            if (!items.ContainsKey(name))
+            {
+                return CreateFile(name, fileContent);
+            } else if (items[name] is VolumeDirectory)
+            {
+                throw new KOSPersistenceException("Can't save file over a directory: " + name);
+            } else
+            {
+                items[name] = new FileContent(fileContent.Bytes.Clone() as byte[]);
+
+                return new HarddiskFile(this, name);
+            }
         }
 
         public bool Exists(string name, bool ksmDefault)

--- a/src/kOS.Safe/Persistence/HarddiskDirectory.cs
+++ b/src/kOS.Safe/Persistence/HarddiskDirectory.cs
@@ -8,6 +8,7 @@ using System.Collections;
 
 namespace kOS.Safe.Persistence
 {
+    [kOS.Safe.Utilities.KOSNomenclature("VolumeFile", KOSToCSharp = false)]
     public class HarddiskDirectory : VolumeDirectory, IEnumerable<VolumeItem>
     {
         private Dictionary<string, Structure> items;

--- a/src/kOS.Safe/Persistence/HarddiskFile.cs
+++ b/src/kOS.Safe/Persistence/HarddiskFile.cs
@@ -1,22 +1,21 @@
-﻿using kOS.Safe.Persistence;
-
-namespace kOS.Safe.Encapsulation
+﻿namespace kOS.Safe.Persistence
 {
     [kOS.Safe.Utilities.KOSNomenclature("VolumeFile", KOSToCSharp = false)]
     public class HarddiskFile : VolumeFile
     {
-        private readonly Harddisk harddisk;
+        private readonly HarddiskDirectory hardiskDirectory;
 
         public override int Size { get { return ReadAll().Size; } }
 
-        public HarddiskFile(Harddisk harddisk, string name) : base(name)
+        public HarddiskFile(HarddiskDirectory harddiskDirectory, string name) : base(harddiskDirectory.Volume as Harddisk,
+            VolumePath.FromString(name, harddiskDirectory.Path))
         {
-            this.harddisk = harddisk;
+            this.hardiskDirectory = harddiskDirectory;
         }
 
         private FileContent GetFileContent()
         {
-            return harddisk.GetFileContent(Name);
+            return hardiskDirectory.GetFileContent(Name);
         }
 
         public override FileContent ReadAll()
@@ -26,7 +25,7 @@ namespace kOS.Safe.Encapsulation
 
         public override bool Write(byte[] content)
         {
-            if (harddisk.FreeSpace <= content.Length) return false;
+            if ((hardiskDirectory.Volume as Harddisk).FreeSpace <= content.Length) return false;
 
             GetFileContent().Write(content);
             return true;

--- a/src/kOS.Safe/Persistence/IVolumeManager.cs
+++ b/src/kOS.Safe/Persistence/IVolumeManager.cs
@@ -20,6 +20,8 @@ namespace kOS.Safe.Persistence
         void SwitchTo(Volume volume);
         void UpdateVolumes(List<Volume> attachedVolumes);
         string GetVolumeBestIdentifier(Volume volume);
+        bool Copy(GlobalPath sourcePath, GlobalPath destinationPath);
+        void Move(GlobalPath sourcePath, GlobalPath destinationPath);
 
         /// <summary>
         /// This creates a proper, absolute GlobalPath from the given string (which is assumed to come from the user).

--- a/src/kOS.Safe/Persistence/IVolumeManager.cs
+++ b/src/kOS.Safe/Persistence/IVolumeManager.cs
@@ -7,7 +7,6 @@ namespace kOS.Safe.Persistence
         Dictionary<int, Volume> Volumes { get; }
         Volume CurrentVolume { get; }
         VolumeDirectory CurrentDirectory { get; set; }
-        float CurrentRequiredPower { get; }
         bool VolumeIsCurrent(Volume volume);
         int GetVolumeId(Volume volume);
         Volume GetVolume(object volumeId);

--- a/src/kOS.Safe/Persistence/IVolumeManager.cs
+++ b/src/kOS.Safe/Persistence/IVolumeManager.cs
@@ -20,8 +20,8 @@ namespace kOS.Safe.Persistence
         void SwitchTo(Volume volume);
         void UpdateVolumes(List<Volume> attachedVolumes);
         string GetVolumeBestIdentifier(Volume volume);
-        bool Copy(GlobalPath sourcePath, GlobalPath destinationPath);
-        void Move(GlobalPath sourcePath, GlobalPath destinationPath);
+        bool Copy(GlobalPath sourcePath, GlobalPath destinationPath, bool verifyFreeSpace = true);
+        bool Move(GlobalPath sourcePath, GlobalPath destinationPath);
 
         /// <summary>
         /// This creates a proper, absolute GlobalPath from the given string (which is assumed to come from the user).

--- a/src/kOS.Safe/Persistence/IVolumeManager.cs
+++ b/src/kOS.Safe/Persistence/IVolumeManager.cs
@@ -6,18 +6,32 @@ namespace kOS.Safe.Persistence
     {
         Dictionary<int, Volume> Volumes { get; }
         Volume CurrentVolume { get; }
+        VolumeDirectory CurrentDirectory { get; set; }
         float CurrentRequiredPower { get; }
         bool VolumeIsCurrent(Volume volume);
         int GetVolumeId(Volume volume);
         Volume GetVolume(object volumeId);
         Volume GetVolume(string name);
         Volume GetVolume(int id);
+        Volume GetVolumeFromPath(GlobalPath path);
         void Add(Volume volume);
         void Remove(string name);
         void Remove(int id);
         void SwitchTo(Volume volume);
         void UpdateVolumes(List<Volume> attachedVolumes);
         string GetVolumeBestIdentifier(Volume volume);
+
+        /// <summary>
+        /// This creates a proper, absolute GlobalPath from the given string (which is assumed to come from the user).
+        /// This handles absolute paths (for example 'volume:/some/path'), paths relative to current volume ('/some/path')
+        /// and paths relative to current directory ('../some/path', 'some/path').
+        ///
+        /// Relative paths need current volume and current directory for resolution, that's why this method is part of this
+        /// interface.
+        /// </summary>
+        /// <returns>GlobalPath instance</returns>
+        /// <param name="pathString">Path string.</param>
+        GlobalPath GlobalPathFromString(string pathString);
 
         /// <summary>
         /// Like GetVolumeBestIdentifier, but without the extra string formatting.

--- a/src/kOS.Safe/Persistence/IVolumeManager.cs
+++ b/src/kOS.Safe/Persistence/IVolumeManager.cs
@@ -24,16 +24,16 @@ namespace kOS.Safe.Persistence
         bool Move(GlobalPath sourcePath, GlobalPath destinationPath);
 
         /// <summary>
-        /// This creates a proper, absolute GlobalPath from the given string (which is assumed to come from the user).
-        /// This handles absolute paths (for example 'volume:/some/path'), paths relative to current volume ('/some/path')
-        /// and paths relative to current directory ('../some/path', 'some/path').
+        /// This creates a proper, absolute GlobalPath from the given object (which is assumed to come from the user).
+        /// This handles volumes, files, directories, absolute paths (for example 'volume:/some/path'),
+        /// paths relative to current volume ('/some/path') and paths relative to current directory ('../some/path', 'some/path').
         ///
         /// Relative paths need current volume and current directory for resolution, that's why this method is part of this
         /// interface.
         /// </summary>
         /// <returns>GlobalPath instance</returns>
         /// <param name="pathString">Path string.</param>
-        GlobalPath GlobalPathFromString(string pathString);
+        GlobalPath GlobalPathFromObject(object pathObject);
 
         /// <summary>
         /// Like GetVolumeBestIdentifier, but without the extra string formatting.

--- a/src/kOS.Safe/Persistence/PathValue.cs
+++ b/src/kOS.Safe/Persistence/PathValue.cs
@@ -71,6 +71,11 @@ namespace kOS.Safe
         {
             Path = GlobalPath.FromString(dump[DumpPath] as string);
         }
+
+        public override string ToString()
+        {
+            return Path.ToString();
+        }
     }
 }
 

--- a/src/kOS.Safe/Persistence/PathValue.cs
+++ b/src/kOS.Safe/Persistence/PathValue.cs
@@ -44,9 +44,9 @@ namespace kOS.Safe
             return new PathValue(path, sharedObjects);
         }
 
-        public PathValue FromPath(VolumePath volumePath, Volume volume)
+        public PathValue FromPath(VolumePath volumePath, string volumeId)
         {
-            return new PathValue(GlobalPath.FromVolumePath(volumePath, volume), sharedObjects);
+            return new PathValue(GlobalPath.FromVolumePath(volumePath, volumeId), sharedObjects);
         }
 
         private void InitializeSuffixes()

--- a/src/kOS.Safe/Persistence/PathValue.cs
+++ b/src/kOS.Safe/Persistence/PathValue.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using kOS.Safe.Serialization;
+using kOS.Safe.Persistence;
+using kOS.Safe.Encapsulation.Suffixes;
+using kOS.Safe.Encapsulation;
+using System.Linq;
+
+namespace kOS.Safe
+{
+    /// <summary>
+    /// Contains suffixes related to GlobalPath.
+    ///
+    /// This exists as a separate class because some of the suffixes require an instance of VolumeManager to work. I think
+    /// it would be counter-productive to pass around an instance of VolumeManager whenever we're dealing with GlobalPath internally.
+    /// Instances of this class are on the other hand created only for the user.
+    /// </summary>
+    [kOS.Safe.Utilities.KOSNomenclature("Path")]
+    public class PathValue : SerializableStructure, IHasSafeSharedObjects
+    {
+        private const string DumpPath = "path";
+
+        public GlobalPath Path { get; private set; }
+        private SafeSharedObjects sharedObjects;
+
+        public SafeSharedObjects Shared {
+            set {
+                sharedObjects = value;
+            }
+        }
+
+        public PathValue(GlobalPath path, SafeSharedObjects sharedObjects)
+        {
+            Path = path;
+            this.sharedObjects = sharedObjects;
+
+            InitializeSuffixes();
+        }
+
+        public PathValue FromPath(GlobalPath path)
+        {
+            return new PathValue(path, sharedObjects);
+        }
+
+        public PathValue FromPath(VolumePath volumePath, Volume volume)
+        {
+            return new PathValue(GlobalPath.FromVolumePath(volumePath, volume), sharedObjects);
+        }
+
+        private void InitializeSuffixes()
+        {
+            AddSuffix("VOLUME", new Suffix<Volume>(() => sharedObjects.VolumeMgr.GetVolumeFromPath(Path)));
+            AddSuffix("PARENT", new Suffix<PathValue>(() => FromPath(Path.GetParent())));
+            AddSuffix("ISPARENT", new OneArgsSuffix<BooleanValue, PathValue>((p) => Path.IsParent(p.Path)));
+            AddSuffix("ROOT", new Suffix<PathValue>(() => FromPath(Path.RootPath())));
+            AddSuffix("SEGMENTS", new Suffix<ListValue>(() => new ListValue(Path.Segments.Select((s) => (Structure)new StringValue(s)))));
+            AddSuffix("LENGTH", new Suffix<ScalarIntValue>(() => Path.Length));
+            AddSuffix("DEPTH", new Suffix<ScalarIntValue>(() => Path.Depth));
+            AddSuffix("NAME", new Suffix<StringValue>(() => Path.Name));
+            AddSuffix("HASEXTENSION", new Suffix<BooleanValue>(() => string.IsNullOrEmpty(Path.Extension)));
+            AddSuffix("EXTENSION", new Suffix<StringValue>(() => Path.Extension));
+            AddSuffix("CHANGEEXTENSION", new OneArgsSuffix<PathValue, StringValue>((e) => FromPath(Path.ChangeExtension(e))));
+            AddSuffix("COMBINE", new VarArgsSuffix<PathValue, StringValue>((segments) => FromPath(Path.Combine(segments.Cast<string>().ToArray()))));
+        }
+
+        public override Dump Dump()
+        {
+            return new Dump { { DumpPath, Path.ToString() } };
+        }
+
+        public override void LoadDump(Dump dump)
+        {
+            Path = GlobalPath.FromString(dump[DumpPath] as string);
+        }
+    }
+}
+

--- a/src/kOS.Safe/Persistence/PathValue.cs
+++ b/src/kOS.Safe/Persistence/PathValue.cs
@@ -59,7 +59,12 @@ namespace kOS.Safe
             AddSuffix("HASEXTENSION", new Suffix<BooleanValue>(() => string.IsNullOrEmpty(Path.Extension)));
             AddSuffix("EXTENSION", new Suffix<StringValue>(() => Path.Extension));
             AddSuffix("CHANGEEXTENSION", new OneArgsSuffix<PathValue, StringValue>((e) => FromPath(Path.ChangeExtension(e))));
-            AddSuffix("COMBINE", new VarArgsSuffix<PathValue, StringValue>((segments) => FromPath(Path.Combine(segments.Cast<string>().ToArray()))));
+            AddSuffix("COMBINE", new VarArgsSuffix<PathValue, StringValue>(Combine));
+        }
+
+        public PathValue Combine(params StringValue[] segments)
+        {
+            return FromPath(Path.Combine(segments.Cast<string>().ToArray()));
         }
 
         public override Dump Dump()

--- a/src/kOS.Safe/Persistence/PathValue.cs
+++ b/src/kOS.Safe/Persistence/PathValue.cs
@@ -52,15 +52,15 @@ namespace kOS.Safe
         private void InitializeSuffixes()
         {
             AddSuffix("VOLUME", new Suffix<Volume>(() => sharedObjects.VolumeMgr.GetVolumeFromPath(Path)));
-            AddSuffix("PARENT", new Suffix<PathValue>(() => FromPath(Path.GetParent())));
-            AddSuffix("ISPARENT", new OneArgsSuffix<BooleanValue, PathValue>((p) => Path.IsParent(p.Path)));
-            AddSuffix("ROOT", new Suffix<PathValue>(() => FromPath(Path.RootPath())));
             AddSuffix("SEGMENTS", new Suffix<ListValue>(() => new ListValue(Path.Segments.Select((s) => (Structure)new StringValue(s)))));
             AddSuffix("LENGTH", new Suffix<ScalarIntValue>(() => Path.Length));
-            AddSuffix("DEPTH", new Suffix<ScalarIntValue>(() => Path.Depth));
             AddSuffix("NAME", new Suffix<StringValue>(() => Path.Name));
             AddSuffix("HASEXTENSION", new Suffix<BooleanValue>(() => string.IsNullOrEmpty(Path.Extension)));
             AddSuffix("EXTENSION", new Suffix<StringValue>(() => Path.Extension));
+            AddSuffix("ROOT", new Suffix<PathValue>(() => FromPath(Path.RootPath())));
+            AddSuffix("PARENT", new Suffix<PathValue>(() => FromPath(Path.GetParent())));
+
+            AddSuffix("ISPARENT", new OneArgsSuffix<BooleanValue, PathValue>((p) => Path.IsParent(p.Path)));
             AddSuffix("CHANGEEXTENSION", new OneArgsSuffix<PathValue, StringValue>((e) => FromPath(Path.ChangeExtension(e))));
             AddSuffix("COMBINE", new VarArgsSuffix<PathValue, StringValue>(Combine));
         }

--- a/src/kOS.Safe/Persistence/PathValue.cs
+++ b/src/kOS.Safe/Persistence/PathValue.cs
@@ -61,6 +61,7 @@ namespace kOS.Safe
             AddSuffix("PARENT", new Suffix<PathValue>(() => FromPath(Path.GetParent())));
 
             AddSuffix("ISPARENT", new OneArgsSuffix<BooleanValue, PathValue>((p) => Path.IsParent(p.Path)));
+            AddSuffix("CHANGENAME", new OneArgsSuffix<PathValue, StringValue>((n) => FromPath(Path.ChangeName(n))));
             AddSuffix("CHANGEEXTENSION", new OneArgsSuffix<PathValue, StringValue>((e) => FromPath(Path.ChangeExtension(e))));
             AddSuffix("COMBINE", new VarArgsSuffix<PathValue, StringValue>(Combine));
         }

--- a/src/kOS.Safe/Persistence/PathValue.cs
+++ b/src/kOS.Safe/Persistence/PathValue.cs
@@ -28,12 +28,15 @@ namespace kOS.Safe
             }
         }
 
-        public PathValue(GlobalPath path, SafeSharedObjects sharedObjects)
+        public PathValue()
+        {
+            InitializeSuffixes();
+        }
+
+        public PathValue(GlobalPath path, SafeSharedObjects sharedObjects) : this()
         {
             Path = path;
             this.sharedObjects = sharedObjects;
-
-            InitializeSuffixes();
         }
 
         public PathValue FromPath(GlobalPath path)

--- a/src/kOS.Safe/Persistence/Volume.cs
+++ b/src/kOS.Safe/Persistence/Volume.cs
@@ -67,7 +67,7 @@ namespace kOS.Safe.Persistence
         /// </summary>
         /// <param name="name">filename to get.  if it has no filename extension, one will be guessed at, ".ks" usually.</param>
         /// <param name="ksmDefault">in the scenario where there is no filename extension, do we prefer the .ksm over the .ks?  The default is to prefer .ks</param>
-        /// <returns>the file</returns>
+        /// <returns>VolumeFile or VolumeDirectory. Null if not found.</returns>
         public abstract VolumeItem Open(VolumePath path, bool ksmDefault = false);
 
         public VolumeDirectory CreateDirectory(string pathString)
@@ -166,7 +166,7 @@ namespace kOS.Safe.Persistence
 
         public override string ToString()
         {
-            return "Volume( " + Name + ", " + Capacity + ")";
+            return "Volume(" + Name + ", " + Capacity + ")";
         }
 
         private void InitializeVolumeSuffixes()

--- a/src/kOS.Safe/Persistence/Volume.cs
+++ b/src/kOS.Safe/Persistence/Volume.cs
@@ -130,7 +130,7 @@ namespace kOS.Safe.Persistence
             return SaveFile(volumeFile.Path, volumeFile.ReadAll());
         }
 
-        public abstract VolumeFile SaveFile(VolumePath path, FileContent content);
+        public abstract VolumeFile SaveFile(VolumePath path, FileContent content, bool verifyFreeSpace = true);
 
         public bool IsRoomFor(VolumePath path, FileContent fileContent)
         {

--- a/src/kOS.Safe/Persistence/Volume.cs
+++ b/src/kOS.Safe/Persistence/Volume.cs
@@ -64,6 +64,13 @@ namespace kOS.Safe.Persistence
             return Open(VolumePath.FromString(pathString), ksmDefault);
         }
 
+        public Structure OpenSafe(string pathString, bool ksmDefault = false)
+        {
+            VolumeItem item = Open(VolumePath.FromString(pathString), ksmDefault);
+
+            return item != null ? (Structure)item : BooleanValue.False;
+        }
+
         /// <summary>
         /// Get a file given its name
         /// </summary>
@@ -183,7 +190,7 @@ namespace kOS.Safe.Persistence
             AddSuffix("FILES" , new Suffix<Lexicon>(ListAsLexicon));
             AddSuffix("CREATE" , new OneArgsSuffix<VolumeFile, StringValue>(path => CreateFile(path)));
             AddSuffix("CREATEDIR" , new OneArgsSuffix<VolumeDirectory, StringValue>(path => CreateDirectory(path)));
-            AddSuffix("OPEN" , new OneArgsSuffix<VolumeItem, StringValue>(path => Open(path)));
+            AddSuffix("OPEN" , new OneArgsSuffix<Structure, StringValue>(path => OpenSafe(path)));
             AddSuffix("DELETE" , new OneArgsSuffix<BooleanValue, StringValue>(path => Delete(path)));
         }
     }

--- a/src/kOS.Safe/Persistence/Volume.cs
+++ b/src/kOS.Safe/Persistence/Volume.cs
@@ -185,6 +185,7 @@ namespace kOS.Safe.Persistence
             AddSuffix("RENAMEABLE" , new Suffix<BooleanValue>(() => Renameable));
             AddSuffix("POWERREQUIREMENT" , new Suffix<ScalarValue>(() => RequiredPower()));
 
+            AddSuffix("ROOT" , new Suffix<VolumeDirectory>(() => Root));
             AddSuffix("EXISTS" , new OneArgsSuffix<BooleanValue, StringValue>(path => Exists(path)));
             AddSuffix("FILES" , new Suffix<Lexicon>(ListAsLexicon));
             AddSuffix("CREATE" , new OneArgsSuffix<VolumeFile, StringValue>(path => CreateFile(path)));

--- a/src/kOS.Safe/Persistence/Volume.cs
+++ b/src/kOS.Safe/Persistence/Volume.cs
@@ -130,7 +130,6 @@ namespace kOS.Safe.Persistence
         }
 
         public abstract bool Delete(VolumePath path, bool ksmDefault = false);
-        //public abstract void Move(VolumePath oldPath, VolumePath newPath);
 
         public VolumeFile SaveFile(VolumeFile volumeFile)
         {

--- a/src/kOS.Safe/Persistence/Volume.cs
+++ b/src/kOS.Safe/Persistence/Volume.cs
@@ -173,7 +173,7 @@ namespace kOS.Safe.Persistence
         {
             AddSuffix("FREESPACE" , new Suffix<ScalarValue>(() => FreeSpace));
             AddSuffix("CAPACITY" , new Suffix<ScalarValue>(() => Capacity));
-            AddSuffix("NAME" , new Suffix<StringValue>(() => Name));
+            AddSuffix("NAME" , new SetSuffix<StringValue>(() => Name, (newName) => Name = newName));
             AddSuffix("RENAMEABLE" , new Suffix<BooleanValue>(() => Renameable));
             AddSuffix("POWERREQUIREMENT" , new Suffix<ScalarValue>(() => RequiredPower()));
 

--- a/src/kOS.Safe/Persistence/Volume.cs
+++ b/src/kOS.Safe/Persistence/Volume.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
+using kOS.Safe.Exceptions;
 
 namespace kOS.Safe.Persistence
 {
@@ -15,16 +16,33 @@ namespace kOS.Safe.Persistence
         protected const float BASE_POWER = 0.04f;
         public const int INFINITE_CAPACITY = -1;
 
-        public abstract Dictionary<string, VolumeFile> FileList { get; }
-        public string Name { get; set; }
+        private string name;
+
+        public abstract VolumeDirectory Root { get; }
         public long Capacity { get; protected set; }
-        public abstract long Size { get; }
         public long FreeSpace {
             get {
                 return Capacity == INFINITE_CAPACITY ? INFINITE_CAPACITY : Capacity - Size;
             }
         }
+        public long Size {
+            get {
+                return Root.Size;
+            }
+        }
         public bool Renameable { get; protected set; }
+        public string Name {
+            get {
+                return name;
+            }
+            set {
+                if (Renameable) {
+                    name = value;
+                } else {
+                    throw new KOSException("Volume name can't be changed");
+                }
+            }
+        }
 
         protected Volume()
         {
@@ -34,48 +52,94 @@ namespace kOS.Safe.Persistence
             InitializeVolumeSuffixes();
         }
 
+        protected void InitializeName(string name)
+        {
+            this.name = name;
+        }
+
+        public VolumeItem Open(string pathString, bool ksmDefault = false)
+        {
+            return Open(VolumePath.FromString(pathString), ksmDefault);
+        }
+
         /// <summary>
         /// Get a file given its name
         /// </summary>
         /// <param name="name">filename to get.  if it has no filename extension, one will be guessed at, ".ks" usually.</param>
         /// <param name="ksmDefault">in the scenario where there is no filename extension, do we prefer the .ksm over the .ks?  The default is to prefer .ks</param>
         /// <returns>the file</returns>
-        public abstract VolumeFile Open(string name, bool ksmDefault = false);
+        public abstract VolumeItem Open(VolumePath path, bool ksmDefault = false);
 
-        public abstract VolumeFile Create(string name);
-
-        public abstract bool Exists(string name);
-
-        public VolumeFile OpenOrCreate(string name, bool ksmDefault = false)
+        public VolumeDirectory CreateDirectory(string pathString)
         {
-            var volumeFile = Open(name, ksmDefault);
-
-            if (volumeFile != null)
-            {
-                return volumeFile;
-            }
-
-            return Create(name);
+            return CreateDirectory(VolumePath.FromString(pathString));
         }
 
-        public abstract bool Delete(string name);
+        public abstract VolumeDirectory CreateDirectory(VolumePath path);
 
-        public abstract bool RenameFile(string name, string newName);
+        public VolumeFile CreateFile(string pathString)
+        {
+            return CreateFile(VolumePath.FromString(pathString));
+        }
 
-        //public abstract bool AppendToFile(string name, string textToAppend);
+        public abstract VolumeFile CreateFile(VolumePath path);
 
-        //public abstract bool AppendToFile(string name, byte[] bytesToAppend);
+        public VolumeDirectory OpenOrCreateDirectory(VolumePath path)
+        {
+            VolumeDirectory directory = Open(path) as VolumeDirectory;
+
+            if (directory == null)
+            {
+                directory = CreateDirectory(path);
+            }
+
+            return directory;
+        }
+
+        public VolumeFile OpenOrCreateFile(VolumePath path, bool ksmDefault = false)
+        {
+            VolumeFile file = Open(path, ksmDefault) as VolumeFile;
+
+            if (file == null)
+            {
+                file = CreateFile(path);
+            }
+
+            return file;
+        }
+
+        public bool Exists(string pathString, bool ksmDefault = false)
+        {
+            return Exists(VolumePath.FromString(pathString), ksmDefault);
+        }
+
+        public abstract bool Exists(VolumePath path, bool ksmDefault = false);
+
+        public bool Delete(string pathString, bool ksmDefault = false)
+        {
+            return Delete(VolumePath.FromString(pathString), ksmDefault);
+        }
+
+        public abstract bool Delete(VolumePath path, bool ksmDefault = false);
+        //public abstract void Move(VolumePath oldPath, VolumePath newPath);
 
         public VolumeFile Save(VolumeFile volumeFile)
         {
-            return Save(volumeFile.Name, volumeFile.ReadAll());
+            return Save(volumeFile.Path, volumeFile.ReadAll());
         }
 
-        public abstract VolumeFile Save(string name, FileContent content);
+        public abstract VolumeFile Save(VolumePath path, FileContent content);
 
-        public bool IsRoomFor(string name, FileContent fileContent)
+        public bool IsRoomFor(VolumePath path, FileContent fileContent)
         {
-            VolumeFile existingFile = Open(name);
+            VolumeItem existing = Open(path);
+
+            if (existing is VolumeDirectory)
+            {
+                throw new KOSPersistenceException("'" + path + "' is a directory");
+            }
+
+            VolumeFile existingFile = existing as VolumeFile;
 
             int usedByThisFile = 0;
 
@@ -95,6 +159,11 @@ namespace kOS.Safe.Persistence
             return powerRequired;
         }
 
+        public Lexicon ListAsLexicon()
+        {
+            return Root.ListAsLexicon();
+        }
+
         public override string ToString()
         {
             return "Volume( " + Name + ", " + Capacity + ")";
@@ -108,22 +177,12 @@ namespace kOS.Safe.Persistence
             AddSuffix("RENAMEABLE" , new Suffix<BooleanValue>(() => Renameable));
             AddSuffix("POWERREQUIREMENT" , new Suffix<ScalarValue>(() => RequiredPower()));
 
-            AddSuffix("EXISTS" , new OneArgsSuffix<BooleanValue, StringValue>(name => Exists(name)));
-            AddSuffix("FILES" , new Suffix<Lexicon>(BuildFileLexicon));
-            AddSuffix("CREATE" , new OneArgsSuffix<VolumeFile, StringValue>(name => Create(name)));
-            AddSuffix("OPEN" , new OneArgsSuffix<VolumeFile, StringValue>(name => Open(name)));
-            AddSuffix("DELETE" , new OneArgsSuffix<BooleanValue, StringValue>(name => Delete(name)));
+            AddSuffix("EXISTS" , new OneArgsSuffix<BooleanValue, StringValue>(path => Exists(path)));
+            AddSuffix("FILES" , new Suffix<Lexicon>(ListAsLexicon));
+            AddSuffix("CREATE" , new OneArgsSuffix<VolumeFile, StringValue>(path => CreateFile(path)));
+            AddSuffix("CREATEDIR" , new OneArgsSuffix<VolumeDirectory, StringValue>(path => CreateDirectory(path)));
+            AddSuffix("OPEN" , new OneArgsSuffix<VolumeItem, StringValue>(path => Open(path)));
+            AddSuffix("DELETE" , new OneArgsSuffix<BooleanValue, StringValue>(path => Delete(path)));
         }
-
-        private Lexicon BuildFileLexicon()
-        {
-            return new Lexicon(FileList.ToDictionary(item => FromPrimitiveWithAssert(item.Key), item => (Structure) item.Value));
-        }
-
-
-        private int FileInfoComparer(VolumeFile a, VolumeFile b)
-        {
-            return string.CompareOrdinal(a.Name, b.Name);
-        }
-    }    
+    }
 }

--- a/src/kOS.Safe/Persistence/Volume.cs
+++ b/src/kOS.Safe/Persistence/Volume.cs
@@ -57,6 +57,8 @@ namespace kOS.Safe.Persistence
             this.name = name;
         }
 
+        public abstract void Clear();
+
         public VolumeItem Open(string pathString, bool ksmDefault = false)
         {
             return Open(VolumePath.FromString(pathString), ksmDefault);
@@ -123,12 +125,12 @@ namespace kOS.Safe.Persistence
         public abstract bool Delete(VolumePath path, bool ksmDefault = false);
         //public abstract void Move(VolumePath oldPath, VolumePath newPath);
 
-        public VolumeFile Save(VolumeFile volumeFile)
+        public VolumeFile SaveFile(VolumeFile volumeFile)
         {
-            return Save(volumeFile.Path, volumeFile.ReadAll());
+            return SaveFile(volumeFile.Path, volumeFile.ReadAll());
         }
 
-        public abstract VolumeFile Save(VolumePath path, FileContent content);
+        public abstract VolumeFile SaveFile(VolumePath path, FileContent content);
 
         public bool IsRoomFor(VolumePath path, FileContent fileContent)
         {

--- a/src/kOS.Safe/Persistence/VolumeDirectory.cs
+++ b/src/kOS.Safe/Persistence/VolumeDirectory.cs
@@ -3,11 +3,12 @@ using kOS.Safe.Persistence;
 using System.Collections.Generic;
 using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
+using System.Collections;
 
 namespace kOS.Safe
 {
     [kOS.Safe.Utilities.KOSNomenclature("VolumeDirectory")]
-    public abstract class VolumeDirectory : VolumeItem
+    public abstract class VolumeDirectory : VolumeItem, IEnumerable<VolumeItem>
     {
         public VolumeDirectory(Volume volume, VolumePath path) : base(volume, path)
         {
@@ -27,6 +28,16 @@ namespace kOS.Safe
         }
 
         public abstract IDictionary<string, VolumeItem> List();
+
+        public IEnumerator<VolumeItem> GetEnumerator()
+        {
+            return List().Values.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
 
         private void InitializeSuffixes()
         {

--- a/src/kOS.Safe/Persistence/VolumeDirectory.cs
+++ b/src/kOS.Safe/Persistence/VolumeDirectory.cs
@@ -41,6 +41,7 @@ namespace kOS.Safe
 
         private void InitializeSuffixes()
         {
+            AddSuffix("ITERATOR", new NoArgsSuffix<Enumerator>(() => new Enumerator(GetEnumerator())));
             AddSuffix("LIST", new Suffix<Lexicon>(ListAsLexicon));
         }
     }

--- a/src/kOS.Safe/Persistence/VolumeDirectory.cs
+++ b/src/kOS.Safe/Persistence/VolumeDirectory.cs
@@ -6,6 +6,7 @@ using kOS.Safe.Encapsulation.Suffixes;
 
 namespace kOS.Safe
 {
+    [kOS.Safe.Utilities.KOSNomenclature("VolumeDirectory")]
     public abstract class VolumeDirectory : VolumeItem
     {
         public VolumeDirectory(Volume volume, VolumePath path) : base(volume, path)

--- a/src/kOS.Safe/Persistence/VolumeDirectory.cs
+++ b/src/kOS.Safe/Persistence/VolumeDirectory.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using kOS.Safe.Persistence;
+using System.Collections.Generic;
+using kOS.Safe.Encapsulation;
+using kOS.Safe.Encapsulation.Suffixes;
+
+namespace kOS.Safe
+{
+    public abstract class VolumeDirectory : VolumeItem
+    {
+        public VolumeDirectory(Volume volume, VolumePath path) : base(volume, path)
+        {
+            InitializeSuffixes();
+        }
+
+        public Lexicon ListAsLexicon()
+        {
+            Lexicon result = new Lexicon();
+
+            foreach (KeyValuePair<string, VolumeItem> entry in List())
+            {
+                result.Add(new StringValue(entry.Key), entry.Value);
+            }
+
+            return result;
+        }
+
+        public abstract IDictionary<string, VolumeItem> List();
+
+        private void InitializeSuffixes()
+        {
+            AddSuffix("LIST", new Suffix<Lexicon>(ListAsLexicon));
+        }
+    }
+}

--- a/src/kOS.Safe/Persistence/VolumeFile.cs
+++ b/src/kOS.Safe/Persistence/VolumeFile.cs
@@ -1,31 +1,15 @@
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Exceptions;
 using System.Linq;
-using kOS.Safe.Persistence;
+using kOS.Safe.Encapsulation;
 
-namespace kOS.Safe.Encapsulation
+namespace kOS.Safe.Persistence
 {
     [kOS.Safe.Utilities.KOSNomenclature("VolumeFile")]
-    public abstract class VolumeFile : Structure
+    public abstract class VolumeFile : VolumeItem
     {
-        public string Name { get; private set; }
-
-        public abstract int Size { get; }
-
-        public string Extension
+        protected VolumeFile(Volume volume, VolumePath path) : base(volume, path)
         {
-            get
-            {
-                var fileParts = Name.Split('.');
-
-                return fileParts.Length > 1 ? fileParts.Last() : string.Empty;
-            }
-        }
-
-        protected VolumeFile(string name)
-        {
-            Name = name;
-
             InitializeSuffixes();
         }
 
@@ -40,7 +24,7 @@ namespace kOS.Safe.Encapsulation
 
         public bool WriteLn(string content)
         {
-            return Write(content + FileContent.NEW_LINE);
+            return Write(content + FileContent.NewLine);
         }
 
         public abstract void Clear();
@@ -52,10 +36,6 @@ namespace kOS.Safe.Encapsulation
 
         private void InitializeSuffixes()
         {
-            AddSuffix("NAME", new Suffix<StringValue>(() => Name));
-            AddSuffix("SIZE", new Suffix<ScalarIntValue>(() => new ScalarIntValue(Size)));
-            AddSuffix("EXTENSION", new Suffix<StringValue>(() => Extension));
-
             AddSuffix("READALL", new Suffix<FileContent>(ReadAll));
             AddSuffix("WRITE", new OneArgsSuffix<BooleanValue, Structure>(str => WriteObject(str)));
             AddSuffix("WRITELN", new OneArgsSuffix<BooleanValue, StringValue>(str => new BooleanValue(WriteLn(str))));

--- a/src/kOS.Safe/Persistence/VolumeItem.cs
+++ b/src/kOS.Safe/Persistence/VolumeItem.cs
@@ -47,6 +47,7 @@ namespace kOS.Safe.Persistence
             AddSuffix("NAME", new Suffix<StringValue>(() => Name));
             AddSuffix("SIZE", new Suffix<ScalarIntValue>(() => new ScalarIntValue(Size)));
             AddSuffix("EXTENSION", new Suffix<StringValue>(() => Extension));
+            AddSuffix("ISFILE", new Suffix<BooleanValue>(() => this is VolumeFile));
         }
 
         public override string ToString()

--- a/src/kOS.Safe/Persistence/VolumeItem.cs
+++ b/src/kOS.Safe/Persistence/VolumeItem.cs
@@ -30,12 +30,16 @@ namespace kOS.Safe.Persistence
         {
             Volume = volume;
             Path = path;
+
+            InitializeSuffixes();
         }
 
         public VolumeItem(Volume volume, VolumePath parentPath, String name)
         {
             Volume = volume;
             Path = VolumePath.FromString(name, parentPath);
+
+            InitializeSuffixes();
         }
 
         private void InitializeSuffixes()

--- a/src/kOS.Safe/Persistence/VolumeItem.cs
+++ b/src/kOS.Safe/Persistence/VolumeItem.cs
@@ -53,7 +53,7 @@ namespace kOS.Safe.Persistence
 
         public override string ToString()
         {
-            return Path.ToString();
+            return string.IsNullOrEmpty(Path.Name) ? "Root directory" : Path.Name;
         }
 
         public abstract int Size { get; }

--- a/src/kOS.Safe/Persistence/VolumeItem.cs
+++ b/src/kOS.Safe/Persistence/VolumeItem.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using kOS.Safe.Persistence;
+using System.Linq;
+using kOS.Safe.Encapsulation;
+using kOS.Safe.Encapsulation.Suffixes;
+
+namespace kOS.Safe.Persistence
+{
+    public abstract class VolumeItem : Structure
+    {
+        public Volume Volume { get; set; }
+        public VolumePath Path { get; set; }
+
+        public string Name
+        {
+            get
+            {
+                return Path.Name;
+            }
+        }
+
+        public string Extension {
+            get
+            {
+                var fileParts = Name.Split('.');
+                return fileParts.Count() > 1 ? fileParts.Last() : string.Empty;
+            }
+        }
+
+        public VolumeItem(Volume volume, VolumePath path)
+        {
+            Volume = volume;
+            Path = path;
+        }
+
+        public VolumeItem(Volume volume, VolumePath parentPath, String name)
+        {
+            Volume = volume;
+            Path = VolumePath.FromString(name, parentPath);
+        }
+
+        private void InitializeSuffixes()
+        {
+            AddSuffix("NAME", new Suffix<StringValue>(() => Name));
+            AddSuffix("SIZE", new Suffix<ScalarIntValue>(() => new ScalarIntValue(Size)));
+            AddSuffix("EXTENSION", new Suffix<StringValue>(() => Extension));
+        }
+
+        public override string ToString()
+        {
+            return Path.ToString();
+        }
+
+        public abstract int Size { get; }
+    }
+}
+

--- a/src/kOS.Safe/Persistence/VolumeItem.cs
+++ b/src/kOS.Safe/Persistence/VolumeItem.cs
@@ -22,8 +22,7 @@ namespace kOS.Safe.Persistence
         public string Extension {
             get
             {
-                var fileParts = Name.Split('.');
-                return fileParts.Count() > 1 ? fileParts.Last() : string.Empty;
+                return Path.Extension;
             }
         }
 

--- a/src/kOS.Safe/Persistence/VolumeItem.cs
+++ b/src/kOS.Safe/Persistence/VolumeItem.cs
@@ -6,6 +6,7 @@ using kOS.Safe.Encapsulation.Suffixes;
 
 namespace kOS.Safe.Persistence
 {
+    [kOS.Safe.Utilities.KOSNomenclature("VolumeItem")]
     public abstract class VolumeItem : Structure
     {
         public Volume Volume { get; set; }

--- a/src/kOS.Safe/Persistence/VolumeManager.cs
+++ b/src/kOS.Safe/Persistence/VolumeManager.cs
@@ -8,16 +8,8 @@ namespace kOS.Safe.Persistence
     public class VolumeManager : IVolumeManager
     {
         private readonly Dictionary<int, Volume> volumes;
-        public virtual Volume CurrentVolume { get; private set; }
-        public VolumeDirectory CurrentDirectory { get
-            {
-                return CurrentDirectory;
-            }
-            set {
-                CurrentDirectory = value;
-                CurrentVolume = value.Volume;
-            }
-        }
+        public virtual Volume CurrentVolume { get { return CurrentDirectory != null ? CurrentDirectory.Volume : null; } }
+        public VolumeDirectory CurrentDirectory { get; set; }
         private int lastId;
         
         public Dictionary<int, Volume> Volumes { get { return volumes; } }
@@ -26,7 +18,6 @@ namespace kOS.Safe.Persistence
         public VolumeManager()
         {
             volumes = new Dictionary<int, Volume>();
-            CurrentVolume = null;
             CurrentDirectory = null;
         }
 
@@ -108,9 +99,9 @@ namespace kOS.Safe.Persistence
             {
                 volumes.Add(lastId++, volume);
 
-                if (CurrentVolume == null)
+                if (CurrentDirectory == null)
                 {
-                    CurrentVolume = volumes[0];
+                    CurrentDirectory = volumes[0].Root;
                     UpdateRequiredPower();
                 }
             }
@@ -133,12 +124,12 @@ namespace kOS.Safe.Persistence
                 {
                     if (volumes.Count > 0)
                     {
-                        CurrentVolume = volumes[0];
+                        CurrentDirectory = volumes[0].Root;
                         UpdateRequiredPower();
                     }
                     else
                     {
-                        CurrentVolume = null;
+                        CurrentDirectory = null;
                     }
                 }
             }
@@ -146,7 +137,6 @@ namespace kOS.Safe.Persistence
 
         public void SwitchTo(Volume volume)
         {
-            CurrentVolume = volume;
             CurrentDirectory = volume.Root;
             UpdateRequiredPower();
         }

--- a/src/kOS.Safe/Persistence/VolumeManager.cs
+++ b/src/kOS.Safe/Persistence/VolumeManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using kOS.Safe.Encapsulation;
 using kOS.Safe.Exceptions;
+using kOS.Safe.Utilities;
 
 namespace kOS.Safe.Persistence
 {
@@ -186,8 +187,27 @@ namespace kOS.Safe.Persistence
             return !string.IsNullOrEmpty(volume.Name) ? volume.Name : id.ToString();
         }
 
+        // Volumes, VolumeItems and strings
+        public GlobalPath GlobalPathFromObject(object pathObject)
+        {
+            if (pathObject is Volume)
+            {
+                GlobalPath p = GlobalPath.FromVolumePath(VolumePath.EMPTY, GetVolumeRawIdentifier(pathObject as Volume));
+                SafeHouse.Logger.Log("Path from volume: " + p);
+                return p;
+            } else if (pathObject is VolumeItem)
+            {
+                VolumeItem volumeItem = pathObject as VolumeItem;
+                return GlobalPath.FromVolumePath(volumeItem.Path, GetVolumeRawIdentifier(volumeItem.Volume));
+            } else
+            {
+                return GlobalPathFromString(pathObject.ToString());
+            }
+
+        }
+
         // Handles global, absolute and relative paths
-        public GlobalPath GlobalPathFromString(string pathString)
+        private GlobalPath GlobalPathFromString(string pathString)
         {
             if (GlobalPath.HasVolumeId(pathString))
             {

--- a/src/kOS.Safe/Persistence/VolumeManager.cs
+++ b/src/kOS.Safe/Persistence/VolumeManager.cs
@@ -196,10 +196,12 @@ namespace kOS.Safe.Persistence
             {
                 if (GlobalPath.IsAbsolute(pathString))
                 {
-                    return GlobalPath.FromVolumePath(VolumePath.FromString(pathString), CurrentVolume);
+                    return GlobalPath.FromVolumePath(VolumePath.FromString(pathString),
+                        GetVolumeRawIdentifier(CurrentVolume));
                 } else
                 {
-                    return GlobalPath.FromStringAndBase(pathString, GlobalPath.FromVolumePath(CurrentDirectory.Path, CurrentVolume));
+                    return GlobalPath.FromStringAndBase(pathString, GlobalPath.FromVolumePath(CurrentDirectory.Path,
+                        GetVolumeRawIdentifier(CurrentVolume)));
                 }
             }
 

--- a/src/kOS.Safe/Persistence/VolumeManager.cs
+++ b/src/kOS.Safe/Persistence/VolumeManager.cs
@@ -274,12 +274,18 @@ namespace kOS.Safe.Persistence
 
             if (destinationVolume.Exists(destinationPath))
             {
-                destinationPath = destinationPath.Combine(sourcePath.Name);
-                destination = destinationVolume.CreateDirectory(destinationPath);
+                if (!destinationPath.IsRoot || !sourcePath.IsRoot)
+                {
+                    destinationPath = destinationPath.Combine(sourcePath.Name);
+                    destination = destinationVolume.CreateDirectory(destinationPath);
+                } else
+                {
+                    destination = destinationVolume.Open(destinationPath) as VolumeDirectory;
+                }
 
                 if (destination == null)
                 {
-                    throw new KOSException("Path was expected to point to a directory: " + destinationPath);
+                    throw new KOSException ("Path was expected to point to a directory: " + destinationPath);
                 }
             } else
             {

--- a/src/kOS.Safe/Persistence/VolumeManager.cs
+++ b/src/kOS.Safe/Persistence/VolumeManager.cs
@@ -244,6 +244,20 @@ namespace kOS.Safe.Persistence
                     throw new KOSPersistenceException("Can't copy directory into a file");
                 }
 
+                if (destination == null)
+                {
+                    destination = destinationVolume.CreateDirectory(destinationPath);
+                } else if (!sourcePath.IsRoot)
+                {
+                    destinationPath = destinationPath.Combine(sourcePath.Name);
+                    destination = destinationVolume.CreateDirectory(destinationPath);
+                }
+
+                if (destination == null)
+                {
+                    throw new KOSException("Path was expected to point to a directory: " + destinationPath);
+                }
+
                 return CopyDirectory(sourcePath, destinationPath, verifyFreeSpace);
             } else
             {
@@ -270,24 +284,16 @@ namespace kOS.Safe.Persistence
 
             VolumeDirectory source = sourceVolume.Open(sourcePath) as VolumeDirectory;
 
-            VolumeDirectory destination;
+            VolumeItem destinationItem = destinationVolume.Open(destinationPath);
 
-            if (destinationVolume.Exists(destinationPath))
+            if (destinationItem is VolumeFile)
             {
-                if (!destinationPath.IsRoot || !sourcePath.IsRoot)
-                {
-                    destinationPath = destinationPath.Combine(sourcePath.Name);
-                    destination = destinationVolume.CreateDirectory(destinationPath);
-                } else
-                {
-                    destination = destinationVolume.Open(destinationPath) as VolumeDirectory;
-                }
+                throw new KOSPersistenceException("Can't copy directory into a file");
+            }
 
-                if (destination == null)
-                {
-                    throw new KOSException ("Path was expected to point to a directory: " + destinationPath);
-                }
-            } else
+            VolumeDirectory destination = destinationItem as VolumeDirectory;
+
+            if (destination == null)
             {
                 destination = destinationVolume.CreateDirectory(destinationPath);
             }

--- a/src/kOS.Safe/Persistence/VolumeManager.cs
+++ b/src/kOS.Safe/Persistence/VolumeManager.cs
@@ -250,7 +250,7 @@ namespace kOS.Safe.Persistence
                 } else if (!sourcePath.IsRoot)
                 {
                     destinationPath = destinationPath.Combine(sourcePath.Name);
-                    destination = destinationVolume.CreateDirectory(destinationPath);
+                    destination = destinationVolume.OpenOrCreateDirectory(destinationPath);
                 }
 
                 if (destination == null)
@@ -335,6 +335,11 @@ namespace kOS.Safe.Persistence
 
         public bool Move(GlobalPath sourcePath, GlobalPath destinationPath)
         {
+            if (sourcePath.IsRoot)
+            {
+                throw new KOSPersistenceException("Can't move root directory: " + sourcePath);
+            }
+
             if (sourcePath.IsParent(destinationPath))
             {
                 throw new KOSPersistenceException("Can't move directory to a subdirectory of itself: " + destinationPath);

--- a/src/kOS.Safe/Persistence/VolumeManager.cs
+++ b/src/kOS.Safe/Persistence/VolumeManager.cs
@@ -14,7 +14,6 @@ namespace kOS.Safe.Persistence
         private int lastId;
 
         public Dictionary<int, Volume> Volumes { get { return volumes; } }
-        public float CurrentRequiredPower { get; private set; }
 
         public VolumeManager()
         {
@@ -103,7 +102,6 @@ namespace kOS.Safe.Persistence
                 if (CurrentDirectory == null)
                 {
                     CurrentDirectory = volumes[0].Root;
-                    UpdateRequiredPower();
                 }
             }
         }
@@ -126,7 +124,6 @@ namespace kOS.Safe.Persistence
                     if (volumes.Count > 0)
                     {
                         CurrentDirectory = volumes[0].Root;
-                        UpdateRequiredPower();
                     }
                     else
                     {
@@ -139,7 +136,6 @@ namespace kOS.Safe.Persistence
         public void SwitchTo(Volume volume)
         {
             CurrentDirectory = volume.Root;
-            UpdateRequiredPower();
         }
 
         public void UpdateVolumes(List<Volume> attachedVolumes)
@@ -237,11 +233,6 @@ namespace kOS.Safe.Persistence
             }
 
             return volume;
-        }
-
-        private void UpdateRequiredPower()
-        {
-            CurrentRequiredPower = (float)Math.Round(CurrentVolume.RequiredPower(), 4);
         }
 
         public bool Copy(GlobalPath sourcePath, GlobalPath destinationPath, bool verifyFreeSpace = true)

--- a/src/kOS.Safe/Persistence/VolumePath.cs
+++ b/src/kOS.Safe/Persistence/VolumePath.cs
@@ -88,6 +88,11 @@ namespace kOS.Safe.Persistence
             return pathString.StartsWith(PathSeparator.ToString());
         }
 
+        public VolumePath Combine(params string[] segments)
+        {
+            return new VolumePath(Segments.Concat(segments));
+        }
+
         public static VolumePath FromString(string pathString, VolumePath basePath)
         {
             if (IsAbsolute(pathString))

--- a/src/kOS.Safe/Persistence/VolumePath.cs
+++ b/src/kOS.Safe/Persistence/VolumePath.cs
@@ -31,6 +31,15 @@ namespace kOS.Safe.Persistence
         }
 
         /// <summary>
+        /// True if path is a root path.
+        /// </summary>
+        public bool IsRoot {
+            get {
+                return Segments.Count == 0;
+            }
+        }
+
+        /// <summary>
         /// Depth of the path. Same as Length if the path does not contain any '..'.
         /// </summary>
         public int Depth {

--- a/src/kOS.Safe/Persistence/VolumePath.cs
+++ b/src/kOS.Safe/Persistence/VolumePath.cs
@@ -145,6 +145,11 @@ namespace kOS.Safe.Persistence
 
             for (int i = 0; i < Segments.Count; i++)
             {
+                if (Segments[i].Contains(PathSeparator))
+                {
+                    throw new KOSInvalidPathException("Segment can't contain '" + PathSeparator + "'", Segments[i]);
+                }
+
                 if (Segments[i].Equals(UpSegment) && newSegments.Count != 0 && !newSegments.Last().Equals(UpSegment))
                 {
                     newSegments.RemoveAt(newSegments.Count() - 1);

--- a/src/kOS.Safe/Persistence/VolumePath.cs
+++ b/src/kOS.Safe/Persistence/VolumePath.cs
@@ -154,6 +154,10 @@ namespace kOS.Safe.Persistence
 
             for (int i = 0; i < Segments.Count; i++)
             {
+                if (string.IsNullOrEmpty(Segments[i])) {
+                    continue;
+                }
+
                 if (Segments[i].Contains(PathSeparator))
                 {
                     throw new KOSInvalidPathException("Segment can't contain '" + PathSeparator + "'", Segments[i]);

--- a/src/kOS.Safe/Persistence/VolumePath.cs
+++ b/src/kOS.Safe/Persistence/VolumePath.cs
@@ -1,0 +1,192 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using System.Linq;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using kOS.Safe.Exceptions;
+
+namespace kOS.Safe.Persistence
+{
+    /// <summary>
+    /// Represents the location of a directory or a file inside a volume.
+    /// </summary>
+    public class VolumePath
+    {
+        public static VolumePath EMPTY = new VolumePath();
+
+        public const char PathSeparator = '/';
+        public const string UpSegment = "..";
+        public const int MaxSegmentLength = 255;
+        public const string SegmentRegexString = @"\A[^/]+\Z";
+        private static readonly Regex segmentRegex = new Regex(SegmentRegexString);
+
+        /// <summary>
+        /// Number of segments in the path.
+        /// </summary>
+        public int Length {
+            get {
+                return Segments.Count;
+            }
+        }
+
+        /// <summary>
+        /// Depth of the path. Same as Length if the path does not contain any '..'.
+        /// </summary>
+        public int Depth {
+            get {
+                int upSegments = Segments.Count(s => s.Equals(UpSegment));
+                return Length - 2 * upSegments;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="kOS.Safe.Persistence.VolumePath"/> points outside of this volume.
+        /// </summary>
+        public bool PointsOutside {
+            get {
+                return Segments.Count > 0 && Segments[0].Equals(UpSegment);
+            }
+        }
+
+        /// <summary>
+        /// Gets the name.
+        /// </summary>
+        public string Name {
+            get {
+                return Segments.Count > 0 ? Segments.Last() : null;
+            }
+        }
+
+        /// <summary>
+        /// Gets this path's segments.
+        /// </summary>
+        public List<string> Segments { get; private set; }
+
+        public static bool IsValidSegment(string segment)
+        {
+            return segment.Length > 0 && segment.Length <= MaxSegmentLength && segmentRegex.IsMatch(segment);
+        }
+
+        /// <summary>
+        /// Determines if a string represents an absolute path.
+        /// </summary>
+        public static Boolean IsAbsolute(String pathString)
+        {
+            return pathString.StartsWith(PathSeparator.ToString());
+        }
+
+        public static VolumePath FromString(string pathString, VolumePath basePath)
+        {
+            if (IsAbsolute(pathString))
+            {
+                throw new KOSInvalidPathException("Relative path expected", pathString);
+            }
+
+            List<string> mergedSegments = new List<string>();
+            mergedSegments.AddRange(basePath.Segments);
+            mergedSegments.AddRange(GetSegmentsFromString(pathString));
+
+            return new VolumePath(mergedSegments);
+        }
+
+        public static VolumePath FromString(string pathString)
+        {
+            if (!pathString.StartsWith(PathSeparator.ToString()))
+            {
+                throw new KOSInvalidPathException("Absolute path expected", pathString);
+            }
+
+            return new VolumePath(GetSegmentsFromString(pathString));
+        }
+
+        protected static List<string> GetSegmentsFromString(string pathString)
+        {
+            IEnumerable<string> segments = pathString.Split(PathSeparator).Where((s) => !String.IsNullOrEmpty(s));
+
+            foreach (string segment in segments)
+            {
+                if (!IsValidSegment(segment))
+                {
+                    throw new KOSInvalidPathException("Invalid path segment: '" + segment + "'", pathString);
+                }
+            }
+
+            return new List<string>(segments);
+        }
+
+        private VolumePath()
+        {
+            this.Segments = new List<string>();
+        }
+
+        protected VolumePath(List<string> segments)
+        {
+            this.Segments = segments;
+
+            Canonicalize();
+        }
+
+        private void Canonicalize()
+        {
+            List<string> newSegments = new List<string>();
+
+            for (int i = 0; i < Segments.Count; i++)
+            {
+                if (Segments[i].Equals(UpSegment) && newSegments.Count != 0 && !newSegments.Last().Equals(UpSegment))
+                {
+                    newSegments.RemoveAt(newSegments.Count() - 1);
+                }
+                else
+                {
+                    newSegments.Add(Segments[i]);
+                }
+            }
+
+            Segments = newSegments;
+
+            if (PointsOutside)
+            {
+                throw new KOSInvalidPathException("This path points to something outside of volume", ToString());
+            }
+        }
+
+        public VolumePath GetParent()
+        {
+            if (Depth < 1)
+            {
+                throw new KOSException("This path does not have a parent");
+            }
+
+            return new VolumePath(new List<string>(Segments.Take(Segments.Count - 1)));
+        }
+
+        public bool IsParent(VolumePath path)
+        {
+            return path.Segments.Count > Segments.Count && path.Segments.GetRange(0, Segments.Count).SequenceEqual(Segments);
+        }
+
+        public override int GetHashCode()
+        {
+            return Segments.Aggregate(1, (i, s) => i + s.GetHashCode());
+        }
+
+        public override bool Equals(object other)
+        {
+            VolumePath otherPath = other as VolumePath;
+
+            if (otherPath == null)
+            {
+                return false;
+            }
+
+            return Segments.SequenceEqual(otherPath.Segments);
+        }
+
+        public override string ToString()
+        {
+            return "/" + String.Join("/", Segments.ToArray());
+        }
+
+    }
+}
+

--- a/src/kOS.Safe/Persistence/VolumePath.cs
+++ b/src/kOS.Safe/Persistence/VolumePath.cs
@@ -54,7 +54,7 @@ namespace kOS.Safe.Persistence
         /// </summary>
         public string Name {
             get {
-                return Segments.Count > 0 ? Segments.Last() : null;
+                return Segments.Count > 0 ? Segments.Last() : string.Empty;
             }
         }
 

--- a/src/kOS.Safe/Persistence/VolumePath.cs
+++ b/src/kOS.Safe/Persistence/VolumePath.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using kOS.Safe.Exceptions;
+using kOS.Safe.Encapsulation;
 
 namespace kOS.Safe.Persistence
 {
@@ -54,6 +55,18 @@ namespace kOS.Safe.Persistence
         public string Name {
             get {
                 return Segments.Count > 0 ? Segments.Last() : null;
+            }
+        }
+
+        public string Extension {
+            get {
+                if (Name == null)
+                {
+                    return null;
+                }
+
+                var nameParts = Name.Split('.');
+                return nameParts.Count() > 1 ? nameParts.Last() : string.Empty;
             }
         }
 
@@ -114,14 +127,14 @@ namespace kOS.Safe.Persistence
             return new List<string>(segments);
         }
 
-        private VolumePath()
+        protected VolumePath()
         {
             this.Segments = new List<string>();
         }
 
-        protected VolumePath(List<string> segments)
+        protected VolumePath(IEnumerable<string> segments)
         {
-            this.Segments = segments;
+            this.Segments = new List<string>(segments);
 
             Canonicalize();
         }

--- a/src/kOS.Safe/Persistence/VolumePath.cs
+++ b/src/kOS.Safe/Persistence/VolumePath.cs
@@ -109,11 +109,6 @@ namespace kOS.Safe.Persistence
 
         public static VolumePath FromString(string pathString)
         {
-            if (!pathString.StartsWith(PathSeparator.ToString()))
-            {
-                throw new KOSInvalidPathException("Absolute path expected", pathString);
-            }
-
             return new VolumePath(GetSegmentsFromString(pathString));
         }
 

--- a/src/kOS.Safe/SafeSharedObjects.cs
+++ b/src/kOS.Safe/SafeSharedObjects.cs
@@ -9,12 +9,12 @@ using kOS.Safe.Sound;
 
 namespace kOS.Safe
 {
-    public class SharedObjects
+    public class SafeSharedObjects
     {
         public ICpu Cpu { get; set; }
         public IScreenBuffer Screen { get; set; }
         public IInterpreter Interpreter { get; set; }
-        public IBindingManager BindingMgr { get; set; }  
+        public IBindingManager BindingMgr { get; set; }
         public Script ScriptHandler { get; set; }
         public ILogger Logger { get; set; }
         public IProcessor Processor { get; set; }

--- a/src/kOS.Safe/Screen/ITermWindow.cs
+++ b/src/kOS.Safe/Screen/ITermWindow.cs
@@ -4,7 +4,7 @@ namespace kOS.Safe.Screen
 {
     public interface ITermWindow
     {
-        void OpenPopupEditor( Volume v, string fName );
+        void OpenPopupEditor(Volume v, GlobalPath path);
         void Open();
         void Close();
         void Toggle();

--- a/src/kOS.Safe/Serialization/IHasSafeSharedObjects.cs
+++ b/src/kOS.Safe/Serialization/IHasSafeSharedObjects.cs
@@ -8,7 +8,7 @@ namespace kOS.Safe.Serialization
     /// kOS has 2 versions of SharedObjects, one from kOS and one from kOS.Safe. SerializationMgr will automatically supply an instance of
     /// kOS.SharedObjects to any Structures that implements IHasSharedObjects during deserialization. However not all classes that are serializable
     /// and require SharedObjects need the kOS version, some (for example GlobalPath) need only the lighter kOS.Safe version. SafeSerializationMgr
-    /// and SerializationMgr will both will both now supply an instance of kOS.Safe.SharedObjects to classes that implement this interface.
+    /// and SerializationMgr will both now supply an instance of kOS.Safe.SharedObjects to classes that implement this interface.
     /// </summary>
     public interface IHasSafeSharedObjects
     {

--- a/src/kOS.Safe/Serialization/IHasSafeSharedObjects.cs
+++ b/src/kOS.Safe/Serialization/IHasSafeSharedObjects.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace kOS.Safe.Serialization
+{
+    /// <summary>
+    /// This exists so that we can keep some of the classes that depend on SharedObjects in kOS.Safe.
+    ///
+    /// kOS has 2 versions of SharedObjects, one from kOS and one from kOS.Safe. SerializationMgr will automatically supply an instance of
+    /// kOS.SharedObjects to any Structures that implements IHasSharedObjects during deserialization. However not all classes that are serializable
+    /// and require SharedObjects need the kOS version, some (for example GlobalPath) need only the lighter kOS.Safe version. SafeSerializationMgr
+    /// and SerializationMgr will both will both now supply an instance of kOS.Safe.SharedObjects to classes that implement this interface.
+    /// </summary>
+    public interface IHasSafeSharedObjects
+    {
+        SafeSharedObjects Shared { set; }
+    }
+}
+

--- a/src/kOS.Safe/Serialization/JSONFormatter.cs
+++ b/src/kOS.Safe/Serialization/JSONFormatter.cs
@@ -112,7 +112,7 @@ namespace kOS.Safe.Serialization
                         sb.Append(ch);
                         if (!quoted)
                         {
-                            sb.Append(FileContent.NEW_LINE);
+                            sb.Append(FileContent.NewLine);
                             Enumerable.Range(0, ++indent).ForEach(item => sb.Append(INDENT_STRING));
                         }
                         break;
@@ -120,7 +120,7 @@ namespace kOS.Safe.Serialization
                     case ']':
                         if (!quoted)
                         {
-                            sb.Append(FileContent.NEW_LINE);
+                            sb.Append(FileContent.NewLine);
                             Enumerable.Range(0, --indent).ForEach(item => sb.Append(INDENT_STRING));
                         }
                         sb.Append(ch);
@@ -138,7 +138,7 @@ namespace kOS.Safe.Serialization
                         sb.Append(ch);
                         if (!quoted)
                         {
-                            sb.Append(FileContent.NEW_LINE);
+                            sb.Append(FileContent.NewLine);
                             Enumerable.Range(0, indent).ForEach(item => sb.Append(INDENT_STRING));
                         }
                         break;

--- a/src/kOS.Safe/Serialization/SafeSerializationMgr.cs
+++ b/src/kOS.Safe/Serialization/SafeSerializationMgr.cs
@@ -12,6 +12,13 @@ namespace kOS.Safe.Serialization
         public static string TYPE_KEY = "$type";
         private static HashSet<string> assemblies = new HashSet<string>();
 
+        private readonly SafeSharedObjects safeSharedObjects;
+
+        public SafeSerializationMgr(SafeSharedObjects sharedObjects)
+        {
+            this.safeSharedObjects = sharedObjects;
+        }
+
         public static void AddAssembly(string assembly)
         {
             assemblies.Add(assembly);
@@ -131,7 +138,15 @@ namespace kOS.Safe.Serialization
                 }
             }
 
-            return Activator.CreateInstance(deserializedType) as IDumper;
+            IDumper instance = Activator.CreateInstance(deserializedType) as IDumper;
+
+            if (instance is IHasSafeSharedObjects)
+            {
+                IHasSafeSharedObjects withSharedObjects = instance as IHasSafeSharedObjects;
+                withSharedObjects.Shared = safeSharedObjects;
+            }
+
+            return instance;
         }
 
         public IDumper Deserialize(string input, IFormatReader formatter)

--- a/src/kOS.Safe/Utilities/Debug.cs
+++ b/src/kOS.Safe/Utilities/Debug.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Runtime.Serialization;
 using kOS.Safe.Compilation;
+using kOS.Safe.Persistence;
 
 namespace kOS.Safe.Utilities
 {
@@ -80,7 +81,7 @@ namespace kOS.Safe.Utilities
             for (int index = 0; index < codes.Count; index++)
             {
                 codeFragment.Add(string.Format(FORMAT_STR,
-                                               codes[index].SourceName ?? "null",
+                                               codes[index].SourcePath ?? GlobalPath.EMPTY,
                                                codes[index].SourceLine,
                                                codes[index].SourceColumn ,
                                                index,

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -240,6 +240,9 @@
     <Compile Include="Serialization\IDumper.cs" />
     <Compile Include="Communication\GenericMessageQueue.cs" />
     <Compile Include="Exceptions\KOSCommunicationException.cs" />
+    <Compile Include="Persistence\GlobalPath.cs" />
+    <Compile Include="Persistence\VolumePath.cs" />
+    <Compile Include="Exceptions\KOSInvalidPathException.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Compilation\CompiledObject-doc.md" />

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -37,6 +37,8 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <WarningLevel>4</WarningLevel>
+    <Optimize>false</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ICSharpCode.SharpZipLib">
@@ -230,9 +232,6 @@
     <Compile Include="Serialization\DumpWithHeader.cs" />
     <Compile Include="Serialization\SerializableStructure.cs" />
     <Compile Include="Persistence\FileContent.cs" />
-    <Compile Include="Encapsulation\VolumeFile.cs" />
-    <Compile Include="Encapsulation\ArchiveFile.cs" />
-    <Compile Include="Encapsulation\HarddiskFile.cs" />
     <Compile Include="Encapsulation\PrimitiveStructure.cs" />
     <Compile Include="Communication\Connection.cs" />
     <Compile Include="Communication\CurrentTimeProvider.cs" />
@@ -243,6 +242,13 @@
     <Compile Include="Persistence\GlobalPath.cs" />
     <Compile Include="Persistence\VolumePath.cs" />
     <Compile Include="Exceptions\KOSInvalidPathException.cs" />
+    <Compile Include="Persistence\ArchiveDirectory.cs" />
+    <Compile Include="Persistence\HarddiskDirectory.cs" />
+    <Compile Include="Persistence\VolumeDirectory.cs" />
+    <Compile Include="Persistence\VolumeItem.cs" />
+    <Compile Include="Persistence\ArchiveFile.cs" />
+    <Compile Include="Persistence\HarddiskFile.cs" />
+    <Compile Include="Persistence\VolumeFile.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Compilation\CompiledObject-doc.md" />

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -251,6 +251,7 @@
     <Compile Include="Serialization\IHasSafeSharedObjects.cs" />
     <Compile Include="SafeSharedObjects.cs" />
     <Compile Include="Persistence\PathValue.cs" />
+    <Compile Include="Execution\InternalPath.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Compilation\CompiledObject-doc.md" />

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -202,7 +202,6 @@
     <Compile Include="Screen\ScreenSnapshot.cs" />
     <Compile Include="Screen\SubBuffer.cs" />
     <Compile Include="Screen\TextEditor.cs" />
-    <Compile Include="SharedObjects.cs" />
     <Compile Include="Sound\ISoundMaker.cs" />
     <Compile Include="UpdateHandler.cs" />
     <Compile Include="UserIO\UnicodeCommand.cs" />
@@ -249,6 +248,9 @@
     <Compile Include="Persistence\ArchiveFile.cs" />
     <Compile Include="Persistence\HarddiskFile.cs" />
     <Compile Include="Persistence\VolumeFile.cs" />
+    <Compile Include="Serialization\IHasSafeSharedObjects.cs" />
+    <Compile Include="SafeSharedObjects.cs" />
+    <Compile Include="Persistence\PathValue.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Compilation\CompiledObject-doc.md" />

--- a/src/kOS/AddOns/RemoteTech/RemoteTechArchive.cs
+++ b/src/kOS/AddOns/RemoteTech/RemoteTechArchive.cs
@@ -5,6 +5,11 @@ namespace kOS.AddOns.RemoteTech
     [kOS.Safe.Utilities.KOSNomenclature("RTArchive")]
     public class RemoteTechArchive : Archive
     {
+        public RemoteTechArchive(string archiveFolder) : base(archiveFolder)
+        {
+
+        }
+
         public bool CheckRange(Vessel vessel)
         {
             if (vessel == null)

--- a/src/kOS/AddOns/RemoteTech/RemoteTechFactory.cs
+++ b/src/kOS/AddOns/RemoteTech/RemoteTechFactory.cs
@@ -2,6 +2,7 @@
 using kOS.Safe.Persistence;
 using kOS.Safe.Screen;
 using kOS.Communication;
+using kOS.Safe.Utilities;
 
 namespace kOS.AddOns.RemoteTech
 {
@@ -14,7 +15,7 @@ namespace kOS.AddOns.RemoteTech
 
         public Archive CreateArchive()
         {
-            return new RemoteTechArchive();
+            return new RemoteTechArchive(SafeHouse.ArchiveFolder);
         }
 
         public IVolumeManager CreateVolumeManager(SharedObjects sharedObjects)

--- a/src/kOS/AddOns/RemoteTech/RemoteTechVolumeManager.cs
+++ b/src/kOS/AddOns/RemoteTech/RemoteTechVolumeManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using kOS.Persistence;
 using kOS.Safe.Persistence;
+using kOS.Safe.Exceptions;
 
 namespace kOS.AddOns.RemoteTech
 {
@@ -26,7 +27,7 @@ namespace kOS.AddOns.RemoteTech
             {
                 return volume;
             }
-            throw new Exception("Volume is out of range");
+            throw new KOSException("Volume is out of range");
         }
 
         // check the range on the current volume without calling GetVolumeWithRangeCheck

--- a/src/kOS/Communication/InterVesselManager.cs
+++ b/src/kOS/Communication/InterVesselManager.cs
@@ -43,7 +43,7 @@ namespace kOS.Communication
 
                     Dump queueDump = ConfigNodeFormatter.Instance.FromConfigNode(queueNode);
 
-                    MessageQueue queue = new SafeSerializationMgr().CreateFromDump(queueDump) as MessageQueue;
+                    MessageQueue queue = new SafeSerializationMgr(null).CreateFromDump(queueDump) as MessageQueue;
 
                     if (queue.Count() > 0)
                     {
@@ -63,7 +63,7 @@ namespace kOS.Communication
                     ConfigNode vesselEntry = new ConfigNode(VesselQueue);
                     vesselEntry.AddValue(Id, id);
 
-                    ConfigNode queueNode = ConfigNodeFormatter.Instance.ToConfigNode(new SafeSerializationMgr().Dump(vesselQueues[id]));
+                    ConfigNode queueNode = ConfigNodeFormatter.Instance.ToConfigNode(new SafeSerializationMgr(null).Dump(vesselQueues[id]));
                     queueNode.name = MessageQueue;
                     vesselEntry.AddNode(queueNode);
 

--- a/src/kOS/Communication/Message.cs
+++ b/src/kOS/Communication/Message.cs
@@ -20,7 +20,7 @@ namespace kOS.Communication
         {
             if (content is SerializableStructure)
             {
-                return new Message(new SafeSerializationMgr().Dump(content as SerializableStructure), sentAt, receivedAt, sender);
+                return new Message(new SafeSerializationMgr(null).Dump(content as SerializableStructure), sentAt, receivedAt, sender);
             } else if (content is PrimitiveStructure)
             {
                 return new Message(content as PrimitiveStructure, sentAt, receivedAt, sender);

--- a/src/kOS/Factories/StandardFactory.cs
+++ b/src/kOS/Factories/StandardFactory.cs
@@ -2,6 +2,7 @@
 using kOS.Safe.Screen;
 using kOS.Screen;
 using kOS.Communication;
+using kOS.Safe.Utilities;
 
 namespace kOS.Factories
 {
@@ -14,7 +15,7 @@ namespace kOS.Factories
 
         public Archive CreateArchive()
         {
-            return new Archive();
+            return new Archive(SafeHouse.ArchiveFolder);
         }
 
         public IVolumeManager CreateVolumeManager(SharedObjects sharedObjects)

--- a/src/kOS/Function/BuildList.cs
+++ b/src/kOS/Function/BuildList.cs
@@ -40,7 +40,7 @@ namespace kOS.Function
                     list = shared.Vessel.PartList(listType, shared);
                     break;
                 case "files":
-                    list = ListValue.CreateList(shared.VolumeMgr.CurrentVolume.FileList.Values.ToList());
+                    list = ListValue.CreateList(shared.VolumeMgr.CurrentVolume.ListAsLexicon().Values.ToList());
                     break;
                 case "volumes":
                     list = ListValue.CreateList(shared.VolumeMgr.Volumes.Values.ToList());

--- a/src/kOS/Function/Misc.cs
+++ b/src/kOS/Function/Misc.cs
@@ -298,7 +298,7 @@ namespace kOS.Function
                 if (justCompiling)
                 {
                     List<CodePart> compileParts = shared.ScriptHandler.Compile(path, 1, fileContent.String, String.Empty, options);
-                    VolumeFile written = volume.Save(outPath, new FileContent(compileParts));
+                    VolumeFile written = volume.SaveFile(outPath, new FileContent(compileParts));
                     if (written == null)
                     {
                         throw new KOSFileException("Can't save compiled file: not enough space or access forbidden");

--- a/src/kOS/Function/Misc.cs
+++ b/src/kOS/Function/Misc.cs
@@ -15,6 +15,7 @@ using kOS.Module;
 using kOS.Safe.Compilation.KS;
 using kOS.Safe.Encapsulation;
 using KSP.UI.Screens;
+using kOS.Safe;
 
 namespace kOS.Function
 {
@@ -146,7 +147,7 @@ namespace kOS.Function
             // run() is strange.  It needs two levels of args - the args to itself, and the args it is meant to
             // pass on to the program it's invoking.  First, these are the args to run itself:
             object volumeId = PopValueAssert(shared, true);
-            string fileName = PopValueAssert(shared, true).ToString();
+            string pathString = PopValueAssert(shared, true).ToString();
             AssertArgBottomAndConsume(shared);
 
             // Now the args it is going to be passing on to the program:
@@ -157,10 +158,15 @@ namespace kOS.Function
             AssertArgBottomAndConsume(shared);
 
             if (shared.VolumeMgr == null) return;
-            if (shared.VolumeMgr.CurrentVolume == null) throw new Exception("Volume not found");
 
-            VolumeFile file = shared.VolumeMgr.CurrentVolume.Open(fileName, true);
-            if (file == null) throw new Exception(string.Format("File '{0}' not found", fileName));
+            GlobalPath path = shared.VolumeMgr.GlobalPathFromString(pathString);
+            Volume volume = shared.VolumeMgr.GetVolumeFromPath(path);
+            VolumeFile volumeFile = volume.Open(path) as VolumeFile;
+
+            FileContent content = volumeFile != null ? volumeFile.ReadAll() : null;
+
+            if (content == null) throw new Exception(string.Format("File '{0}' not found", path));
+
             if (shared.ScriptHandler == null) return;
 
             if (volumeId != null)
@@ -170,9 +176,9 @@ namespace kOS.Function
                 {
                     if (shared.ProcessorMgr != null)
                     {
-                        string filePath = string.Format("{0}/{1}", shared.VolumeMgr.GetVolumeRawIdentifier(targetVolume), fileName);
                         var options = new CompilerOptions { LoadProgramsInSameAddressSpace = true, FuncManager = shared.FunctionManager };
-                        List<CodePart> parts = shared.ScriptHandler.Compile(filePath, 1, file.ReadAll().String, "program", options);
+
+                        List<CodePart> parts = shared.ScriptHandler.Compile(path, 1, volumeFile.ReadAll().String, "program", options);
                         var builder = new ProgramBuilder();
                         builder.AddRange(parts);
                         List<Opcode> program = builder.BuildProgram();
@@ -189,22 +195,21 @@ namespace kOS.Function
                 // clear the "program" compilation context
                 shared.Cpu.StartCompileStopwatch();
                 shared.ScriptHandler.ClearContext("program");
-                string filePath = shared.VolumeMgr.GetVolumeRawIdentifier(shared.VolumeMgr.CurrentVolume) + "/" + fileName;
+                //string filePath = shared.VolumeMgr.GetVolumeRawIdentifier(shared.VolumeMgr.CurrentVolume) + "/" + fileName;
                 var options = new CompilerOptions { LoadProgramsInSameAddressSpace = true, FuncManager = shared.FunctionManager };
                 var programContext = ((CPU)shared.Cpu).SwitchToProgramContext();
 
                 List<CodePart> codeParts;
-                FileContent content = file.ReadAll();
                 if (content.Category == FileCategory.KSM)
                 {
                     string prefix = programContext.Program.Count.ToString();
-                    codeParts = content.AsParts(fileName, prefix);
+                    codeParts = content.AsParts(path, prefix);
                 }
                 else
                 {
                     try
                     {
-                        codeParts = shared.ScriptHandler.Compile(filePath, 1, content.String, "program", options);
+                        codeParts = shared.ScriptHandler.Compile(path, 1, content.String, "program", options);
                     }
                     catch (Exception)
                     {
@@ -241,7 +246,7 @@ namespace kOS.Function
         {
             bool defaultOutput = false;
             bool justCompiling = false; // is this load() happening to compile, or to run?
-            string fileNameOut = null;
+            string outPathString = null;
             object topStack = PopValueAssert(shared, true); // null if there's no output file (output file means compile, not run).
             if (topStack != null)
             {
@@ -250,30 +255,36 @@ namespace kOS.Function
                 if (outputArg.Equals("-default-compile-out-"))
                     defaultOutput = true;
                 else
-                    fileNameOut = PersistenceUtilities.CookedFilename(outputArg, Volume.KOS_MACHINELANGUAGE_EXTENSION);
+                    outPathString = outputArg;
             }
 
-            string fileName = null;
+            string pathString = null;
             topStack = PopValueAssert(shared, true);
             if (topStack != null)
-                fileName = topStack.ToString();
+                pathString = topStack.ToString();
 
             AssertArgBottomAndConsume(shared);
 
-            if (fileName == null)
+            if (pathString == null)
                 throw new KOSFileException("No filename to load was given.");
 
-            VolumeFile file = shared.VolumeMgr.CurrentVolume.Open(fileName, !justCompiling); // if running, look for KSM first.  If compiling look for KS first.
-            if (file == null) throw new KOSFileException(string.Format("Can't find file '{0}'.", fileName));
-            fileName = file.Name; // just in case GetByName picked an extension that changed it.
+            GlobalPath path = shared.VolumeMgr.GlobalPathFromString(pathString);
+            Volume volume = shared.VolumeMgr.GetVolumeFromPath(path);
+
+            VolumeFile file = volume.Open(path) as VolumeFile; // if running, look for KSM first.  If compiling look for KS first.
+            if (file == null) throw new KOSFileException(string.Format("Can't find file '{0}'.", path));
+            string fileName = file.Name; // just in case Get picked an extension that changed it.
+
             FileContent fileContent = file.ReadAll();
 
             // filename is now guaranteed to have an extension.  To make default output name, replace the extension with KSM:
             if (defaultOutput)
-                fileNameOut = fileName.Substring(0, fileName.LastIndexOf('.')) + "." + Volume.KOS_MACHINELANGUAGE_EXTENSION;
+                outPathString = fileName.Substring(0, fileName.LastIndexOf('.')) + "." + Volume.KOS_MACHINELANGUAGE_EXTENSION;
 
-            if (fileNameOut != null && fileName == fileNameOut)
-                throw new KOSFileException("Input and output filenames must differ.");
+            GlobalPath outPath = shared.VolumeMgr.GlobalPathFromString(outPathString);
+
+            if (path.Equals(outPath))
+                throw new KOSFileException("Input and output paths must differ.");
 
             if (shared.VolumeMgr == null) return;
             if (shared.VolumeMgr.CurrentVolume == null) throw new KOSFileException("Volume not found");
@@ -282,14 +293,13 @@ namespace kOS.Function
             {
                 shared.Cpu.StartCompileStopwatch();
                 var options = new CompilerOptions { LoadProgramsInSameAddressSpace = true, FuncManager = shared.FunctionManager };
-                string filePath = shared.VolumeMgr.GetVolumeRawIdentifier(shared.VolumeMgr.CurrentVolume) + "/" + fileName;
                 // add this program to the address space of the parent program,
                 // or to a file to save:
                 if (justCompiling)
                 {
-                    List<CodePart> compileParts = shared.ScriptHandler.Compile(filePath, 1, fileContent.String, string.Empty, options);
-                    VolumeFile volumeFile = shared.VolumeMgr.CurrentVolume.Save(fileNameOut, new FileContent(compileParts));
-                    if (volumeFile == null)
+                    List<CodePart> compileParts = shared.ScriptHandler.Compile(path, 1, fileContent.String, String.Empty, options);
+                    VolumeFile written = volume.Save(outPath, new FileContent(compileParts));
+                    if (written == null)
                     {
                         throw new KOSFileException("Can't save compiled file: not enough space or access forbidden");
                     }
@@ -301,11 +311,11 @@ namespace kOS.Function
                     if (fileContent.Category == FileCategory.KSM)
                     {
                         string prefix = programContext.Program.Count.ToString();
-                        parts = fileContent.AsParts(filePath, prefix);
+                        parts = fileContent.AsParts(path, prefix);
                     }
                     else
                     {
-                        parts = shared.ScriptHandler.Compile(filePath, 1, fileContent.String, "program", options);
+                        parts = shared.ScriptHandler.Compile(path, 1, fileContent.String, "program", options);
                     }
                     int programAddress = programContext.AddObjectParts(parts);
                     // push the entry point address of the new program onto the stack
@@ -343,26 +353,31 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            string fileName = PopValueAssert(shared, true).ToString();
-            string expressionResult = PopValueAssert(shared).ToString();
+            string pathString = PopValueAssert(shared, true).ToString();
+            string toAppend = PopValueAssert(shared).ToString();
             AssertArgBottomAndConsume(shared);
 
             if (shared.VolumeMgr != null)
             {
-                Volume volume = shared.VolumeMgr.CurrentVolume;
-                if (volume != null)
-                {
-                    VolumeFile volumeFile = volume.OpenOrCreate(fileName);
+                GlobalPath path = shared.VolumeMgr.GlobalPathFromString(pathString);
+                Volume volume = shared.VolumeMgr.GetVolumeFromPath(path);
 
-                    if (volumeFile == null || !volumeFile.WriteLn(expressionResult))
-                    {
-                        throw new KOSFileException("Can't append to file: not enough space or access forbidden");
-                    }
+                VolumeItem volumeItem = volume.Open(path) as VolumeFile;
+                VolumeFile volumeFile = null;
+
+                if (volumeItem == null) {
+                    volumeFile = volume.CreateFile(path);
+                } else if (volumeItem is VolumeDirectory) {
+                    throw new KOSFileException("Can't append to file: path points to a directory");
+                } else {
+                    volumeFile = volumeItem as VolumeFile;
                 }
-                else
+
+                if (!volumeFile.WriteLn(toAppend))
                 {
-                    throw new KOSFileException("Volume not found");
+                    throw new KOSFileException("Can't append to file: not enough space or access forbidden");
                 }
+
             }
         }
     }
@@ -424,7 +439,7 @@ namespace kOS.Function
             ReturnValue = sb.ToString();
         }
     }
-    
+
     [Function("warpto")]
     public class WarpTo : FunctionBase
     {
@@ -446,7 +461,7 @@ namespace kOS.Function
             TimeWarp.fetch.WarpTo(ut);
         }
     }
-        
+
     [Function("processor")]
     public class FunctionProcessor : FunctionBase
     {
@@ -514,7 +529,7 @@ namespace kOS.Function
             AssertArgBottomAndConsume(shared);
         }
     }
-    
+
     [Function("makebuiltindelegate")]
     public class MakeBuiltinDelegate : FunctionBase
     {
@@ -522,7 +537,7 @@ namespace kOS.Function
         {
            string name = PopValueAssert(shared).ToString();
            AssertArgBottomAndConsume(shared);
-           
+
            ReturnValue = new BuiltinDelegate(shared.Cpu, name);
         }
     }

--- a/src/kOS/Function/Misc.cs
+++ b/src/kOS/Function/Misc.cs
@@ -147,7 +147,7 @@ namespace kOS.Function
             // run() is strange.  It needs two levels of args - the args to itself, and the args it is meant to
             // pass on to the program it's invoking.  First, these are the args to run itself:
             object volumeId = PopValueAssert(shared, true);
-            string pathString = PopValueAssert(shared, true).ToString();
+            object pathObject = PopValueAssert(shared, true);
             AssertArgBottomAndConsume(shared);
 
             // Now the args it is going to be passing on to the program:
@@ -159,7 +159,7 @@ namespace kOS.Function
 
             if (shared.VolumeMgr == null) return;
 
-            GlobalPath path = shared.VolumeMgr.GlobalPathFromString(pathString);
+            GlobalPath path = shared.VolumeMgr.GlobalPathFromObject(pathObject);
             Volume volume = shared.VolumeMgr.GetVolumeFromPath(path);
             VolumeFile volumeFile = volume.Open(path) as VolumeFile;
 
@@ -255,20 +255,17 @@ namespace kOS.Function
                 if (outputArg.Equals("-default-compile-out-"))
                     defaultOutput = true;
                 else
-                    outPath = shared.VolumeMgr.GlobalPathFromString(outputArg);
+                    outPath = shared.VolumeMgr.GlobalPathFromObject(outputArg);
             }
 
-            string pathString = null;
-            topStack = PopValueAssert(shared, true);
-            if (topStack != null)
-                pathString = topStack.ToString();
+            object pathObject = PopValueAssert(shared, true);
 
             AssertArgBottomAndConsume(shared);
 
-            if (string.IsNullOrEmpty(pathString))
+            if (pathObject == null)
                 throw new KOSFileException("No filename to load was given.");
 
-            GlobalPath path = shared.VolumeMgr.GlobalPathFromString(pathString);
+            GlobalPath path = shared.VolumeMgr.GlobalPathFromObject(pathObject);
             Volume volume = shared.VolumeMgr.GetVolumeFromPath(path);
 
             VolumeFile file = volume.Open(path, !justCompiling) as VolumeFile; // if running, look for KSM first.  If compiling look for KS first.
@@ -356,7 +353,7 @@ namespace kOS.Function
 
             if (shared.VolumeMgr != null)
             {
-                GlobalPath path = shared.VolumeMgr.GlobalPathFromString(pathString);
+                GlobalPath path = shared.VolumeMgr.GlobalPathFromObject(pathString);
                 Volume volume = shared.VolumeMgr.GetVolumeFromPath(path);
 
                 VolumeItem volumeItem = volume.Open(path) as VolumeFile;

--- a/src/kOS/Function/Persistence.cs
+++ b/src/kOS/Function/Persistence.cs
@@ -8,10 +8,33 @@ using kOS.Serialization;
 using System;
 using KSP.IO;
 using kOS.Safe;
-using kOS.Safe.Exceptions;
 
 namespace kOS.Function
 {
+    [Function("path")]
+    public class FunctionPath : FunctionBase
+    {
+        public override void Execute(SharedObjects shared)
+        {
+            int remaining = CountRemainingArgs(shared);
+
+            GlobalPath path;
+
+            if (remaining == 0)
+            {
+                path = GlobalPath.FromVolumePath(shared.VolumeMgr.CurrentDirectory.Path, shared.VolumeMgr.CurrentVolume);
+            } else
+            {
+                string pathString = PopValueAssert(shared, true).ToString();
+                path = shared.VolumeMgr.GlobalPathFromString(pathString);
+            }
+
+            AssertArgBottomAndConsume(shared);
+
+            ReturnValue = new PathValue(path, shared);
+        }
+    }
+
     [Function("switch")]
     public class FunctionSwitch : FunctionBase
     {

--- a/src/kOS/Function/Persistence.cs
+++ b/src/kOS/Function/Persistence.cs
@@ -221,15 +221,12 @@ namespace kOS.Function
             string sourcePathString = PopValueAssert(shared, true).ToString();
             AssertArgBottomAndConsume(shared);
 
-            SafeHouse.Logger.Log(string.Format("FunctionCopy: {0} {1}", sourcePathString, destinationPathString));
+            SafeHouse.Logger.Log(string.Format("FunctionMove: {0} {1}", sourcePathString, destinationPathString));
 
             GlobalPath sourcePath = shared.VolumeMgr.GlobalPathFromString(sourcePathString);
             GlobalPath destinationPath = shared.VolumeMgr.GlobalPathFromString(destinationPathString);
 
-            //Copy(shared.VolumeMgr, sourcePath, destinationPath);
-
-            //Volume sourceVolume = shared.VolumeMgr.GetVolumeFromPath(sourcePath);
-            //sourceVolume.Delete(sourcePath);
+            shared.VolumeMgr.Move(sourcePath, destinationPath);
         }
     }
 

--- a/src/kOS/Function/Persistence.cs
+++ b/src/kOS/Function/Persistence.cs
@@ -88,8 +88,8 @@ namespace kOS.Function
                     shared.VolumeMgr.GetVolumeRawIdentifier(shared.VolumeMgr.CurrentVolume));
             } else
             {
-                string pathString = PopValueAssert(shared, true).ToString();
-                path = shared.VolumeMgr.GlobalPathFromString(pathString);
+                object pathObject = PopValueAssert(shared, true);
+                path = shared.VolumeMgr.GlobalPathFromObject(pathObject);
             }
 
             AssertArgBottomAndConsume(shared);
@@ -114,6 +114,11 @@ namespace kOS.Function
             {
                 object volumeId = PopValueAssert(shared, true);
                 volume = shared.VolumeMgr.GetVolume(volumeId);
+
+                if (volume == null)
+                {
+                    throw new KOSPersistenceException("Could not find volume: " + volumeId);
+                }
             }
 
             AssertArgBottomAndConsume(shared);
@@ -164,10 +169,10 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            string pathString = PopValueAssert(shared, true).ToString();
+            object pathObject = PopValueAssert(shared, true);
             AssertArgBottomAndConsume(shared);
 
-            GlobalPath path = shared.VolumeMgr.GlobalPathFromString(pathString);
+            GlobalPath path = shared.VolumeMgr.GlobalPathFromObject(pathObject);
             Volume vol = shared.VolumeMgr.GetVolumeFromPath(path);
             shared.Window.OpenPopupEditor(vol, path);
 
@@ -188,16 +193,16 @@ namespace kOS.Function
                 directory = shared.VolumeMgr.CurrentVolume.Root;
             } else
             {
-                string pathString = PopValueAssert(shared, true).ToString();
+                object pathObject = PopValueAssert(shared, true);
 
-                GlobalPath path = shared.VolumeMgr.GlobalPathFromString(pathString);
+                GlobalPath path = shared.VolumeMgr.GlobalPathFromObject(pathObject);
                 Volume volume = shared.VolumeMgr.GetVolumeFromPath(path);
 
                 directory = volume.Open(path) as VolumeDirectory;
 
                 if (directory == null)
                 {
-                    throw new KOSException("Invalid directory: " + pathString);
+                    throw new KOSException("Invalid directory: " + pathObject);
                 }
 
             }
@@ -213,14 +218,14 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            string destinationPathString = PopValueAssert(shared, true).ToString();
-            string sourcePathString = PopValueAssert(shared, true).ToString();
+            object destinationPathObject = PopValueAssert(shared, true);
+            object sourcePathObject = PopValueAssert(shared, true);
             AssertArgBottomAndConsume(shared);
 
-            GlobalPath sourcePath = shared.VolumeMgr.GlobalPathFromString(sourcePathString);
-            GlobalPath destinationPath = shared.VolumeMgr.GlobalPathFromString(destinationPathString);
+            GlobalPath sourcePath = shared.VolumeMgr.GlobalPathFromObject(sourcePathObject);
+            GlobalPath destinationPath = shared.VolumeMgr.GlobalPathFromObject(destinationPathObject);
 
-            shared.VolumeMgr.Copy(sourcePath, destinationPath);
+            ReturnValue = shared.VolumeMgr.Copy(sourcePath, destinationPath);
         }
     }
 
@@ -229,14 +234,14 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            string destinationPathString = PopValueAssert(shared, true).ToString();
-            string sourcePathString = PopValueAssert(shared, true).ToString();
+            object destinationPathObject = PopValueAssert(shared, true);
+            object sourcePathObject = PopValueAssert(shared, true);
             AssertArgBottomAndConsume(shared);
 
-            GlobalPath sourcePath = shared.VolumeMgr.GlobalPathFromString(sourcePathString);
-            GlobalPath destinationPath = shared.VolumeMgr.GlobalPathFromString(destinationPathString);
+            GlobalPath sourcePath = shared.VolumeMgr.GlobalPathFromObject(sourcePathObject);
+            GlobalPath destinationPath = shared.VolumeMgr.GlobalPathFromObject(destinationPathObject);
 
-            shared.VolumeMgr.Move(sourcePath, destinationPath);
+            ReturnValue = shared.VolumeMgr.Move(sourcePath, destinationPath);
         }
     }
 
@@ -245,17 +250,13 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            string pathString = PopValueAssert(shared, true).ToString();
+            object pathObject = PopValueAssert(shared, true);
             AssertArgBottomAndConsume(shared);
 
-            GlobalPath path = shared.VolumeMgr.GlobalPathFromString(pathString);
+            GlobalPath path = shared.VolumeMgr.GlobalPathFromObject(pathObject);
             Volume volume = shared.VolumeMgr.GetVolumeFromPath(path);
-            volume.Delete(path);
 
-            if (!volume.Delete(path))
-            {
-                throw new Exception(string.Format("Could not remove '{0}'", path));
-            }
+            ReturnValue = volume.Delete(path);
         }
     }
 
@@ -264,7 +265,7 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            string pathString = PopValueAssert(shared, true).ToString();
+            object pathObject = PopValueAssert(shared, true);
             SerializableStructure serialized = PopValueAssert(shared, true) as SerializableStructure;
             AssertArgBottomAndConsume(shared);
 
@@ -277,7 +278,7 @@ namespace kOS.Function
 
             FileContent fileContent = new FileContent(serializedString);
 
-            GlobalPath path = shared.VolumeMgr.GlobalPathFromString(pathString);
+            GlobalPath path = shared.VolumeMgr.GlobalPathFromObject(pathObject);
             Volume volume = shared.VolumeMgr.GetVolumeFromPath(path);
 
             ReturnValue = volume.SaveFile(path, fileContent);
@@ -289,10 +290,10 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            string pathString = PopValueAssert(shared, true).ToString();
+            object pathObject = PopValueAssert(shared, true);
             AssertArgBottomAndConsume(shared);
 
-            GlobalPath path = shared.VolumeMgr.GlobalPathFromString(pathString);
+            GlobalPath path = shared.VolumeMgr.GlobalPathFromObject(pathObject);
             Volume volume = shared.VolumeMgr.GetVolumeFromPath(path);
 
             VolumeFile volumeFile = volume.Open(path) as VolumeFile;
@@ -312,10 +313,10 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            string pathString = PopValueAssert(shared, true).ToString();
+            object pathObject = PopValueAssert(shared, true);
             AssertArgBottomAndConsume(shared);
 
-            GlobalPath path = shared.VolumeMgr.GlobalPathFromString(pathString);
+            GlobalPath path = shared.VolumeMgr.GlobalPathFromObject(pathObject);
             Volume volume = shared.VolumeMgr.GetVolumeFromPath(path);
 
             ReturnValue = volume.Exists(path);
@@ -327,10 +328,10 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            string pathString = PopValueAssert(shared, true).ToString();
+            object pathObject = PopValueAssert(shared, true);
             AssertArgBottomAndConsume(shared);
 
-            GlobalPath path = shared.VolumeMgr.GlobalPathFromString(pathString);
+            GlobalPath path = shared.VolumeMgr.GlobalPathFromObject(pathObject);
             Volume volume = shared.VolumeMgr.GetVolumeFromPath(path);
 
             VolumeItem volumeItem = volume.Open(path);
@@ -349,10 +350,10 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            string pathString = PopValueAssert(shared, true).ToString();
+            object pathObject = PopValueAssert(shared, true);
             AssertArgBottomAndConsume(shared);
 
-            GlobalPath path = shared.VolumeMgr.GlobalPathFromString(pathString);
+            GlobalPath path = shared.VolumeMgr.GlobalPathFromObject(pathObject);
             Volume volume = shared.VolumeMgr.GetVolumeFromPath(path);
 
             VolumeFile volumeFile = volume.CreateFile(path);
@@ -366,10 +367,10 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            string pathString = PopValueAssert(shared, true).ToString();
+            object pathObject = PopValueAssert(shared, true);
             AssertArgBottomAndConsume(shared);
 
-            GlobalPath path = shared.VolumeMgr.GlobalPathFromString(pathString);
+            GlobalPath path = shared.VolumeMgr.GlobalPathFromObject(pathObject);
             Volume volume = shared.VolumeMgr.GetVolumeFromPath(path);
 
             VolumeDirectory volumeDirectory = volume.CreateDirectory(path);

--- a/src/kOS/Function/Persistence.cs
+++ b/src/kOS/Function/Persistence.cs
@@ -22,8 +22,9 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            PopValueAssert(shared, true).ToString();
-            PopValueAssert(shared, true).ToString();
+            PopValueAssert(shared, true);
+            PopValueAssert(shared, true);
+            PopValueAssert(shared, true);
             AssertArgBottomAndConsume(shared);
 
             throw new KOSDeprecationException("1.0.0", "`COPY FILENAME FROM VOLUMEID.` syntax", "`COPY(FROMPATH, TOPATH)`");
@@ -35,8 +36,10 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            PopValueAssert(shared, true).ToString();
-            PopValueAssert(shared, true).ToString();
+            PopValueAssert(shared, true);
+            PopValueAssert(shared, true);
+            PopValueAssert(shared, true);
+
             AssertArgBottomAndConsume(shared);
 
             throw new KOSDeprecationException("1.0.0", "`RENAME FILE OLDNAME TO NEWNAME.` syntax", "`MOVE(FROMPATH, TOPATH)`");
@@ -48,24 +51,12 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            PopValueAssert(shared, true).ToString();
-            PopValueAssert(shared, true).ToString();
+            PopValueAssert(shared, true);
+            PopValueAssert(shared, true);
+            PopValueAssert(shared, true);
             AssertArgBottomAndConsume(shared);
 
             throw new KOSDeprecationException("1.0.0", "`RENAME VOLUME OLDNAME TO NEWNAME.` syntax", "`SET VOLUME:NAME TO NEWNAME.`");
-        }
-    }
-
-    [Function("delete_deprecated")]
-    public class FunctionDeleteDeprecated : FunctionWithCopy
-    {
-        public override void Execute(SharedObjects shared)
-        {
-            PopValueAssert(shared, true).ToString();
-            PopValueAssert(shared, true).ToString();
-            AssertArgBottomAndConsume(shared);
-
-            throw new KOSDeprecationException("1.0.0", "`DELETE FILENAME FROM VOLUMEID.` syntax", "`DELETE(PATH)`");
         }
     }
 
@@ -334,6 +325,22 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
+            /*
+             * Parser will treat 'DELETE(filename)' as the old 'DELETE filename [FROM volume]' syntax. So we're unable
+             * to differentiate between new and old syntax. That's why currently both 'DELETE(filename)'
+             * and 'DELETE filename' will work. We only throw the depracation warning when 'FROM' is present, in this
+             * case we're sure that the user wanted to use the old syntax.
+             */
+            int remaining = CountRemainingArgs(shared);
+
+            if (remaining == 2) {
+                PopValueAssert(shared, true);
+                PopValueAssert(shared, true);
+                AssertArgBottomAndConsume(shared);
+
+                throw new KOSDeprecationException("1.0.0", "`DELETE FILENAME FROM VOLUMEID.` syntax", "`DELETE(PATH)`");
+            }
+
             string pathString = PopValueAssert(shared, true).ToString();
             AssertArgBottomAndConsume(shared);
 
@@ -384,7 +391,7 @@ namespace kOS.Function
             GlobalPath path = shared.VolumeMgr.GlobalPathFromString(pathString);
             Volume volume = shared.VolumeMgr.GetVolumeFromPath(path);
 
-            VolumeFile volumeFile = volume.Open(pathString) as VolumeFile;
+            VolumeFile volumeFile = volume.Open(path) as VolumeFile;
 
             if (volumeFile == null)
             {

--- a/src/kOS/Function/Persistence.cs
+++ b/src/kOS/Function/Persistence.cs
@@ -27,7 +27,7 @@ namespace kOS.Function
             PopValueAssert(shared, true);
             AssertArgBottomAndConsume(shared);
 
-            throw new KOSDeprecationException("1.0.0", "`COPY FILENAME FROM VOLUMEID.` syntax", "`COPY(FROMPATH, TOPATH)`", string.Empty);
+            throw new KOSDeprecationException("1.0.0", "`COPY FILENAME FROM VOLUMEID.` syntax", "`COPYPATH(FROMPATH, TOPATH)`", string.Empty);
         }
     }
 
@@ -42,7 +42,7 @@ namespace kOS.Function
 
             AssertArgBottomAndConsume(shared);
 
-            throw new KOSDeprecationException("1.0.0", "`RENAME FILE OLDNAME TO NEWNAME.` syntax", "`MOVE(FROMPATH, TOPATH)`", string.Empty);
+            throw new KOSDeprecationException("1.0.0", "`RENAME FILE OLDNAME TO NEWNAME.` syntax", "`MOVEPATH(FROMPATH, TOPATH)`", string.Empty);
         }
     }
 
@@ -57,6 +57,19 @@ namespace kOS.Function
             AssertArgBottomAndConsume(shared);
 
             throw new KOSDeprecationException("1.0.0", "`RENAME VOLUME OLDNAME TO NEWNAME.` syntax", "`SET VOLUME:NAME TO NEWNAME.`", string.Empty);
+        }
+    }
+
+    [Function("delete_deprecated")]
+    public class FunctionDeleteDeprecated : FunctionBase
+    {
+        public override void Execute(SharedObjects shared)
+        {
+            PopValueAssert(shared, true);
+            PopValueAssert(shared, true);
+            AssertArgBottomAndConsume(shared);
+
+            throw new KOSDeprecationException("1.0.0", "`DELETE FILENAME FROM VOLUMEID.` syntax", "`DELETEPATH(PATH)`", string.Empty);
         }
     }
 
@@ -195,16 +208,14 @@ namespace kOS.Function
         }
     }
 
-    [Function("copy")]
-    public class FunctionCopy : FunctionBase
+    [Function("copypath")]
+    public class FunctionCopyPath : FunctionBase
     {
         public override void Execute(SharedObjects shared)
         {
             string destinationPathString = PopValueAssert(shared, true).ToString();
             string sourcePathString = PopValueAssert(shared, true).ToString();
             AssertArgBottomAndConsume(shared);
-
-            SafeHouse.Logger.Log(string.Format("FunctionCopy: {0} {1}", sourcePathString, destinationPathString));
 
             GlobalPath sourcePath = shared.VolumeMgr.GlobalPathFromString(sourcePathString);
             GlobalPath destinationPath = shared.VolumeMgr.GlobalPathFromString(destinationPathString);
@@ -213,7 +224,7 @@ namespace kOS.Function
         }
     }
 
-    [Function("move")]
+    [Function("movepath")]
     public class FunctionMove : FunctionBase
     {
         public override void Execute(SharedObjects shared)
@@ -222,8 +233,6 @@ namespace kOS.Function
             string sourcePathString = PopValueAssert(shared, true).ToString();
             AssertArgBottomAndConsume(shared);
 
-            SafeHouse.Logger.Log(string.Format("FunctionMove: {0} {1}", sourcePathString, destinationPathString));
-
             GlobalPath sourcePath = shared.VolumeMgr.GlobalPathFromString(sourcePathString);
             GlobalPath destinationPath = shared.VolumeMgr.GlobalPathFromString(destinationPathString);
 
@@ -231,27 +240,11 @@ namespace kOS.Function
         }
     }
 
-    [Function("delete")]
-    public class FunctionDelete : FunctionBase
+    [Function("deletepath")]
+    public class FunctionDeletePath : FunctionBase
     {
         public override void Execute(SharedObjects shared)
         {
-            /*
-             * Parser will treat 'DELETE(filename)' as the old 'DELETE filename [FROM volume]' syntax. So we're unable
-             * to differentiate between new and old syntax. That's why currently both 'DELETE(filename)'
-             * and 'DELETE filename' will work. We only throw the depracation warning when 'FROM' is present, in this
-             * case we're sure that the user wanted to use the old syntax.
-             */
-            int remaining = CountRemainingArgs(shared);
-
-            if (remaining == 2) {
-                PopValueAssert(shared, true);
-                PopValueAssert(shared, true);
-                AssertArgBottomAndConsume(shared);
-
-                throw new KOSDeprecationException("1.0.0", "`DELETE FILENAME FROM VOLUMEID.` syntax", "`DELETE(PATH)`", string.Empty);
-            }
-
             string pathString = PopValueAssert(shared, true).ToString();
             AssertArgBottomAndConsume(shared);
 

--- a/src/kOS/Function/Persistence.cs
+++ b/src/kOS/Function/Persistence.cs
@@ -71,7 +71,8 @@ namespace kOS.Function
 
             if (remaining == 0)
             {
-                path = GlobalPath.FromVolumePath(shared.VolumeMgr.CurrentDirectory.Path, shared.VolumeMgr.CurrentVolume);
+                path = GlobalPath.FromVolumePath(shared.VolumeMgr.CurrentDirectory.Path,
+                    shared.VolumeMgr.GetVolumeRawIdentifier(shared.VolumeMgr.CurrentVolume));
             } else
             {
                 string pathString = PopValueAssert(shared, true).ToString();

--- a/src/kOS/Function/Persistence.cs
+++ b/src/kOS/Function/Persistence.cs
@@ -22,8 +22,8 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            string destinationPathString = PopValueAssert(shared, true).ToString();
-            string sourcePathString = PopValueAssert(shared, true).ToString();
+            PopValueAssert(shared, true).ToString();
+            PopValueAssert(shared, true).ToString();
             AssertArgBottomAndConsume(shared);
 
             throw new KOSDeprecationException("1.0.0", "`COPY FILENAME FROM VOLUMEID.` syntax", "`COPY(FROMPATH, TOPATH)`");
@@ -35,8 +35,8 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            string destinationPathString = PopValueAssert(shared, true).ToString();
-            string sourcePathString = PopValueAssert(shared, true).ToString();
+            PopValueAssert(shared, true).ToString();
+            PopValueAssert(shared, true).ToString();
             AssertArgBottomAndConsume(shared);
 
             throw new KOSDeprecationException("1.0.0", "`RENAME FILE OLDNAME TO NEWNAME.` syntax", "`MOVE(FROMPATH, TOPATH)`");
@@ -48,8 +48,8 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            string destinationPathString = PopValueAssert(shared, true).ToString();
-            string sourcePathString = PopValueAssert(shared, true).ToString();
+            PopValueAssert(shared, true).ToString();
+            PopValueAssert(shared, true).ToString();
             AssertArgBottomAndConsume(shared);
 
             throw new KOSDeprecationException("1.0.0", "`RENAME VOLUME OLDNAME TO NEWNAME.` syntax", "`SET VOLUME:NAME TO NEWNAME.`");
@@ -61,8 +61,8 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            string destinationPathString = PopValueAssert(shared, true).ToString();
-            string sourcePathString = PopValueAssert(shared, true).ToString();
+            PopValueAssert(shared, true).ToString();
+            PopValueAssert(shared, true).ToString();
             AssertArgBottomAndConsume(shared);
 
             throw new KOSDeprecationException("1.0.0", "`DELETE FILENAME FROM VOLUMEID.` syntax", "`DELETE(PATH)`");
@@ -174,18 +174,30 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            string pathString = PopValueAssert(shared, true).ToString();
-            AssertArgBottomAndConsume(shared);
+            int remaining = CountRemainingArgs(shared);
 
-            GlobalPath path = shared.VolumeMgr.GlobalPathFromString(pathString);
-            Volume volume = shared.VolumeMgr.GetVolumeFromPath(path);
+            VolumeDirectory directory;
 
-            VolumeDirectory directory = volume.Open(path) as VolumeDirectory;
-
-            if (directory == null)
+            if (remaining == 0)
             {
-                throw new KOSException("Invalid directory: " + pathString);
+                directory = shared.VolumeMgr.CurrentVolume.Root;
+            } else
+            {
+                string pathString = PopValueAssert(shared, true).ToString();
+
+                GlobalPath path = shared.VolumeMgr.GlobalPathFromString(pathString);
+                Volume volume = shared.VolumeMgr.GetVolumeFromPath(path);
+
+                directory = volume.Open(path) as VolumeDirectory;
+
+                if (directory == null)
+                {
+                    throw new KOSException("Invalid directory: " + pathString);
+                }
+
             }
+
+            AssertArgBottomAndConsume(shared);
 
             shared.VolumeMgr.CurrentDirectory = directory;
         }

--- a/src/kOS/Function/Persistence.cs
+++ b/src/kOS/Function/Persistence.cs
@@ -8,6 +8,7 @@ using kOS.Serialization;
 using System;
 using KSP.IO;
 using kOS.Safe;
+using kOS.Safe.Compilation;
 
 namespace kOS.Function
 {
@@ -32,6 +33,20 @@ namespace kOS.Function
             AssertArgBottomAndConsume(shared);
 
             ReturnValue = new PathValue(path, shared);
+        }
+    }
+
+    [Function("scriptpath")]
+    public class FunctionScriptPath : FunctionBase
+    {
+        public override void Execute(SharedObjects shared)
+        {
+            AssertArgBottomAndConsume(shared);
+
+            int currentOpcode = shared.Cpu.GetCallTrace()[0];
+            Opcode opcode = shared.Cpu.GetOpcodeAt(currentOpcode);
+
+            ReturnValue = new PathValue(opcode.SourcePath, shared);
         }
     }
 

--- a/src/kOS/Function/Persistence.cs
+++ b/src/kOS/Function/Persistence.cs
@@ -27,7 +27,7 @@ namespace kOS.Function
             PopValueAssert(shared, true);
             AssertArgBottomAndConsume(shared);
 
-            throw new KOSDeprecationException("1.0.0", "`COPY FILENAME FROM VOLUMEID.` syntax", "`COPY(FROMPATH, TOPATH)`");
+            throw new KOSDeprecationException("1.0.0", "`COPY FILENAME FROM VOLUMEID.` syntax", "`COPY(FROMPATH, TOPATH)`", string.Empty);
         }
     }
 
@@ -42,7 +42,7 @@ namespace kOS.Function
 
             AssertArgBottomAndConsume(shared);
 
-            throw new KOSDeprecationException("1.0.0", "`RENAME FILE OLDNAME TO NEWNAME.` syntax", "`MOVE(FROMPATH, TOPATH)`");
+            throw new KOSDeprecationException("1.0.0", "`RENAME FILE OLDNAME TO NEWNAME.` syntax", "`MOVE(FROMPATH, TOPATH)`", string.Empty);
         }
     }
 
@@ -56,7 +56,7 @@ namespace kOS.Function
             PopValueAssert(shared, true);
             AssertArgBottomAndConsume(shared);
 
-            throw new KOSDeprecationException("1.0.0", "`RENAME VOLUME OLDNAME TO NEWNAME.` syntax", "`SET VOLUME:NAME TO NEWNAME.`");
+            throw new KOSDeprecationException("1.0.0", "`RENAME VOLUME OLDNAME TO NEWNAME.` syntax", "`SET VOLUME:NAME TO NEWNAME.`", string.Empty);
         }
     }
 
@@ -249,7 +249,7 @@ namespace kOS.Function
                 PopValueAssert(shared, true);
                 AssertArgBottomAndConsume(shared);
 
-                throw new KOSDeprecationException("1.0.0", "`DELETE FILENAME FROM VOLUMEID.` syntax", "`DELETE(PATH)`");
+                throw new KOSDeprecationException("1.0.0", "`DELETE FILENAME FROM VOLUMEID.` syntax", "`DELETE(PATH)`", string.Empty);
             }
 
             string pathString = PopValueAssert(shared, true).ToString();

--- a/src/kOS/Function/Persistence.cs
+++ b/src/kOS/Function/Persistence.cs
@@ -12,6 +12,62 @@ using kOS.Safe.Compilation;
 
 namespace kOS.Function
 {
+    /*
+     * A couple of syntaxes from kRISC.tpg were deprecated when subdirectories where introduced. It will be possible to
+     * remove these function below as well any metions of delete/rename file/rename volume/copy from kRISC.tpg in the future.
+     */
+    [Function("copy_deprecated")]
+    public class FunctionCopyDeprecated : FunctionWithCopy
+    {
+        public override void Execute(SharedObjects shared)
+        {
+            string destinationPathString = PopValueAssert(shared, true).ToString();
+            string sourcePathString = PopValueAssert(shared, true).ToString();
+            AssertArgBottomAndConsume(shared);
+
+            throw new KOSDeprecationException("1.0.0", "`COPY FILENAME FROM VOLUMEID.` syntax", "`COPY(FROMPATH, TOPATH)`");
+        }
+    }
+
+    [Function("rename_file_deprecated")]
+    public class FunctionRenameFileDeprecated : FunctionWithCopy
+    {
+        public override void Execute(SharedObjects shared)
+        {
+            string destinationPathString = PopValueAssert(shared, true).ToString();
+            string sourcePathString = PopValueAssert(shared, true).ToString();
+            AssertArgBottomAndConsume(shared);
+
+            throw new KOSDeprecationException("1.0.0", "`RENAME FILE OLDNAME TO NEWNAME.` syntax", "`MOVE(FROMPATH, TOPATH)`");
+        }
+    }
+
+    [Function("rename_volume_deprecated")]
+    public class FunctionRenameVolumeDeprecated : FunctionWithCopy
+    {
+        public override void Execute(SharedObjects shared)
+        {
+            string destinationPathString = PopValueAssert(shared, true).ToString();
+            string sourcePathString = PopValueAssert(shared, true).ToString();
+            AssertArgBottomAndConsume(shared);
+
+            throw new KOSDeprecationException("1.0.0", "`RENAME VOLUME OLDNAME TO NEWNAME.` syntax", "`SET VOLUME:NAME TO NEWNAME.`");
+        }
+    }
+
+    [Function("delete_deprecated")]
+    public class FunctionDeleteDeprecated : FunctionWithCopy
+    {
+        public override void Execute(SharedObjects shared)
+        {
+            string destinationPathString = PopValueAssert(shared, true).ToString();
+            string sourcePathString = PopValueAssert(shared, true).ToString();
+            AssertArgBottomAndConsume(shared);
+
+            throw new KOSDeprecationException("1.0.0", "`DELETE FILENAME FROM VOLUMEID.` syntax", "`DELETE(PATH)`");
+        }
+    }
+
     [Function("path")]
     public class FunctionPath : FunctionBase
     {

--- a/src/kOS/Function/Persistence.cs
+++ b/src/kOS/Function/Persistence.cs
@@ -92,6 +92,30 @@ namespace kOS.Function
         }
     }
 
+    [Function("volume")]
+    public class FunctionVolume : FunctionBase
+    {
+        public override void Execute(SharedObjects shared)
+        {
+            int remaining = CountRemainingArgs(shared);
+
+            Volume volume;
+
+            if (remaining == 0)
+            {
+                volume = shared.VolumeMgr.CurrentVolume;
+            } else
+            {
+                object volumeId = PopValueAssert(shared, true);
+                volume = shared.VolumeMgr.GetVolume(volumeId);
+            }
+
+            AssertArgBottomAndConsume(shared);
+
+            ReturnValue = volume;
+        }
+    }
+
     [Function("scriptpath")]
     public class FunctionScriptPath : FunctionBase
     {

--- a/src/kOS/Function/PrintList.cs
+++ b/src/kOS/Function/PrintList.cs
@@ -81,7 +81,7 @@ namespace kOS.Function
             }
         }
 
-        private kList GetFileList(Safe.SharedObjects shared)
+        private kList GetFileList(Safe.SafeSharedObjects shared)
         {
             var list = new kList();
             list.AddColumn("Name", 30, ColumnAlignment.Left);
@@ -107,7 +107,7 @@ namespace kOS.Function
             return list;
         }
 
-        private kList GetVolumeList(Safe.SharedObjects shared)
+        private kList GetVolumeList(Safe.SafeSharedObjects shared)
         {
             var list = new kList { Title = "Volumes" };
             list.AddColumn("ID", 6, ColumnAlignment.Left);

--- a/src/kOS/Function/PrintList.cs
+++ b/src/kOS/Function/PrintList.cs
@@ -10,6 +10,8 @@ using System.Collections.Generic;
 using System.Text;
 using kOS.Utilities;
 using Math = System.Math;
+using System.Linq;
+using kOS.Safe;
 
 namespace kOS.Function
 {
@@ -85,22 +87,22 @@ namespace kOS.Function
             list.AddColumn("Name", 30, ColumnAlignment.Left);
             list.AddColumn("Size", 7, ColumnAlignment.Right);
 
-            if (shared.VolumeMgr != null)
+            list.Title = shared.VolumeMgr.CurrentDirectory.Path.ToString();
+
+            IOrderedEnumerable<VolumeItem> items = shared.VolumeMgr.CurrentDirectory.ListAsLexicon().Values.Cast<VolumeItem>().OrderBy(i => i.Name);
+
+            foreach (VolumeDirectory info in items.OfType<VolumeDirectory>())
             {
-                Volume volume = shared.VolumeMgr.CurrentVolume;
-                if (volume != null)
-                {
-                    list.Title = "Volume " + shared.VolumeMgr.GetVolumeBestIdentifier(volume);
-
-                    foreach (KeyValuePair<string, VolumeFile> pair in volume.FileList)
-                    {
-                        list.AddItem(pair.Key, pair.Value.Size);
-                    }
-
-                    long freeSpace = volume.FreeSpace;
-                    list.Footer = "Free space remaining: " + (freeSpace != Volume.INFINITE_CAPACITY ? freeSpace.ToString() : " infinite");
-                }
+                list.AddItem(info.Name, "<DIR>");
             }
+
+            foreach (VolumeFile info in items.OfType<VolumeFile>())
+            {
+                list.AddItem(info.Name, info.Size);
+            }
+
+            long freeSpace = shared.VolumeMgr.CurrentVolume.FreeSpace;
+            list.Footer = "Free space remaining: " + (freeSpace != Volume.INFINITE_CAPACITY ? freeSpace.ToString() : " infinite");
 
             return list;
         }

--- a/src/kOS/KSPLogger.cs
+++ b/src/kOS/KSPLogger.cs
@@ -178,10 +178,10 @@ namespace kOS
                 return "<<Probably internal error within kOS C# code>>";
             }
 
-            Volume vol = Shared.VolumeMgr.GetVolumeFromPath(path);
-            
             if (path == Interpreter.InterpreterHistory)
                 return Shared.Interpreter.GetCommandHistoryAbsolute(line);
+
+            Volume vol = Shared.VolumeMgr.GetVolumeFromPath(path);
 
             VolumeFile file = vol.Open(path) as VolumeFile;
             if (file != null)

--- a/src/kOS/KSPLogger.cs
+++ b/src/kOS/KSPLogger.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using kOS.Safe.Compilation;
 using kOS.Safe.Persistence;
 using kOS.Safe.Encapsulation;
+using kOS.Screen;
 
 namespace kOS
 {
@@ -106,21 +107,21 @@ namespace kOS
                     if (index > 0)
                     {
                         Opcode prevOpcode = Shared.Cpu.GetOpcodeAt(trace[index-1]);
-                        if (prevOpcode.SourceName == thisOpcode.SourceName &&
+                        if (prevOpcode.SourcePath.Equals(thisOpcode.SourcePath) &&
                             prevOpcode.SourceLine == thisOpcode.SourceLine)
                         {
                             continue;
                         }
                     }
 
-                    string textLine = (thisOpcode is OpcodeEOF) ? "<<--EOF" : GetSourceLine(thisOpcode.SourceName, thisOpcode.SourceLine);
+                    string textLine = (thisOpcode is OpcodeEOF) ? "<<--EOF" : GetSourceLine(thisOpcode.SourcePath, thisOpcode.SourceLine);
                     
                     if (msg.Length == 0)
                         msg += "At ";
                     else
                         msg += "Called from ";
                     
-                    msg += (thisOpcode is OpcodeEOF) ? "interpreter" : BuildLocationString(thisOpcode.SourceName, thisOpcode.SourceLine);
+                    msg += (thisOpcode is OpcodeEOF) ? "interpreter" : BuildLocationString(thisOpcode.SourcePath, thisOpcode.SourceLine);
                     msg += "\n" + textLine + "\n";
 
                     int useColumn = (thisOpcode is OpcodeEOF) ? 1 : thisOpcode.SourceColumn;
@@ -142,7 +143,7 @@ namespace kOS
             }
         }
         
-        private string BuildLocationString(string source, int line)
+        private string BuildLocationString(GlobalPath path, int line)
         {
             if (line < 0)
             {
@@ -151,21 +152,17 @@ namespace kOS
                 // to recalculate LOCK THROTTLE and LOCK STEERING each time there's an Update).
                 return "(kOS built-in Update)";
             }
-            if (string.IsNullOrEmpty(source))
+            if (path == GlobalPath.EMPTY)
             {
                 return "<<probably internal kOS C# error>>";
             }
 
-            string[] splitParts = source.Split('/');
-
-            if (splitParts.Length <= 1)
-                return string.Format("{0}, line {1}", source, line);
-            if (source == "interpreter history")
+            if (path == Interpreter.InterpreterHistory)
                 return string.Format("interpreter line {0}", line);
-            return string.Format("{0} on {1}, line {2}", splitParts[1], splitParts[0], line);
+            return string.Format("{0}, line {2}", path, line);
         }
         
-        private string GetSourceLine(string filePath, int line)
+        private string GetSourceLine(GlobalPath path, int line)
         {
             string returnVal = "(Can't show source line)";
             if (line < 0)
@@ -176,37 +173,18 @@ namespace kOS
                 return "<<System Built-In Flight Control Updater>>";
             }
 
-            if (string.IsNullOrEmpty(filePath))
+            if (path == GlobalPath.EMPTY)
             {
                 return "<<Probably internal error within kOS C# code>>";
             }
-            string[] pathParts = filePath.Split('/');
-            string fileName = pathParts.Last();
-            Volume vol;
-            if (pathParts.Length > 1)
-            {
-                string volName = pathParts.First();
-                if (Regex.IsMatch(volName, @"^\d+$"))
-                {
-                    // If the volume is a number, then get the volume by integer id.
-                    int volNum;
-                    int.TryParse(volName, out volNum);
-                    vol = Shared.VolumeMgr.GetVolume(volNum);
-                }
-                else
-                {
-                    // If the volume is not a number, then get the volume by name string.
-                    vol = Shared.VolumeMgr.GetVolume(volName);
-                }
-            }
-            else
-                vol = Shared.VolumeMgr.CurrentVolume;
+
+            Volume vol = Shared.VolumeMgr.GetVolumeFromPath(path);
             
-            if (fileName == "interpreter history")
+            if (path == Interpreter.InterpreterHistory)
                 return Shared.Interpreter.GetCommandHistoryAbsolute(line);
 
-            VolumeFile file = vol.Open(fileName);
-            if (file!=null)
+            VolumeFile file = vol.Open(path) as VolumeFile;
+            if (file != null)
             {
                 if (file.ReadAll().Category == FileCategory.KSM)
                     return  "<<machine language file: can't show source line>>";
@@ -219,6 +197,5 @@ namespace kOS
             }
             return returnVal;
         }
-
     }
 }

--- a/src/kOS/KSPLogger.cs
+++ b/src/kOS/KSPLogger.cs
@@ -159,7 +159,7 @@ namespace kOS
 
             if (path == Interpreter.InterpreterHistory)
                 return string.Format("interpreter line {0}", line);
-            return string.Format("{0}, line {2}", path, line);
+            return string.Format("{0}, line {1}", path, line);
         }
         
         private string GetSourceLine(GlobalPath path, int line)

--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -59,7 +59,7 @@ namespace kOS.Module
         private const int PROCESSOR_HARD_CAP = 655360;
 
         [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "Boot File"), UI_ChooseOption(scene = UI_Scene.Editor)]
-        public string bootFile = "boot.ks";
+        public string bootFile = "/boot.ks";
 
         [KSPField(isPersistant = true, guiName = "kOS Disk Space", guiActive = true)]
         public int diskSpace = 1024;

--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -368,7 +368,7 @@ namespace kOS.Module
                         FileContent content = bootVolumeFile.ReadAll();
                         if (HardDisk.IsRoomFor(bootFilePath, content))
                         {
-                            HardDisk.Save(bootFilePath, content);
+                            HardDisk.SaveFile(bootFilePath, content);
                         }
                         else
                         {

--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -50,7 +50,7 @@ namespace kOS.Module
 
         private MovingAverage averagePower = new MovingAverage();
 
-        // This is the "constant" byte count used when calculating the EC 
+        // This is the "constant" byte count used when calculating the EC
         // required by the archive volume (which has infinite space).
         // TODO: This corresponds to the existing value and should be adjusted for balance.
         private const int ARCHIVE_EFFECTIVE_BYTES = 50000;
@@ -58,8 +58,12 @@ namespace kOS.Module
         //640K ought to be enough for anybody -sic
         private const int PROCESSOR_HARD_CAP = 655360;
 
+        private const string BootDirectoryName = "boot";
+        private GlobalPath bootDirectoryPath = GlobalPath.FromVolumePath(VolumePath.FromString(BootDirectoryName),
+            Archive.ArchiveName);
+
         [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "Boot File"), UI_ChooseOption(scene = UI_Scene.Editor)]
-        public string bootFile = "/boot.ks";
+        public string bootFile = "boot.ks";
 
         [KSPField(isPersistant = true, guiName = "kOS Disk Space", guiActive = true)]
         public int diskSpace = 1024;
@@ -113,12 +117,9 @@ namespace kOS.Module
             ProcessorMode = ProcessorModes.READY;
         }
 
-        public VolumePath BootFilePath {
+        public GlobalPath BootFilePath {
             get {
-                return VolumePath.FromString(bootFile);
-            }
-            set {
-                bootFile = value.ToString();
+                return bootDirectoryPath.Combine(bootFile);
             }
         }
 
@@ -216,7 +217,7 @@ namespace kOS.Module
             // For the sake of GetInfo, prorate the EC usage based on the smallest physics frame currently selected
             // Because this is called before the part is set, we need to manually calculate it instead of letting Update handle it.
             double power = diskSpace * ECPerBytePerSecond + defaultAvgInstructions * ECPerInstruction / Time.fixedDeltaTime;
-            string chargeText = (ECPerInstruction == 0) ? 
+            string chargeText = (ECPerInstruction == 0) ?
                 "None.  It's powered by pure magic ... apparently." : // for cheaters who use MM or editing part.cfg, to get rid of it.
                 string.Format("1 per {0} instructions executed", (int)(1 / ECPerInstruction));
             return string.Format(format, diskSpace, chargeText, power, defaultAvgInstructions);
@@ -257,25 +258,32 @@ namespace kOS.Module
 
         public override void OnStart(StartState state)
         {
-            //if in Editor, populate boot script selector, diskSpace selector and etc.
-            if (state == StartState.Editor)
+            try
             {
-                if (baseDiskSpace == 0)
-                    baseDiskSpace = diskSpace;
+                //if in Editor, populate boot script selector, diskSpace selector and etc.
+                if (state == StartState.Editor)
+                {
+                    if (baseDiskSpace == 0)
+                        baseDiskSpace = diskSpace;
 
-                InitUI();
-            }
+                    InitUI();
+                }
 
-            UpdateCostAndMass();
 
-            //Do not start from editor and at KSP first loading
-            if (state == StartState.Editor || state == StartState.None)
+                UpdateCostAndMass();
+
+                //Do not start from editor and at KSP first loading
+                if (state == StartState.Editor || state == StartState.None)
+                {
+                    return;
+                }
+
+                SafeHouse.Logger.Log(string.Format("OnStart: {0} {1}", state, ProcessorMode));
+                InitObjects();
+            } catch (Exception e)
             {
-                return;
+                SafeHouse.Logger.LogException(e);
             }
-
-            SafeHouse.Logger.Log(string.Format("OnStart: {0} {1}", state, ProcessorMode));
-            InitObjects();
         }
 
         private void InitUI()
@@ -286,19 +294,12 @@ namespace kOS.Module
 
             var bootFiles = new List<string>();
 
-            var temp = new Archive(SafeHouse.ArchiveFolder);
-            var files = temp.Root.List();
-            var maxchoice = 0;
             bootFiles.Add("None");
-            foreach (KeyValuePair<string, VolumeItem> pair in files)
-            {
-                if (!(pair.Value is VolumeFile) || !pair.Key.StartsWith("boot", StringComparison.InvariantCultureIgnoreCase)) continue;
-                bootFiles.Add(pair.Key);
-                maxchoice++;
-            }
-            //no need to show the control if there are no files starting with boot
-            options.controlEnabled = maxchoice > 0;
-            field.guiActiveEditor = maxchoice > 0;
+            bootFiles.AddRange(BootDirectoryFiles());
+
+            //no need to show the control if there are no available boot files
+            options.controlEnabled = bootFiles.Count > 1;
+            field.guiActiveEditor = bootFiles.Count > 1;
             options.options = bootFiles.ToArray();
 
             //populate diskSpaceUI selector
@@ -312,10 +313,35 @@ namespace kOS.Module
             options.options = sizeOptions;
         }
 
+        private IEnumerable<string> BootDirectoryFiles()
+        {
+            var result = new List<string>();
+
+            var archive = new Archive(SafeHouse.ArchiveFolder);
+
+            var bootDirectory = archive.Open(bootDirectoryPath) as VolumeDirectory;
+
+            if (bootDirectory == null)
+            {
+                return result;
+            }
+
+            var files = bootDirectory.List();
+
+            foreach (KeyValuePair<string, VolumeItem> pair in files)
+            {
+                if (pair.Value is VolumeFile && (pair.Value.Extension.Equals(Volume.KERBOSCRIPT_EXTENSION)
+                    || pair.Value.Extension.Equals(Volume.KOS_MACHINELANGUAGE_EXTENSION)))
+                {
+                    result.Add(pair.Key);
+                }
+            }
+
+            return result;
+        }
+
         public void InitObjects()
         {
-            SafeHouse.Logger.LogWarning("InitObjects: " + (shared == null));
-
             shared = new SharedObjects();
             CreateFactory();
 
@@ -344,6 +370,7 @@ namespace kOS.Module
 
             // initialize archive
             var archive = shared.Factory.CreateArchive();
+
             shared.VolumeMgr.Add(archive);
 
             Messages = new MessageQueue();
@@ -361,16 +388,14 @@ namespace kOS.Module
                 // populate it with the boot file, but only if using a new disk and in PRELAUNCH situation:
                 if (vessel.situation == Vessel.Situations.PRELAUNCH && bootFile != "None" && !SafeHouse.Config.StartOnArchive)
                 {
-                    var bootVolumeFile = archive.Open(bootFile) as VolumeFile;
+                    var bootVolumeFile = archive.Open(BootFilePath) as VolumeFile;
                     if (bootVolumeFile != null)
                     {
-                        VolumePath bootFilePath = VolumePath.FromString(bootFile);
-                        FileContent content = bootVolumeFile.ReadAll();
-                        if (HardDisk.IsRoomFor(bootFilePath, content))
-                        {
-                            HardDisk.SaveFile(bootFilePath, content);
-                        }
-                        else
+                        GlobalPath harddiskPath = GlobalPath.FromVolumePath(
+                            VolumePath.FromString(BootFilePath.Name),
+                            shared.VolumeMgr.GetVolumeRawIdentifier(HardDisk));
+
+                        if (HardDisk.SaveFile(harddiskPath, bootVolumeFile.ReadAll()) == null)
                         {
                             // Throwing an exception during InitObjects will break the initialization and won't show
                             // the error to the user.  So we just log the error instead.  At some point in the future
@@ -380,6 +405,7 @@ namespace kOS.Module
                     }
                 }
             }
+
             shared.VolumeMgr.Add(HardDisk);
 
             // process setting

--- a/src/kOS/Persistence/PersistenceExtensions.cs
+++ b/src/kOS/Persistence/PersistenceExtensions.cs
@@ -7,9 +7,15 @@ using System.Text;
 
 namespace kOS.Persistence
 {
+
+    /// <summary>
+    /// Persistence extensions needed to store Harddisks in KSP saves files. Perhaps one day we could use serialization instead
+    /// and simplify all of this (and make it unit testable too).
+    /// </summary>
     public static class PersistenceExtensions
     {
-        private const string FILENAME_VALUE_STRING = "filename";
+        private const string FilenameValueString = "filename";
+        private const string DirnameValueString = "dirname";
 
         public static Harddisk ToHardDisk(this ConfigNode configNode)
         {
@@ -22,32 +28,61 @@ namespace kOS.Persistence
             if (configNode.HasValue("volumeName"))
                 toReturn.Name = configNode.GetValue("volumeName");
 
-            foreach (ConfigNode fileNode in configNode.GetNodes("file"))
-            {
-                toReturn.Save(fileNode.ToHarddiskFile(toReturn));
-            }
+            toReturn.RootHarddiskDirectory = configNode.ToHarddiskDirectory(toReturn, VolumePath.EMPTY);
+
             return toReturn;
         }
 
-        public static HarddiskFile ToHarddiskFile(this ConfigNode configNode, Harddisk harddisk)
+        private static HarddiskDirectory ToHarddiskDirectory(this ConfigNode configNode, Harddisk harddisk, VolumePath parentPath)
         {
-            var filename = configNode.GetValue(FILENAME_VALUE_STRING);
+            string dirName = configNode.GetValue(DirnameValueString);
+            HarddiskDirectory directory = new HarddiskDirectory(harddisk, VolumePath.FromString(dirName, parentPath));
 
-            FileContent fileContent = Decode(configNode.GetValue("line"));
-            harddisk.Save(filename, fileContent);
-            return new HarddiskFile(harddisk, filename);
+            foreach (ConfigNode fileNode in configNode.GetNodes("file"))
+            {
+                directory.CreateFile(fileNode.GetValue(FilenameValueString), fileNode.ToHarddiskFile(harddisk, directory));
+            }
+
+            foreach (ConfigNode dirNode in configNode.GetNodes("directory"))
+            {
+                directory.CreateDirectory(dirName, dirNode.ToHarddiskDirectory(harddisk, VolumePath.FromString(dirName, parentPath)));
+            }
+
+            return directory;
+        }
+
+        public static FileContent ToHarddiskFile(this ConfigNode configNode, Harddisk harddisk, HarddiskDirectory directory)
+        {
+            return Decode(configNode.GetValue("line"));
         }
 
         public static ConfigNode ToConfigNode(this Harddisk harddisk, string nodeName)
         {
-            var node = new ConfigNode(nodeName);
+            var node = harddisk.RootHarddiskDirectory.ToConfigNode(nodeName);
             node.AddValue("capacity", harddisk.Capacity);
             node.AddValue("volumeName", harddisk.Name);
 
-            foreach (VolumeFile volumeFile in harddisk.FileList.Values)
+            return node;
+        }
+
+        public static ConfigNode ToConfigNode(this HarddiskDirectory directory, string nodeName)
+        {
+            ConfigNode node = new ConfigNode(nodeName);
+            node.AddValue(DirnameValueString, directory.Name);
+
+            foreach (VolumeItem item in directory)
             {
-                var file = (HarddiskFile) volumeFile;
-                node.AddNode(file.ToConfigNode("file"));
+                if (item is HarddiskDirectory)
+                {
+                    HarddiskDirectory dir = item as HarddiskDirectory;
+                    node.AddNode(dir.ToConfigNode("directory"));
+                }
+
+                if (item is HarddiskFile)
+                {
+                    HarddiskFile file = item as HarddiskFile;
+                    node.AddNode(file.ToConfigNode("file"));
+                }
             }
 
             return node;
@@ -56,7 +91,7 @@ namespace kOS.Persistence
         public static ConfigNode ToConfigNode(this HarddiskFile file, string nodeName)
         {
             var node = new ConfigNode(nodeName);
-            node.AddValue(FILENAME_VALUE_STRING, file.Name);
+            node.AddValue(FilenameValueString, file.Name);
 
             FileContent content = file.ReadAll();
 

--- a/src/kOS/Persistence/PersistenceExtensions.cs
+++ b/src/kOS/Persistence/PersistenceExtensions.cs
@@ -33,10 +33,9 @@ namespace kOS.Persistence
             return toReturn;
         }
 
-        private static HarddiskDirectory ToHarddiskDirectory(this ConfigNode configNode, Harddisk harddisk, VolumePath parentPath)
+        private static HarddiskDirectory ToHarddiskDirectory(this ConfigNode configNode, Harddisk harddisk, VolumePath path)
         {
-            string dirName = configNode.GetValue(DirnameValueString);
-            HarddiskDirectory directory = new HarddiskDirectory(harddisk, VolumePath.FromString(dirName, parentPath));
+            HarddiskDirectory directory = new HarddiskDirectory(harddisk, path);
 
             foreach (ConfigNode fileNode in configNode.GetNodes("file"))
             {
@@ -45,7 +44,9 @@ namespace kOS.Persistence
 
             foreach (ConfigNode dirNode in configNode.GetNodes("directory"))
             {
-                directory.CreateDirectory(dirName, dirNode.ToHarddiskDirectory(harddisk, VolumePath.FromString(dirName, parentPath)));
+                string dirName = dirNode.GetValue(DirnameValueString);
+
+                directory.CreateDirectory(dirName, dirNode.ToHarddiskDirectory(harddisk, VolumePath.FromString(dirName, path)));
             }
 
             return directory;

--- a/src/kOS/Screen/Interpreter.cs
+++ b/src/kOS/Screen/Interpreter.cs
@@ -6,11 +6,14 @@ using kOS.Safe.Compilation;
 using kOS.Safe.Execution;
 using kOS.Safe.Screen;
 using kOS.Safe.UserIO;
+using kOS.Safe.Persistence;
 
 namespace kOS.Screen
 {
     public class Interpreter : TextEditor, IInterpreter
     {
+        public static GlobalPath InterpreterHistory = GlobalPath.FromString("interpreterhistory:");
+
         private readonly List<string> commandHistory = new List<string>();
         private int commandHistoryIndex;
         private bool locked;
@@ -139,7 +142,7 @@ namespace kOS.Screen
                     IsCalledFromRun = false
                 };
 
-                List<CodePart> commandParts = Shared.ScriptHandler.Compile("interpreter history", commandHistoryIndex, commandText, "interpreter", options);
+                List<CodePart> commandParts = Shared.ScriptHandler.Compile(InterpreterHistory, commandHistoryIndex, commandText, "interpreter", options);
                 if (commandParts == null) return;
 
                 var interpreterContext = ((CPU)Shared.Cpu).GetInterpreterContext();

--- a/src/kOS/Screen/Interpreter.cs
+++ b/src/kOS/Screen/Interpreter.cs
@@ -12,7 +12,7 @@ namespace kOS.Screen
 {
     public class Interpreter : TextEditor, IInterpreter
     {
-        public static GlobalPath InterpreterHistory = GlobalPath.FromString("interpreterhistory:");
+        public static GlobalPath InterpreterHistory = GlobalPath.FromString("terminal:");
 
         private readonly List<string> commandHistory = new List<string>();
         private int commandHistoryIndex;

--- a/src/kOS/Screen/Interpreter.cs
+++ b/src/kOS/Screen/Interpreter.cs
@@ -12,8 +12,7 @@ namespace kOS.Screen
 {
     public class Interpreter : TextEditor, IInterpreter
     {
-        public static GlobalPath InterpreterHistory = new InterpreterPath();
-
+        public const string InterpreterName = "interpreter";
         private readonly List<string> commandHistory = new List<string>();
         private int commandHistoryIndex;
         private bool locked;
@@ -142,7 +141,8 @@ namespace kOS.Screen
                     IsCalledFromRun = false
                 };
 
-                List<CodePart> commandParts = Shared.ScriptHandler.Compile(InterpreterHistory, commandHistoryIndex, commandText, "interpreter", options);
+                List<CodePart> commandParts = Shared.ScriptHandler.Compile(new InterpreterPath(this),
+                    commandHistoryIndex, commandText, InterpreterName, options);
                 if (commandParts == null) return;
 
                 var interpreterContext = ((CPU)Shared.Cpu).GetInterpreterContext();
@@ -166,7 +166,7 @@ namespace kOS.Screen
 
         public override void Reset()
         {
-            Shared.ScriptHandler.ClearContext("interpreter");
+            Shared.ScriptHandler.ClearContext(InterpreterName);
             commandHistory.Clear();
             commandHistoryIndex = 0;
             base.Reset();
@@ -179,16 +179,23 @@ namespace kOS.Screen
             RestoreCursorPos();
         }
 
-        private class InterpreterPath : GlobalPath
+        private class InterpreterPath : InternalPath
         {
-            public InterpreterPath() : base("Interpreter")
-            {
+            private Interpreter interpreter;
 
+            public InterpreterPath(Interpreter interpreter) : base()
+            {
+                this.interpreter = interpreter;
+            }
+
+            public override string Line(int line)
+            {
+                return interpreter.GetCommandHistoryAbsolute(line);
             }
 
             public override string ToString()
             {
-                return "[Interpreter]";
+                return InterpreterName;
             }
         }
     }

--- a/src/kOS/Screen/Interpreter.cs
+++ b/src/kOS/Screen/Interpreter.cs
@@ -12,7 +12,7 @@ namespace kOS.Screen
 {
     public class Interpreter : TextEditor, IInterpreter
     {
-        public static GlobalPath InterpreterHistory = GlobalPath.FromString("terminal:");
+        public static GlobalPath InterpreterHistory = new InterpreterPath();
 
         private readonly List<string> commandHistory = new List<string>();
         private int commandHistoryIndex;
@@ -177,6 +177,19 @@ namespace kOS.Screen
             SaveCursorPos();
             base.PrintAt(textToPrint, row, column);
             RestoreCursorPos();
+        }
+
+        private class InterpreterPath : GlobalPath
+        {
+            public InterpreterPath() : base("Interpreter")
+            {
+
+            }
+
+            public override string ToString()
+            {
+                return "[Interpreter]";
+            }
         }
     }
 }

--- a/src/kOS/Screen/KOSTextEditPopup.cs
+++ b/src/kOS/Screen/KOSTextEditPopup.cs
@@ -3,6 +3,7 @@ using kOS.Safe.Persistence;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using kOS.Safe.Exceptions;
 
 namespace kOS.Screen
 {
@@ -25,8 +26,8 @@ namespace kOS.Screen
         private Rect reloadCoords;
         private Rect resizeButtonCoords;
         private TermWindow term; // The terminal that this popup is attached to.
-        private string fileName = "";
-        private string loadingFileName = "";
+        private GlobalPath filePath;
+        private GlobalPath loadingPath;
         private Volume volume;
         private Volume loadingVolume;
         private string contents = "";
@@ -61,14 +62,14 @@ namespace kOS.Screen
             urlGetter.LoadImageIntoTexture(resizeImage);
         }
 
-        public void AttachTo(TermWindow termWindow, Volume attachVolume, string attachFileName = "")
+        public void AttachTo(TermWindow termWindow, Volume attachVolume, GlobalPath path)
         {
             term = termWindow;
             WindowRect = new Rect(0, 0, 470, 280); // will be resized and moved in onGUI.
             frozen = false;
             loadingVolume = attachVolume;
-            loadingFileName = attachFileName;
-            LoadContents(attachVolume, attachFileName);
+            loadingPath = path;
+            LoadContents(attachVolume, path);
         }
 
         public bool Contains(Vector2 posAbs)
@@ -144,7 +145,7 @@ namespace kOS.Screen
 
         public void SaveContents()
         {
-            if (volume.Save(fileName, new FileContent(contents)) == null)
+            if (volume.Save(filePath, new FileContent(contents)) == null)
             {
                 // For some reason the normal trap that prints exceptions on
                 // the terminal doesn't work here in this part of the code,
@@ -153,7 +154,7 @@ namespace kOS.Screen
                 throw new Exception("File Save Failed from Text Editor.");
             }
             isDirty = false;
-            term.Print("[Saved changes to " + fileName + "]");
+            term.Print("[Saved changes to " + filePath + "]");
         }
 
         protected void ReloadContents()
@@ -164,19 +165,19 @@ namespace kOS.Screen
                 DelegateLoadContents(this);
         }
 
-        public void LoadContents(Volume vol, string fName)
+        public void LoadContents(Volume vol, GlobalPath path)
         {
             if (isDirty)
             {
                 Freeze(true);
                 InvokeDirtySaveLoadDialog();
                 loadingVolume = vol;
-                loadingFileName = fName;
+                loadingPath = path;
             }
             else
             {
                 loadingVolume = vol;
-                loadingFileName = fName;
+                loadingPath = path;
                 DelegateLoadContents(this);
             }
         }
@@ -192,7 +193,7 @@ namespace kOS.Screen
             choices.Add("Cancel");
             actions.Add(DelegateCancel);
 
-            dialog.Invoke(this, "\"" + fileName + "\" has been edited.  Save it before exiting?", choices, actions);
+            dialog.Invoke(this, "\"" + filePath + "\" has been edited.  Save it before exiting?", choices, actions);
         }
 
         protected void InvokeDirtySaveLoadDialog()
@@ -206,7 +207,7 @@ namespace kOS.Screen
             choices.Add("Cancel");
             actions.Add(DelegateCancel);
 
-            dialog.Invoke(this, "\"" + fileName + "\" has been edited.  Save before loading \"" + loadingFileName + "\"?", choices, actions);
+            dialog.Invoke(this, "\"" + filePath + "\" has been edited.  Save before loading \"" + loadingPath.Name + "\"?", choices, actions);
         }
 
         protected void InvokeReloadConfirmDialog()
@@ -218,7 +219,7 @@ namespace kOS.Screen
             choices.Add("No");
             actions.Add(DelegateCancel);
 
-            dialog.Invoke(this, "\"" + fileName + "\" has been edited.  Throw away changes and reload?", choices, actions);
+            dialog.Invoke(this, "\"" + filePath + "\" has been edited.  Throw away changes and reload?", choices, actions);
         }
 
         protected static void DelegateSaveExit(KOSTextEditPopup me)
@@ -242,18 +243,22 @@ namespace kOS.Screen
 
         protected static void DelegateLoadContents(KOSTextEditPopup me)
         {
-            me.volume = me.loadingVolume;
-            me.fileName = me.loadingFileName;
-            VolumeFile file = me.volume.Open(me.fileName);
-            if (file == null)
+            VolumeItem item = me.loadingVolume.Open(me.filePath);
+            if (item == null)
             {
                 me.term.Print("[New File]");
                 me.contents = "";
-            }
-            else
+            } else if (item is VolumeFile)
             {
+                VolumeFile file = item as VolumeFile;
                 me.contents = file.ReadAll().String;
+            } else
+            {
+                throw new KOSPersistenceException("Path '" + me.filePath + "' points to a directory");
             }
+
+            me.volume = me.loadingVolume;
+            me.filePath = me.loadingPath;
             me.isDirty = false;
         }
 
@@ -515,8 +520,8 @@ namespace kOS.Screen
         protected string BuildTitle()
         {
             if (volume.Name.Length > 0)
-                return fileName + " on " + volume.Name;
-            return fileName + " on local volume";  // Don't know which number because no link to VolumeManager from this class.
+                return filePath + " on " + volume.Name;
+            return filePath + " on local volume";  // Don't know which number because no link to VolumeManager from this class.
         }
     }
 }

--- a/src/kOS/Screen/KOSTextEditPopup.cs
+++ b/src/kOS/Screen/KOSTextEditPopup.cs
@@ -243,7 +243,7 @@ namespace kOS.Screen
 
         protected static void DelegateLoadContents(KOSTextEditPopup me)
         {
-            VolumeItem item = me.loadingVolume.Open(me.filePath);
+            VolumeItem item = me.loadingVolume.Open(me.loadingPath);
             if (item == null)
             {
                 me.term.Print("[New File]");
@@ -519,9 +519,7 @@ namespace kOS.Screen
 
         protected string BuildTitle()
         {
-            if (volume.Name.Length > 0)
-                return filePath + " on " + volume.Name;
-            return filePath + " on local volume";  // Don't know which number because no link to VolumeManager from this class.
+            return filePath.ToString();
         }
     }
 }

--- a/src/kOS/Screen/KOSTextEditPopup.cs
+++ b/src/kOS/Screen/KOSTextEditPopup.cs
@@ -145,7 +145,7 @@ namespace kOS.Screen
 
         public void SaveContents()
         {
-            if (volume.Save(filePath, new FileContent(contents)) == null)
+            if (volume.SaveFile(filePath, new FileContent(contents)) == null)
             {
                 // For some reason the normal trap that prints exceptions on
                 // the terminal doesn't work here in this part of the code,

--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -194,9 +194,9 @@ namespace kOS.Screen
             if (imageLoader.isDone && imageLoader.size == 0) allTexturesFound = false;
         }
         
-        public void OpenPopupEditor( Volume v, string fName )
+        public void OpenPopupEditor(Volume v, GlobalPath path)
         {
-            popupEditor.AttachTo(this, v, fName );
+            popupEditor.AttachTo(this, v, path);
             popupEditor.Open();
         }
         

--- a/src/kOS/Serialization/IHasSharedObjects.cs
+++ b/src/kOS/Serialization/IHasSharedObjects.cs
@@ -14,4 +14,3 @@ namespace kOS.Serialization
         SharedObjects Shared { set; }
     }
 }
-

--- a/src/kOS/Serialization/IHasSharedObjects.cs
+++ b/src/kOS/Serialization/IHasSharedObjects.cs
@@ -1,7 +1,14 @@
 ﻿using kOS.Safe.Encapsulation;
+using kOS.Safe.Serialization;
 
 namespace kOS.Serialization
 {
+    /// <summary>
+    /// Indicates that a class need an instance of kOS.SharedObjects to function.
+    ///
+    /// SerializationMgr will provide an instance of SharedObjects during deserialization.
+    /// </summary>
+    /// <seealso cref="IHasSafeSharedObjects"/>
     public interface IHasSharedObjects
     {
         SharedObjects Shared { set; }

--- a/src/kOS/Serialization/SerializationMgr.cs
+++ b/src/kOS/Serialization/SerializationMgr.cs
@@ -12,16 +12,10 @@ namespace kOS.Serialization
     {
         private readonly SharedObjects sharedObjects;
 
-        static SerializationMgr()
+        public SerializationMgr(SharedObjects sharedObjects) : base(sharedObjects)
         {
             SafeSerializationMgr.AddAssembly(typeof(SerializationMgr).Assembly.FullName);
         }
-
-        public SerializationMgr(SharedObjects sharedObjects)
-        {
-            this.sharedObjects = sharedObjects;
-        }
-
 
         public override IDumper CreateAndLoad(string typeFullName, Dump data)
         {
@@ -30,6 +24,10 @@ namespace kOS.Serialization
             if (instance is IHasSharedObjects)
             {
                 IHasSharedObjects withSharedObjects = instance as IHasSharedObjects;
+                withSharedObjects.Shared = sharedObjects;
+            } else if (instance is IHasSafeSharedObjects)
+            {
+                IHasSafeSharedObjects withSharedObjects = instance as IHasSafeSharedObjects;
                 withSharedObjects.Shared = sharedObjects;
             }
 

--- a/src/kOS/SharedObjects.cs
+++ b/src/kOS/SharedObjects.cs
@@ -6,7 +6,7 @@ using kOS.Screen;
 
 namespace kOS
 {
-    public class SharedObjects : Safe.SharedObjects
+    public class SharedObjects : Safe.SafeSharedObjects
     {
         public Vessel Vessel { get; set; }
         public ProcessorManager ProcessorMgr { get; set; }

--- a/src/kOS/Suffixed/BodyAtmosphere.cs
+++ b/src/kOS/Suffixed/BodyAtmosphere.cs
@@ -19,7 +19,7 @@ namespace kOS.Suffixed
             AddSuffix("SEALEVELPRESSURE", new Suffix<ScalarValue>(()=> celestialBody.atmosphere ? celestialBody.atmospherePressureSeaLevel : 0));
             AddSuffix("HEIGHT", new Suffix<ScalarValue>(()=> celestialBody.atmosphere ? celestialBody.atmosphereDepth : 0));
 
-            AddSuffix("SCALE", new Suffix<ScalarValue>(() => { throw new KOSAtmosphereDeprecationException("0.17.2","SCALE","<None>",string.Empty); }));
+            AddSuffix("SCALE", new Suffix<ScalarValue>(() => { throw new KOSAtmosphereDeprecationException("0.17.2", "SCALE", "<None>"); }));
         }
 
         public override string ToString()

--- a/src/kOS/Suffixed/BodyAtmosphere.cs
+++ b/src/kOS/Suffixed/BodyAtmosphere.cs
@@ -19,7 +19,7 @@ namespace kOS.Suffixed
             AddSuffix("SEALEVELPRESSURE", new Suffix<ScalarValue>(()=> celestialBody.atmosphere ? celestialBody.atmospherePressureSeaLevel : 0));
             AddSuffix("HEIGHT", new Suffix<ScalarValue>(()=> celestialBody.atmosphere ? celestialBody.atmosphereDepth : 0));
 
-            AddSuffix("SCALE", new Suffix<ScalarValue>(() => { throw new KOSAtmosphereDeprecationException("0.17.2", "SCALE", "<None>"); }));
+            AddSuffix("SCALE", new Suffix<ScalarValue>(() => { throw new KOSAtmosphereDeprecationException("0.17.2","SCALE","<None>",string.Empty); }));
         }
 
         public override string ToString()

--- a/src/kOS/Suffixed/Part/DockingPortValue.cs
+++ b/src/kOS/Suffixed/Part/DockingPortValue.cs
@@ -18,9 +18,9 @@ namespace kOS.Suffixed.Part
 
         private void DockingInitializeSuffixes()
         {
-            AddSuffix("AQUIRERANGE", new Suffix<ScalarValue>(() => { throw new Safe.Exceptions.KOSDeprecationException("0.18.0", "AQUIRERANGE", "ACQUIRERANGE"); }));
-            AddSuffix("AQUIREFORCE", new Suffix<ScalarValue>(() => { throw new Safe.Exceptions.KOSDeprecationException("0.18.0", "AQUIREFORCE", "ACQUIREFORCE"); }));
-            AddSuffix("AQUIRETORQUE", new Suffix<ScalarValue>(() => { throw new Safe.Exceptions.KOSDeprecationException("0.18.0", "AQUIRETORQUE", "ACQUIRETORQUE"); }));
+            AddSuffix("AQUIRERANGE", new Suffix<ScalarValue>(() => { throw new Safe.Exceptions.KOSDeprecationException("0.18.0", "AQUIRERANGE", "ACQUIRERANGE", string.Empty); }));
+            AddSuffix("AQUIREFORCE", new Suffix<ScalarValue>(() => { throw new Safe.Exceptions.KOSDeprecationException("0.18.0", "AQUIREFORCE", "ACQUIREFORCE", string.Empty); }));
+            AddSuffix("AQUIRETORQUE", new Suffix<ScalarValue>(() => { throw new Safe.Exceptions.KOSDeprecationException("0.18.0", "AQUIRETORQUE", "ACQUIRETORQUE", string.Empty); }));
             AddSuffix("ACQUIRERANGE", new Suffix<ScalarValue>(() => module.acquireRange));
             AddSuffix("ACQUIREFORCE", new Suffix<ScalarValue>(() => module.acquireForce));
             AddSuffix("ACQUIRETORQUE", new Suffix<ScalarValue>(() => module.acquireTorque));

--- a/src/kOS/Suffixed/Part/DockingPortValue.cs
+++ b/src/kOS/Suffixed/Part/DockingPortValue.cs
@@ -18,9 +18,9 @@ namespace kOS.Suffixed.Part
 
         private void DockingInitializeSuffixes()
         {
-            AddSuffix("AQUIRERANGE", new Suffix<ScalarValue>(() => { throw new Safe.Exceptions.KOSDeprecationException("0.18.0", "AQUIRERANGE", "ACQUIRERANGE", string.Empty); }));
-            AddSuffix("AQUIREFORCE", new Suffix<ScalarValue>(() => { throw new Safe.Exceptions.KOSDeprecationException("0.18.0", "AQUIREFORCE", "ACQUIREFORCE", string.Empty); }));
-            AddSuffix("AQUIRETORQUE", new Suffix<ScalarValue>(() => { throw new Safe.Exceptions.KOSDeprecationException("0.18.0", "AQUIRETORQUE", "ACQUIRETORQUE", string.Empty); }));
+            AddSuffix("AQUIRERANGE", new Suffix<ScalarValue>(() => { throw new Safe.Exceptions.KOSDeprecationException("0.18.0", "AQUIRERANGE", "ACQUIRERANGE"); }));
+            AddSuffix("AQUIREFORCE", new Suffix<ScalarValue>(() => { throw new Safe.Exceptions.KOSDeprecationException("0.18.0", "AQUIREFORCE", "ACQUIREFORCE"); }));
+            AddSuffix("AQUIRETORQUE", new Suffix<ScalarValue>(() => { throw new Safe.Exceptions.KOSDeprecationException("0.18.0", "AQUIRETORQUE", "ACQUIRETORQUE"); }));
             AddSuffix("ACQUIRERANGE", new Suffix<ScalarValue>(() => module.acquireRange));
             AddSuffix("ACQUIREFORCE", new Suffix<ScalarValue>(() => module.acquireForce));
             AddSuffix("ACQUIRETORQUE", new Suffix<ScalarValue>(() => module.acquireTorque));

--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -435,12 +435,12 @@ namespace kOS.Suffixed
             AddSuffix("MASS", new Suffix<ScalarValue>(() => Vessel.GetTotalMass()));
             AddSuffix("VERTICALSPEED", new Suffix<ScalarValue>(() => Vessel.verticalSpeed));
             AddSuffix("GROUNDSPEED", new Suffix<ScalarValue>(GetHorizontalSrfSpeed));
-            AddSuffix("SURFACESPEED", new Suffix<ScalarValue>(() => { throw new KOSDeprecationException("0.18.0","SURFACESPEED","GROUNDSPEED"); }));
+            AddSuffix("SURFACESPEED", new Suffix<ScalarValue>(() => { throw new KOSDeprecationException("0.18.0","SURFACESPEED","GROUNDSPEED",""); }));
             AddSuffix("AIRSPEED", new Suffix<ScalarValue>(() => (Vessel.orbit.GetVel() - FlightGlobals.currentMainBody.getRFrmVel(Vessel.findWorldCenterOfMass())).magnitude, "the velocity of the vessel relative to the air"));
             AddSuffix(new[] { "SHIPNAME", "NAME" }, new SetSuffix<StringValue>(() => Vessel.vesselName, RenameVessel, "The KSP name for a craft, cannot be empty"));
             AddSuffix("TYPE", new SetSuffix<StringValue>(() => Vessel.vesselType.ToString(), RetypeVessel, "The Ship's KSP type (e.g. rover, base, probe)"));
             AddSuffix("SENSORS", new Suffix<VesselSensors>(() => new VesselSensors(Vessel)));
-            AddSuffix("TERMVELOCITY", new Suffix<ScalarValue>(() => { throw new KOSAtmosphereDeprecationException("17.2", "TERMVELOCITY", "<None>"); }));
+            AddSuffix("TERMVELOCITY", new Suffix<ScalarValue>(() => { throw new KOSAtmosphereDeprecationException("17.2", "TERMVELOCITY", "<None>", string.Empty); }));
             AddSuffix(new [] { "DYNAMICPRESSURE" , "Q"} , new Suffix<ScalarValue>(() => Vessel.dynamicPressurekPa * ConstantValue.KpaToAtm, "Dynamic Pressure in Atmospheres"));
             AddSuffix("LOADED", new Suffix<BooleanValue>(() => Vessel.loaded));
             AddSuffix("UNPACKED", new Suffix<BooleanValue>(() => !Vessel.packed));

--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -435,12 +435,12 @@ namespace kOS.Suffixed
             AddSuffix("MASS", new Suffix<ScalarValue>(() => Vessel.GetTotalMass()));
             AddSuffix("VERTICALSPEED", new Suffix<ScalarValue>(() => Vessel.verticalSpeed));
             AddSuffix("GROUNDSPEED", new Suffix<ScalarValue>(GetHorizontalSrfSpeed));
-            AddSuffix("SURFACESPEED", new Suffix<ScalarValue>(() => { throw new KOSDeprecationException("0.18.0","SURFACESPEED","GROUNDSPEED",""); }));
+            AddSuffix("SURFACESPEED", new Suffix<ScalarValue>(() => { throw new KOSDeprecationException("0.18.0","SURFACESPEED","GROUNDSPEED"); }));
             AddSuffix("AIRSPEED", new Suffix<ScalarValue>(() => (Vessel.orbit.GetVel() - FlightGlobals.currentMainBody.getRFrmVel(Vessel.findWorldCenterOfMass())).magnitude, "the velocity of the vessel relative to the air"));
             AddSuffix(new[] { "SHIPNAME", "NAME" }, new SetSuffix<StringValue>(() => Vessel.vesselName, RenameVessel, "The KSP name for a craft, cannot be empty"));
             AddSuffix("TYPE", new SetSuffix<StringValue>(() => Vessel.vesselType.ToString(), RetypeVessel, "The Ship's KSP type (e.g. rover, base, probe)"));
             AddSuffix("SENSORS", new Suffix<VesselSensors>(() => new VesselSensors(Vessel)));
-            AddSuffix("TERMVELOCITY", new Suffix<ScalarValue>(() => { throw new KOSAtmosphereDeprecationException("17.2", "TERMVELOCITY", "<None>", string.Empty); }));
+            AddSuffix("TERMVELOCITY", new Suffix<ScalarValue>(() => { throw new KOSAtmosphereDeprecationException("17.2", "TERMVELOCITY", "<None>"); }));
             AddSuffix(new [] { "DYNAMICPRESSURE" , "Q"} , new Suffix<ScalarValue>(() => Vessel.dynamicPressurekPa * ConstantValue.KpaToAtm, "Dynamic Pressure in Atmospheres"));
             AddSuffix("LOADED", new Suffix<BooleanValue>(() => Vessel.loaded));
             AddSuffix("UNPACKED", new Suffix<BooleanValue>(() => !Vessel.packed));


### PR DESCRIPTION
Fixes #1364, fixes #778, fixes #754, fixes #1136, fixes #969, fixes #1536 

I've started to update my old subdirectories code. I should have time to work on it in the next few days and I hope to make solid progress on the whole subdirectories front.

### Breaking changes:
- Boot files are now expected to be placed in `boot` directory.
- `delete filename from volume`, `copy filename from/to volume`, `rename (both forms)` have been deprecated in favor of `deletepath(path)`, `copypath(fromPath, toPath)`, `movepath(fromPath, toPath)` and `set volume:name to newname`.

### Here's an outline of things to do:

- [x] Path handling types
- [x] `VolumeDirectory` type
- [x] Support directories on Archive
- [x] Support directories on Harddisk
- [x] Add directory support to Harddisk persistence
- [x] Substitute all occurences of string filenames with `GlobalPath`
- [x] Access path of the current script
- [x] Userspace `Path` type
- [x] `path()` command to create paths (`path` with no arguments creates a `Path` for the current path)
- [x] `VolumeDirectory` as a userspace type
- [x] Add a `volume()` command, to get a volume by name or id
- [x] `Volume` suffixes should accept strings representing `VolumePath`s
- [x] Expose all new stuff to the user, add new commands and change syntax wherever necessary
- [x] `copypath()` command
- [x] `movepath()` command
- [x] commands that accept string paths should also work with instances of `Path`
- [x] Make sure everything works (and doesn't work when it shouldn't) with RemoteTech
- [x] Test with compressed persistence disabled and enabled
- [x] Test everything with cooked filenames
- [x] Revert the change to KOSDeprecationException
- [x] List files from `boot` directory as bootfiles
- [x] test case sensitivity on archive
- [x] `Path` documentation
- [x] Document new `Volume` suffixes
- [x] Document `path()`
- [x] Document `volume()`
- [x] Document `scriptpath()`
- [x] Document `cd()`
- [x] Document `copypath()`, `movepath()`, `deletepath()`
- [x] Document `createdir()`
- [x] Document changes to `create()`, `exists()` and `open()`
- [x] `VolumeItem` documentation
- [x] `VolumeDirectory` documentation
- [x] Document new boot file handling
- [x] Review existing documentation and update if necessary