### PR TITLE
Fixes 1573 toolbar window for ksp 1.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ####INDEX
 * [Pull Requests](#pull-requests)
-  * [Nobody merges their own PR](#nobody-merges-their-own-pr
+  * [Nobody merges their own PR](#nobody-merges-their-own-pr)
 * [Setting Up Your Environment](#setting-up-your-environment)
   * [Assumptions](#assumptions)
   * [Your Repository](#setting-up-your-repository)

--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -14,7 +14,6 @@ using kOS.Safe.Screen;
 using kOS.Safe.Utilities;
 using kOS.Utilities;
 using KSP.IO;
-using KSPAPIExtensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/kOS/kOS.csproj
+++ b/src/kOS/kOS.csproj
@@ -48,9 +48,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="KSPAPIExtensions">
-      <HintPath>..\..\..\..\..\Dropbox\kOS\KSPAPIExtensions.dll</HintPath>
-    </Reference>
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Resources\UnityEngine.dll</HintPath>
@@ -116,7 +113,7 @@
     <Compile Include="Screen\KOSManagedWindow.cs" />
     <Compile Include="Screen\KOSNameTagWindow.cs" />
     <Compile Include="Screen\KOSTextEditPopup.cs" />
-    <Compile Include="Screen\KOSToolBarWindow.cs" />
+    <Compile Include="Screen\KOSToolbarWindow.cs" />
     <Compile Include="Screen\ToolbarWrapper.cs" />
     <Compile Include="Suffixed\ActiveResourceValue.cs" />
     <Compile Include="Suffixed\BodyAtmosphere.cs" />


### PR DESCRIPTION
(Also contains the compiled locks stuff because that's apparently not in develop-1.1 yet), although that had nothing to do with the work I did in this PR.  It's just something from vanilla develop that isn't in develop-1.1.