### PR TITLE
Fix node removal

### DIFF
--- a/src/kOS/Suffixed/Node.cs
+++ b/src/kOS/Suffixed/Node.cs
@@ -164,7 +164,7 @@ namespace kOS.Suffixed
                     "A KSP limitation makes it impossible to access the manuever nodes of this vessel at this time. " +
                     "(perhaps it's not the active vessel?)");
 
-            vesselRef.patchedConicSolver.RemoveManeuverNode(nodeRef);
+            nodeRef.RemoveSelf();
 
             nodeRef = null;
             vesselRef = null;


### PR DESCRIPTION
Fixes #1572

Node.cs
* Use nodeRef.RemoveSelf() in place of
patchedConicSolver.RemoveManeuverNode(nodeRef).  Using the patched conic
solver did not clean up the graphical element and cause an artifact at
the center of the map view and flight view.