### PR TITLE
Fixes #1610: The problem was caused by not clearing the stack when aborting with c…

### DIFF
--- a/src/kOS.Safe/Execution/CPU.cs
+++ b/src/kOS.Safe/Execution/CPU.cs
@@ -371,6 +371,7 @@ namespace kOS.Safe.Execution
                     shared.Screen.Print("Program aborted.");
                     shared.BindingMgr.UnBindAll();
                     PrintStatistics();
+                    stack.Clear();
                 }
                 else
                 {
@@ -381,6 +382,7 @@ namespace kOS.Safe.Execution
                         shared.Screen.Print("Program ended.");
                         shared.BindingMgr.UnBindAll();
                         PrintStatistics();
+                        stack.Clear();
                     }
                 }
             }
@@ -413,11 +415,13 @@ namespace kOS.Safe.Execution
         {
             if (userDelegate.ProgContext != currentContext)
             {
-                throw new KOSInvalidDelegateContextException(
-                    (currentContext == contexts[0] ? "the interpreter" : "a program"),
-                    (currentContext == contexts[0] ? "a program" : "the interpreter")
-                    );
-            }
+                string currentContextName = (currentContext == contexts[0] ? "the interpreter" : "a program");
+                string delegateContextName = (
+                    userDelegate.ProgContext == contexts[0] ? currentContextName = "the interpreter" : (
+                        currentContext == contexts[0] ? "a program" : "a different program from a previous run" ) );
+
+                throw new KOSInvalidDelegateContextException(currentContextName, delegateContextName);
+           }
         }
 
         /// <summary>


### PR DESCRIPTION
…ontrol-C.

Fixes #1610 

It was falsifying the notion of whether or not the system is at
global scope when it sees a "local" directive, because it
saw the leftover remains of the previous run on the stack.  That
error cascaded into other problems causing it to end up seeing
the old leftover version of the delegate that was still in the
global variable from last time.