### PR TITLE
Separate pitch, yaw and roll gimbal enabling/locking

### DIFF
--- a/doc/source/structures/vessels/gimbal.rst
+++ b/doc/source/structures/vessels/gimbal.rst
@@ -23,7 +23,19 @@ Many engines in KSP have thrust vectoring gimbals which are handled by their own
         * - :attr:`LOCK`
           - :ref:`Boolean <boolean>`
           - Is the Gimbal locked in neutral position? 
-          
+
+        * - :attr:`PITCH`
+          - :ref:`Boolean <boolean>`
+          - Does the Gimbal respond to pitch controls? 
+
+        * - :attr:`YAW`
+          - :ref:`Boolean <boolean>`
+          - Does the Gimbal respond to yaw controls? 
+
+        * - :attr:`ROLL`
+          - :ref:`Boolean <boolean>`
+          - Does the Gimbal respond to roll controls? 
+
         * - :attr:`LIMIT`
           - :ref:`scalar <scalar>` (%)
           - Percentage of the maximum range the Gimbal is allowed to travel 
@@ -60,6 +72,27 @@ Many engines in KSP have thrust vectoring gimbals which are handled by their own
     :access: Get/Set
         
     Is this gimbal locked to neutral position and not responding to steering controls right now? When you set it to true it will snap the engine back to 0s for pitch, yaw and roll
+
+.. attribute:: Gimbal:PITCH
+
+    :type: :ref:`Boolean <boolean>`
+    :access: Get/Set
+        
+    Is the gimbal responding to pitch controls? Relevant only if the gimbal is not locked.
+
+.. attribute:: Gimbal:YAW
+
+    :type: :ref:`Boolean <boolean>`
+    :access: Get/Set
+        
+    Is the gimbal responding to yaw controls? Relevant only if the gimbal is not locked.
+
+.. attribute:: Gimbal:ROLL
+
+    :type: :ref:`Boolean <boolean>`
+    :access: Get/Set
+        
+    Is the gimbal responding to roll controls? Relevant only if the gimbal is not locked.
 
 .. attribute:: Gimbal:LIMIT
 

--- a/src/kOS/Suffixed/PartModuleField/GimbalFields.cs
+++ b/src/kOS/Suffixed/PartModuleField/GimbalFields.cs
@@ -20,6 +20,18 @@ namespace kOS.Suffixed.PartModuleField
             {
                 gimbal.gimbalLock = value;
             }, "Is the Gimbal free to travel?"));
+            AddSuffix("PITCH", new SetSuffix<BooleanValue>(() => gimbal.enablePitch, value =>
+            {
+                gimbal.enablePitch = value;
+            }, "Does the Gimbal respond to pitch controls?"));
+            AddSuffix("YAW", new SetSuffix<BooleanValue>(() => gimbal.enableYaw, value =>
+            {
+                gimbal.enableYaw = value;
+            }, "Does the Gimbal respond to yaw controls?"));
+            AddSuffix("ROLL", new SetSuffix<BooleanValue>(() => gimbal.enableRoll, value =>
+            {
+                gimbal.enableRoll = value;
+            }, "Does the Gimbal respond to roll controls?"));
             AddSuffix("LIMIT", new ClampSetSuffix<ScalarValue>(() => gimbal.gimbalLimiter,
                                               value => gimbal.gimbalLimiter = value,
                                               0f, 100f, 1f,


### PR DESCRIPTION
One of the new features of 1.1 - ability to enable/disable pitch yaw and roll response of the gimbals separately. 
Added corresponding suffixes to the Gimbal part module.