### PR TITLE
Expanded action group documentation

### DIFF
--- a/doc/source/bindings.rst
+++ b/doc/source/bindings.rst
@@ -23,22 +23,25 @@ SHIP:
 - **Description**: Whichever vessel happens to be the one containing the
   CPU part that is running this Kerboscript code at the moment. This is
   the `CPU Vessel <general/cpu_vessel.html>`__.
- 
+
 TARGET:
 
 - **Variable Name**: TARGET
 - **Gettable**: yes
 - **Settable**: yes
 - **Type**: `Vessel <structures/vessels/vessel.html>`__ or
-  `Body <structures/celestial_bodies/body.html>`__
+  `Body <structures/celestial_bodies/body.html>`__ or
+  `Part <structures/vessels/part.html>`__
+
 - **Description**: Whichever `Orbitable <structures/orbits/orbitable.html>`__
-  object happens to be the one selected as the current KSP target. If set
-  to a string, it will assume the string is the name of a vessel being
+  object happens to be the one selected as the current KSP target. If a
+  docking port is selected as the target, it will be the corresponding part.
+  If set to a string, it will assume the string is the name of a vessel being
   targeted and set it to a vessel by that name. For best results set it
   to Body("some name") or Vessel("some name") explicitly.  This will
   throw an exception if called from a vessel other than the active vessel,
   as limitations in how KSP sets the target vessel limit the
-  implementation to working with only the active vessel.  
+  implementation to working with only the active vessel.
 
 .. _hastarget:
 
@@ -81,7 +84,7 @@ ANGULARVEL       Same as SHIP:ANGULARVEL
 ANGULARVELOCITY  Same as SHIP:ANGULARVEL
 MASS             Same as SHIP:MASS
 VERTICALSPEED    Same as SHIP:VERTICALSPEED
-GROUNDSPEED      Same as SHIP:GROUNDSPEED 
+GROUNDSPEED      Same as SHIP:GROUNDSPEED
 SURFACESPEED     This has been obsoleted as of kOS 0.18.0.  Replace it with GROUNDSPEED.
 AIRSPEED         Same as SHIP:AIRSPEED
 ALTITUDE         Same as SHIP:ALTITUDE
@@ -192,7 +195,7 @@ Any other resources that you have added using other mods should be
 query-able this way, provided that you spell
 the term exactly as it appears in the resources window.
 
-You can also get a list of all resources, either in SHIP: or STAGE: with the :RESOURCES suffix. 
+You can also get a list of all resources, either in SHIP: or STAGE: with the :RESOURCES suffix.
 
 .. |Resources| image:: /_images/reference/bindings/resources.png
 
@@ -202,7 +205,7 @@ ALT ALIAS
 The special variable `ALT <structures/vessels/alt.html>`__ gives you
 access to a few altitude predictions:
 
-ALT:APOAPSIS 
+ALT:APOAPSIS
 
 ALT:PERIAPSIS
 
@@ -217,7 +220,7 @@ ETA ALIAS
 The special variable `ETA <structures/vessels/eta.html>`__ gives you
 access to a few time predictions:
 
-ETA:APOAPSIS 
+ETA:APOAPSIS
 
 ETA:PERIAPSIS
 
@@ -242,37 +245,55 @@ These are variables that behave like boolean flags. They can be True or
 False, and can be set or toggled
 using the "ON" and "OFF" and "TOGGLE" commands.
 Many of these are for action group flags.
-**NOTE ABOUT ACTION GROUP FLAGS:** If the boolean flag is for an action
+
+**NOTE ABOUT STOCK/AGE ACTION GROUP FLAGS:** If the boolean flag is for a tock or AGE action
 group, be aware that each time the
 user presses the action group keypress, it *toggles* the action group,
 so you might need to check for both
 the change in state from false to true AND the change in state from true
 to false to see if the key was hit.
+Setting a value to these flags will result in actions triggered only if the value is changed.
 
-============== ==========   ========= ===============
-Variable Name  Can Read     Can Set   Description
-============== ==========   ========= ===============
-SAS            yes          yes       (Same as "SAS" indicator on the navball.)
-RCS            yes          yes       (Same as "RCS" indicator on the navball.)
-GEAR           yes          yes       Is the GEAR enabled right now? (Note, KSP does some strange things with this flag, like needing to hit it twice the first time).
-LEGS           yes          yes       Are the landing LEGS extended? (as opposed to GEAR which is for the wheels of a plane.)
-CHUTES         yes          yes       Are the parachutes extended? (Treats all parachutes as one single unit. Does not activate them individually.)
-LIGHTS         yes          yes       Are the lights on? (like the "U" key in manual flight.)
-PANELS         yes          yes       Are the solar panels extended? (Treats all solar panels as one single unit. Does not activate them individually.)
-BRAKES         yes          yes       Are the brakes on?
-ABORT          yes          yes       Abort Action Group.
-AG1            yes          yes       Action Group 1.
-AG2            yes          yes       Action Group 2.
-AG3            yes          yes       Action Group 3.
-AG4            yes          yes       Action Group 4.
-AG5            yes          yes       Action Group 5.
-AG6            yes          yes       Action Group 6.
-AG7            yes          yes       Action Group 7.
-AG8            yes          yes       Action Group 8.
-AG9            yes          yes       Action Group 9.
-AG10           yes          yes       Action Group 10.
-AGn            yes          yes       If you have the Action Groups Extended mod installed, you can access its groups the same way, i.e. AG11, AG12, AG13, etc.
-============== ==========   ========= ===============
+**NOTE ABOUT kOS CUSTOM ACTION GROUP FLAGS:** If the boolean flag is for a kOS action
+group, be aware that the value of the flag represents the actual state of the parts of the particular type
+(most of them will always return false if no corresponding parts found) 
+and is neither guaranteed to change immediately when a value is set, nor prevents the actions happening
+when the value is set to its current value (if the parts are in different states). 
+Setting the values to these fields will trigger all the corresponding parts that have different state than the one being set.
+
+============== ==========   =========   ========= ===============
+Variable Name  Can Read     Can Set     Source    Description
+============== ==========   =========   ========= ===============
+SAS            yes          yes          stock     (Same as "SAS" indicator on the navball.)
+RCS            yes          yes          stock     (Same as "RCS" indicator on the navball.)
+GEAR           yes          yes          stock     Is the GEAR enabled right now? (Note, since it may be true with all or most gear retracted, you may want to set it off and back on to guarantee everything is deployed).
+LIGHTS         yes          yes          stock     Are the lights on? (like the "U" key in manual flight)
+BRAKES         yes          yes          stock     Are the brakes on?
+ABORT          yes          yes          stock     Abort Action Group.
+LEGS           yes          yes          kOS       Are the landing LEGS extended? (as opposed to GEAR which is for the wheels of a plane.)
+CHUTES         yes          yes          kOS       Are the parachutes deployed? (Deploys all chutes when set to true)
+CHUTESSAFE     yes          yes          kOS       Are the parachutes that are safe to deploy deployed? (Deploys all chutes that are currently safe to deploy when set to true)
+PANELS         yes          yes          kOS       Are the solar panels extended? (Deploys/retracts all the solar panels when set)
+RADIATORS      yes          yes          kOS       Are the radiators extended/active? (Deploys and activates/retracts and deactivates all the radiators when set)
+LADDERS        yes          yes          kOS       Are the ladders extended? (Deploys/retracts all the extendable ladders when set)
+BAYS           yes          yes          kOS       Are any payload/service bays open? (Opens/closes all the payload and service bays when set)
+INTAKES        yes          yes          kOS       Are the air intakes open? (Opens/closes all the intakes when set)
+DRILLSDEPLOY   yes          yes          kOS       Are the resource drills deployed? (Deploys/retracts all the drills when set)
+DRILLS         yes          yes          kOS       Are any resource drills mining? (Starts/stops all the drills when set)
+FUELCELLS      yes          yes          kOS       Are any fuel cells active? (Starts/stops all the fuel cells when set)
+ISRU           yes          yes          kOS       Are any ISRU converters active? (Starts/stops all the ISRU converters when set)
+AG1            yes          yes          stock     Action Group 1.
+AG2            yes          yes          stock     Action Group 2.
+AG3            yes          yes          stock     Action Group 3.
+AG4            yes          yes          stock     Action Group 4.
+AG5            yes          yes          stock     Action Group 5.
+AG6            yes          yes          stock     Action Group 6.
+AG7            yes          yes          stock     Action Group 7.
+AG8            yes          yes          stock     Action Group 8.
+AG9            yes          yes          stock     Action Group 9.
+AG10           yes          yes          stock     Action Group 10.
+AGn            yes          yes          AGE       If you have the Action Groups Extended mod installed, you can access its groups the same way, i.e. AG11, AG12, AG13, etc.
+============== ==========   =========   ========= ===============
 
 Flight Control
 --------------
@@ -289,7 +310,7 @@ use `Raw Control <commands/flight/raw.html>`__.
 
 If you want to be able to READ what the player is attempting to do
 while your script is running, and perhaps respond to it, then use
-`Reading the Pilot's Control settings (i.e reading what the manual input is attempting) <commands/flight/pilot.html>`__ 
+`Reading the Pilot's Control settings (i.e reading what the manual input is attempting) <commands/flight/pilot.html>`__
 (By default your script will override manual piloting attempts, but
 you can read what the pilot's controls are set at and make your
 autopilot take them under advisement - sort of like how a
@@ -427,7 +448,7 @@ PROFILERESULT()
 If you have the runtime statistics configuration option
 :attr:`Config:STAT` set to ``True``, then in addition to
 the summary statistics after the program run, you can also
-see a detailed report of the "profiling" result of your 
+see a detailed report of the "profiling" result of your
 most recent program run, by calling the built-in function
 ``ProfileResult()``.  *"Profiling"* is a programmer's term
 that means gathering data about how long the program is

--- a/doc/source/bindings.rst
+++ b/doc/source/bindings.rst
@@ -246,7 +246,7 @@ False, and can be set or toggled
 using the "ON" and "OFF" and "TOGGLE" commands.
 Many of these are for action group flags.
 
-**NOTE ABOUT STOCK/AGE ACTION GROUP FLAGS:** If the boolean flag is for a tock or AGE action
+**NOTE ABOUT STOCK/AGX ACTION GROUP FLAGS:** If the boolean flag is for a stock or AGX action
 group, be aware that each time the
 user presses the action group keypress, it *toggles* the action group,
 so you might need to check for both
@@ -259,41 +259,42 @@ group, be aware that the value of the flag represents the actual state of the pa
 (most of them will always return false if no corresponding parts found) 
 and is neither guaranteed to change immediately when a value is set, nor prevents the actions happening
 when the value is set to its current value (if the parts are in different states). 
-Setting the values to these fields will trigger all the corresponding parts that have different state than the one being set.
+Setting the values to these fields will trigger all the corresponding parts that have different state than the one being set. 
 
-============== ==========   =========   ========= ===============
-Variable Name  Can Read     Can Set     Source    Description
-============== ==========   =========   ========= ===============
-SAS            yes          yes          stock     (Same as "SAS" indicator on the navball.)
-RCS            yes          yes          stock     (Same as "RCS" indicator on the navball.)
-GEAR           yes          yes          stock     Is the GEAR enabled right now? (Note, since it may be true with all or most gear retracted, you may want to set it off and back on to guarantee everything is deployed).
-LIGHTS         yes          yes          stock     Are the lights on? (like the "U" key in manual flight)
-BRAKES         yes          yes          stock     Are the brakes on?
-ABORT          yes          yes          stock     Abort Action Group.
-LEGS           yes          yes          kOS       Are the landing LEGS extended? (as opposed to GEAR which is for the wheels of a plane.)
-CHUTES         yes          yes          kOS       Are the parachutes deployed? (Deploys all chutes when set to true)
-CHUTESSAFE     yes          yes          kOS       Are the parachutes that are safe to deploy deployed? (Deploys all chutes that are currently safe to deploy when set to true)
-PANELS         yes          yes          kOS       Are the solar panels extended? (Deploys/retracts all the solar panels when set)
-RADIATORS      yes          yes          kOS       Are the radiators extended/active? (Deploys and activates/retracts and deactivates all the radiators when set)
-LADDERS        yes          yes          kOS       Are the ladders extended? (Deploys/retracts all the extendable ladders when set)
-BAYS           yes          yes          kOS       Are any payload/service bays open? (Opens/closes all the payload and service bays when set)
-INTAKES        yes          yes          kOS       Are the air intakes open? (Opens/closes all the intakes when set)
-DRILLSDEPLOY   yes          yes          kOS       Are the resource drills deployed? (Deploys/retracts all the drills when set)
-DRILLS         yes          yes          kOS       Are any resource drills mining? (Starts/stops all the drills when set)
-FUELCELLS      yes          yes          kOS       Are any fuel cells active? (Starts/stops all the fuel cells when set)
-ISRU           yes          yes          kOS       Are any ISRU converters active? (Starts/stops all the ISRU converters when set)
-AG1            yes          yes          stock     Action Group 1.
-AG2            yes          yes          stock     Action Group 2.
-AG3            yes          yes          stock     Action Group 3.
-AG4            yes          yes          stock     Action Group 4.
-AG5            yes          yes          stock     Action Group 5.
-AG6            yes          yes          stock     Action Group 6.
-AG7            yes          yes          stock     Action Group 7.
-AG8            yes          yes          stock     Action Group 8.
-AG9            yes          yes          stock     Action Group 9.
-AG10           yes          yes          stock     Action Group 10.
-AGn            yes          yes          AGE       If you have the Action Groups Extended mod installed, you can access its groups the same way, i.e. AG11, AG12, AG13, etc.
-============== ==========   =========   ========= ===============
+
+===================================================================  ==========   =========   ========= ===============
+Variable Name                                                         Can Read     Can Set     Source    Description
+===================================================================  ==========   =========   ========= ===============
+`SAS <commands/flight/systems.html#global:SAS>`__                     yes          yes          stock     (Same as "SAS" indicator on the navball.)
+`RCS <commands/flight/systems.html#global:RCS>`__                     yes          yes          stock     (Same as "RCS" indicator on the navball.)
+`GEAR <commands/flight/systems.html#global:GEAR>`__                   yes          yes          stock     Is the GEAR enabled right now? (Note, since it may be true with all or most gear retracted, you may want to set it off and back on to guarantee everything is deployed).
+`LIGHTS <commands/flight/systems.html#global:LIGHTS>`__               yes          yes          stock     Are the lights on? (like the "U" key in manual flight)
+`BRAKES <commands/flight/systems.html#global:BRAKES>`__               yes          yes          stock     Are the brakes on?
+`ABORT <commands/flight/systems.html#global:ABORT>`__                 yes          yes          stock     Abort Action Group.
+`LEGS <commands/flight/systems.html#global:LEGS>`__                   yes          yes          kOS       Are the landing LEGS extended? (as opposed to GEAR which is for the wheels of a plane.)
+`CHUTES <commands/flight/systems.html#global:CHUTES>`__               yes          yes          kOS       Are the parachutes deployed? (Deploys all chutes when set to true)
+`CHUTESSAFE <commands/flight/systems.html#global:CHUTESSAFE>`__       yes          yes          kOS       Are the parachutes that are safe to deploy deployed? (Deploys all chutes that are currently safe to deploy when set to true)
+`PANELS <commands/flight/systems.html#global:PANELS>`__               yes          yes          kOS       Are the solar panels extended? (Deploys/retracts all the solar panels when set)
+`RADIATORS <commands/flight/systems.html#global:RADIATORS>`__         yes          yes          kOS       Are the radiators extended/active? (Deploys and activates/retracts and deactivates all the radiators when set)
+`LADDERS <commands/flight/systems.html#global:LADDERS>`__             yes          yes          kOS       Are the ladders extended? (Deploys/retracts all the extendable ladders when set)
+`BAYS <commands/flight/systems.html#global:BAYS>`__                   yes          yes          kOS       Are any payload/service bays open? (Opens/closes all the payload and service bays when set)
+`INTAKES <commands/flight/systems.html#global:INTAKES>`__             yes          yes          kOS       Are the air intakes open? (Opens/closes all the intakes when set)
+`DRILLSDEPLOY <commands/flight/systems.html#global:DRILLSDEPLOY>`__   yes          yes          kOS       Are the resource drills deployed? (Deploys/retracts all the drills when set)
+`DRILLS <commands/flight/systems.html#global:DRILLS>`__               yes          yes          kOS       Are any resource drills mining? (Starts/stops all the drills when set)
+`FUELCELLS <commands/flight/systems.html#global:FUELCELLS>`__         yes          yes          kOS       Are any fuel cells active? (Starts/stops all the fuel cells when set)
+`ISRU <commands/flight/systems.html#global:ISRU>`__                   yes          yes          kOS       Are any ISRU converters active? (Starts/stops all the ISRU converters when set)
+AG1                                                                   yes          yes          stock     Action Group 1.
+AG2                                                                   yes          yes          stock     Action Group 2.
+AG3                                                                   yes          yes          stock     Action Group 3.
+AG4                                                                   yes          yes          stock     Action Group 4.
+AG5                                                                   yes          yes          stock     Action Group 5.
+AG6                                                                   yes          yes          stock     Action Group 6.
+AG7                                                                   yes          yes          stock     Action Group 7.
+AG8                                                                   yes          yes          stock     Action Group 8.
+AG9                                                                   yes          yes          stock     Action Group 9.
+AG10                                                                  yes          yes          stock     Action Group 10.
+`AGn <addons/AGX.html>`__                                             yes          yes          AGX       If you have the Action Groups Extended mod installed, you can access its groups the same way, i.e. AG11, AG12, AG13, etc.
+===================================================================  ==========   =========   ========= ===============
 
 Flight Control
 --------------

--- a/doc/source/commands/flight/systems.rst
+++ b/doc/source/commands/flight/systems.rst
@@ -3,7 +3,21 @@
 Ship Systems
 ============
 
-.. _CONTROLFROM:
+CONTROL REFERENCE
+-----------------
+
+    The axis for ship control and ship-relative coordinate system are determined in relation to a specific part (or a specific transform belonging to the part) on the ship.
+    All vessels must have at least one "control from"
+    part on them somewhere, which is why there's no mechanism for un-setting
+    the "control from" setting other than to pick another part and set it
+    to that part instead.
+
+.. Vessel:CONTROLPART:
+
+    Returns the part currently used as the control reference for the vessel. 
+    For more information see :attr:`Vessel:CONTROLPART`. 
+
+.. Part:CONTROLFROM:
 
     e.g.::
 
@@ -11,14 +25,14 @@ Ship Systems
         somepart:CONTROLFROM().
 
     If you have a handle on a part, from ``LIST PARTS``, you can select that part to set the orientation of the craft, just like using the "control from here" in the right-click menu in the game. For more information see :attr:`Part:CONTROLFROM`. 
-    All vessels must have at least one "control from"
-    part on them somewhere, which is why there's no mechanism for un-setting
-    the "control from" setting other than to pick another part and set it
-    to that part instead.
+
+RCS and SAS
+-----------
 
 .. global:: RCS
 
-    :access: Toggle ON/OFF
+    :access: Toggle ON/OFF; get/set
+    :type: Action Group, :ref:`Boolean <boolean>`
 
     Turns the RCS **on** or **off**, like using ``R`` at the keyboard::
 
@@ -26,7 +40,8 @@ Ship Systems
 
 .. global:: SAS
 
-    :access: Toggle ON/OFF
+    :access: Toggle ON/OFF; get/set
+    :type: Action Group, :ref:`Boolean <boolean>`
 
     Turns the SAS **on** or **off**, like using ``T`` at the keybaord::
 
@@ -34,24 +49,54 @@ Ship Systems
 
 .. _sasmode:
 
-.. object:: SET SASMODE TO value.
+.. object:: SASMODE
 
     :access: Get/Set
-    :type: string
+    :type: :ref:`string <string>`
 
     Getting this variable will return the currently selected mode.  Where ``value`` is one of the valid strings listed below, this will set the stock SAS mode for the cpu vessel::
 
         SET SASMODE TO value.
 
     It is the equivalent to clicking on the buttons next to the nav ball while manually piloting the craft, and will respect the current mode of the nav ball (orbital, surface, or target velocity).  Valid strings for ``value`` are ``"PROGRADE"``, ``"RETROGRADE"``, ``"NORMAL"``, ``"ANTINORMAL"``, ``"RADIALOUT"``, ``"RADIALIN"``, ``"TARGET"``, ``"ANTITARGET"``, ``"MANEUVER"``, ``"STABILITYASSIST"``, and ``"STABILITY"``.  A null or empty string will default to stability assist mode, however any other invalid string will throw an exception.  This feature will respect career mode limitations, and will throw an exception if the current vessel is not able to use the mode passed to the command.  An exception is also thrown if ``"TARGET"`` or ``"ANTITARGET"`` are used, but no target is selected.
-		
+
+    .. note::
+        SAS mode is reset to stability assist when toggling SAS on, however it doesn't happen immediately.
+        Therefore, after activating SAS, you'll have to skip a frame before setting the SAS mode.
+        Velocity-related modes also reset back to stability assist when the velocity gets too low.		
+
 .. warning:: SASMODE does not work with RemoteTech
 
     Due to the way that RemoteTech disables flight control input, the built in SAS modes do not function properly when there is no connection to the KSC or a Command Center.  If you are writing scripts for use with RemoteTech, make sure to take this into account.
 
+STOCK ACTION GROUPS
+-------------------
+
+    These action groups (including abovementioned SAS and RCS) are stored as boolean values which can be read to determine their current state, which can be used by kOS as one of the forms of user input::
+
+        IF RCS PRINT "RCS is on".
+
+    The action groups can be toggled both by giving `ON` or `OFF` command and by setting the boolean value. The following commands will have the same effect::
+
+        SAS ON.
+        SET SAS TO TRUE.
+
+    However, using the `SET` command allows to use any boolean variable or expression, for example::
+
+        SET GEAR TO ALT:RADAR<1000.
+        SET LIGHTS TO GEAR.
+        SET BRAKES TO NOT BRAKES.
+
+    Some parts automatically add their actions to basic action groups or otherwise react to them.
+    More actions can be added to the groups in the editor, if VAB or SPH is advanced enough.
+    .. note::
+        Part modules react to changes in action group state, therefore calling `GEAR ON` when it's already on will have no effect even on undeployed gear.
+        Some actions react differently to toggling the group on and off, other will give the same response to both.
+
 .. global:: LIGHTS
 
-    :access: Toggle ON/OFF
+    :access: Toggle ON/OFF; get/set
+    :type: Action Group, :ref:`Boolean <boolean>`
 
     Turns the lights **on** or **off**, like using the ``U`` key at the keyboard::
 
@@ -59,16 +104,201 @@ Ship Systems
 
 .. global:: BRAKES
 
-    :access: Toggle ON/OFF
+    :access: Toggle ON/OFF; get/set
+    :type: Action Group, :ref:`Boolean <boolean>`
 
     Turns the brakes **on** or **off**, like clicking the brakes button, though *not* like using the ``B`` key, because they stay on::
 
         BRAKES ON.
 
+.. global:: GEAR
+
+    :access: Toggle ON/OFF; get/set
+    :type: Action Group, :ref:`Boolean <boolean>`
+
+    Deploys or retracts the landing gear, like using the ``G`` key at the keyboard::
+
+        GEAR ON.
+
+.. global:: ABORT
+
+    :access: Toggle ON/OFF; get/set
+    :type: Action Group, :ref:`Boolean <boolean>`
+
+    Abort action group (no actions are automatically assigned, configurable in the editor), like using the ``Backspace`` key at the keyboard::
+
+        ABORT ON.
+
+.. global:: AG1 ... AG10
+
+    :access: Toggle ON/OFF; get/set
+    :type: Action Group, :ref:`Boolean <boolean>`
+
+    10 custom action groups (no actions are automatically assigned, configurable in the editor), like using the numeric keys at the keyboard::
+
+        AG1 ON.
+        AG4 OFF.
+        SET AG10 to AG3.
+
+kOS CUSTOM ACTION GROUPS
+------------------------
+
+    kOS adds several action groups that can be used by scripts in the same way the stock groups are used::
+
+        PANELS ON.
+        IF BAYS PRINT "Payload/service bays are ajar!".
+        SET RADIATORS TO LEGS.
+
+    However, unlike the stock groups, you can't manually assign actions to these groups in the VAB. 
+    They automatically affect all the parts of the corresponding type. 
+    The biggest difference is that the values for these groups are not stored, instead, the value is directly dependent on the state of the corresponding parts.
+    Another difference from stock groups is that both `ON` and `OFF` commands work independantly of the initial state of the action group.
+    For example, if some of the payload bays are closed and some are open (`BAYS` would return true), `BAYS ON` will open the ones that were closed, and `BAYS OFF` will close the ones that are opened.
+
+
+.. global:: LEGS
+
+    :access: Toggle ON/OFF; get/set
+    :type: Action Group, :ref:`Boolean <boolean>`
+
+    Deploys or retracts all the landing legs (but not wheeled landing gear)::
+
+        LEGS ON.
+
+    The `LEGS` value is true if all the legs are deployed.
+
+.. global:: CHUTES
+
+    :access: Toggle ON; get/set
+    :type: Action Group, :ref:`Boolean <boolean>`
+
+    Deploys all the parachutes (only `ON` command has effect)::
+
+        CHUTES ON.
+
+    The `CHUTES` value is true if all the chutes are deployed.
+
+.. global:: CHUTESSAFE
+
+    :access: Toggle ON; get/set
+    :type: Action Group, :ref:`Boolean <boolean>`
+
+    Deploys all the parachutes than can be safely deployed in the current conditions (only `ON` command has effect)::
+
+        CHUTESSAFE ON.
+
+    The `CHUTESSAFE` value is false only if there are undeployed chutes to be safely deployed, true if nothing more can be deployed safely. 
+    The following code will gradually deploy all the chutes as the speed drops::
+
+        WHEN (NOT CHUTESSAFE) THEN {CHUTESSAFE ON. RETURN (NOT CHUTES).}
+
+.. global:: PANELS
+
+    :access: Toggle ON/OFF; get/set
+    :type: Action Group, :ref:`Boolean <boolean>`
+
+    Extends or retracts all the deployable solar panels::
+
+        PANELS ON.
+
+    Note that some of the panels can't be retracted once deployed. The `PANELS` value is true if all the panels are extended.
+
+.. global:: RADIATORS
+
+    :access: Toggle ON/OFF; get/set
+    :type: Action Group, :ref:`Boolean <boolean>`
+
+    Extends or retracts all the deployable radiators and activates or deactivates all the fixed ones::
+
+        RADIATORS ON.
+
+    The `RADIATORS` value is true if all the radiators are extended (if deployable) extended and active.
+
+.. global:: LADDERS
+
+    :access: Toggle ON/OFF; get/set
+    :type: Action Group, :ref:`Boolean <boolean>`
+
+    Extends or retracts all the extendable ladders::
+
+        LADDERS ON.
+
+    The `LADDERS` value is true if all the ladders are extended.
+
+.. global:: BAYS
+
+    :access: Toggle ON/OFF; get/set
+    :type: Action Group, :ref:`Boolean <boolean>`
+
+    Opens or closes all the payload and service bays (including the cargo ramp)::
+
+        BAYS ON.
+
+    The `BAYS` value is true if at least one bay is open.
+
+.. global:: DEPLOYDRILLS
+
+    :access: Toggle ON/OFF; get/set
+    :type: Action Group, :ref:`Boolean <boolean>`
+
+    Deploys or retracts all the mining drills::
+
+        DEPLOYDRILLS ON.
+
+    The `DEPLOYDRILLS` value is true if all the drills are deployed.
+
+.. global:: DRILLS
+
+    :access: Toggle ON/OFF; get/set
+    :type: Action Group, :ref:`Boolean <boolean>`
+
+    Activates (has effect only on drills that are deployed and in contact with minable surface) or stops all the mining drills::
+
+        DRILLS ON.
+
+    The `DRILLS` value is true if at least one drill is actually mining.
+
+.. global:: FUELCELLS
+
+    :access: Toggle ON/OFF; get/set
+    :type: Action Group, :ref:`Boolean <boolean>`
+
+    Activates or deactivates all the fuel cells (distingushed from other conveters by converter/action names)::
+
+        FUELCELLS ON.
+
+    The `FUELCELLS` value is true if at least one fuel cell is activated.
+
+.. global:: ISRU
+
+    :access: Toggle ON/OFF; get/set
+    :type: Action Group, :ref:`Boolean <boolean>`
+
+    Activates or deactivates all the ISRU converters (distingushed from other conveters by converter/action names)::
+
+        ISRU ON.
+
+    The `ISRU` value is true if at least one ISRU converter is activated.
+
+.. global:: INTAKES
+
+    :access: Toggle ON/OFF; get/set
+    :type: Action Group, :ref:`Boolean <boolean>`
+
+    Opens or closes all the air intakes::
+
+        INTAKES ON.
+
+    The value is true if all the intakes are open.
+
+
+TARGET
+------
+
 .. global:: TARGET
 
     :access: Get/Set
-    :type: string
+    :type: :ref:`string <string>` (set); `Vessel <structures/vessels/vessel.html>`__ or `Body <structures/celestial_bodies/body.html>`__ or `Part <structures/vessels/part.html>`__ (get)
 
     Where ``name`` is the name of a target vessel or planet, this will set the current target::
 

--- a/doc/source/commands/flight/systems.rst
+++ b/doc/source/commands/flight/systems.rst
@@ -54,11 +54,11 @@ RCS and SAS
     :access: Get/Set
     :type: :ref:`string <string>`
 
-    Getting this variable will return the currently selected mode.  Where ``value`` is one of the valid strings listed below, this will set the stock SAS mode for the cpu vessel::
+    Getting this variable will return the currently selected SAS mode.  Where ``value`` is one of the valid strings listed below, this will set the stock SAS mode for the cpu vessel::
 
         SET SASMODE TO value.
 
-    It is the equivalent to clicking on the buttons next to the nav ball while manually piloting the craft, and will respect the current mode of the nav ball (orbital, surface, or target velocity).  Valid strings for ``value`` are ``"PROGRADE"``, ``"RETROGRADE"``, ``"NORMAL"``, ``"ANTINORMAL"``, ``"RADIALOUT"``, ``"RADIALIN"``, ``"TARGET"``, ``"ANTITARGET"``, ``"MANEUVER"``, ``"STABILITYASSIST"``, and ``"STABILITY"``.  A null or empty string will default to stability assist mode, however any other invalid string will throw an exception.  This feature will respect career mode limitations, and will throw an exception if the current vessel is not able to use the mode passed to the command.  An exception is also thrown if ``"TARGET"`` or ``"ANTITARGET"`` are used, but no target is selected.
+    It is the equivalent to clicking on the buttons next to the nav ball while manually piloting the craft, and will respect the current mode of the nav ball (orbital, surface, or target velocity - use NAVMODE to read or set it).  Valid strings for ``value`` are ``"PROGRADE"``, ``"RETROGRADE"``, ``"NORMAL"``, ``"ANTINORMAL"``, ``"RADIALOUT"``, ``"RADIALIN"``, ``"TARGET"``, ``"ANTITARGET"``, ``"MANEUVER"``, ``"STABILITYASSIST"``, and ``"STABILITY"``.  A null or empty string will default to stability assist mode, however any other invalid string will throw an exception.  This feature will respect career mode limitations, and will throw an exception if the current vessel is not able to use the mode passed to the command.  An exception is also thrown if ``"TARGET"`` or ``"ANTITARGET"`` are used, but no target is selected.
 
     .. note::
         SAS mode is reset to stability assist when toggling SAS on, however it doesn't happen immediately.
@@ -68,6 +68,19 @@ RCS and SAS
 .. warning:: SASMODE does not work with RemoteTech
 
     Due to the way that RemoteTech disables flight control input, the built in SAS modes do not function properly when there is no connection to the KSC or a Command Center.  If you are writing scripts for use with RemoteTech, make sure to take this into account.
+
+.. _navmode:
+
+.. object:: NAVMODE
+
+    :access: Get/Set
+    :type: :ref:`string <string>`
+
+    Getting this variable will return the currently selected nav ball speed display mode.  Where ``value`` is one of the valid strings listed below, this will set the nav ball mode for the cpu vessel::
+
+        SET NAVMODE TO value.
+
+    It is the equivalent to changing the nav ball mode by clicking on speed display on the nav ball while manually piloting the craft, and will change the current mode of the nav ball, affecting behavior of most SAS modes.  Valid strings for ``value`` are ``"ORBIT"``, ``"SURFACE"`` and ``"TARGET"``.  A null or empty string will default to orbit mode, however any other invalid string will throw an exception.  This feature is accessible only for the active vessel, and will throw an exception if the current vessel is not active.  An exception is also thrown if ``"TARGET"`` is used, but no target is selected.
 
 STOCK ACTION GROUPS
 -------------------


### PR DESCRIPTION
Docs for #1626, and serious expansion of action group docs.

Action group control in kOS definitely needs better explanation, especially with the custom groups kOS creates (I didn't know about them for quite some time, just because they weren't properly explained).

So here's what I propose with this documentation