### PR TITLE
NAVMODE -  NavBall / speed display modes

### DIFF
--- a/src/kOS/Binding/FlightControlManager.cs
+++ b/src/kOS/Binding/FlightControlManager.cs
@@ -202,9 +202,16 @@ namespace kOS.Binding
             {
                 //TODO: implment use of direction subclasses.
                 throw new Safe.Exceptions.KOSException(
-                    string.Format("Cannot set autopilot mode to direction {0}, use the name of the mode (as string) for SASMODE or, alternatively, LOCK STEERING to direction", autopilotMode));
+                    string.Format("Cannot set SAS mode to a direction. Should use the name of the mode (as string, e.g. \"PROGRADE\", not PROGRADE) for SASMODE. Alternatively, can use LOCK STEERING TO Direction instead of using SAS"));
             }
-            else SelectAutopilotMode((string)autopilotMode);
+            else
+            {
+                if (!((autopilotMode is kOS.Safe.Encapsulation.StringValue) || (autopilotMode is string)))
+                {
+                    throw new KOSWrongControlValueTypeException(
+                      "SASMODE", autopilotMode.GetType().Name, "name of the SAS mode (as string)");
+                }
+                SelectAutopilotMode((string)autopilotMode); }
         }
 
         public void SelectAutopilotMode(VesselAutopilot.AutopilotMode autopilotMode)
@@ -312,6 +319,11 @@ namespace kOS.Binding
 
         public void SetNavMode(object navMode)
         {
+            if (!((navMode is kOS.Safe.Encapsulation.StringValue) || (navMode is string)))
+            {
+                throw new KOSWrongControlValueTypeException(
+                  "NAVMODE", navMode.GetType().Name, "string (\"ORBIT\", \"SURFACE\" or \"TARGET\")");
+            }
             SetNavMode((string)navMode);
         }
 

--- a/src/kOS/Binding/FlightControlManager.cs
+++ b/src/kOS/Binding/FlightControlManager.cs
@@ -201,6 +201,8 @@ namespace kOS.Binding
             if (autopilotMode is Direction)
             {
                 //TODO: implment use of direction subclasses.
+                throw new Safe.Exceptions.KOSException(
+                    string.Format("Cannot set autopilot mode to direction {0}, use the name of the mode (as string) for SASMODE or, alternatively, LOCK STEERING to direction", autopilotMode));
             }
             else SelectAutopilotMode((string)autopilotMode);
         }

--- a/src/kOS/Binding/FlightControlManager.cs
+++ b/src/kOS/Binding/FlightControlManager.cs
@@ -46,10 +46,10 @@ namespace kOS.Binding
             AddNewFlightParam("wheelthrottle", Shared);
             AddNewFlightParam("wheelsteering", Shared);
 
-            shared.BindingMgr.AddSetter("SASMODE", value => SelectAutopilotMode((string)value));
-            shared.BindingMgr.AddGetter("SASMODE", () => GetAutopilotModeName().ToUpper());
-            shared.BindingMgr.AddSetter("NAVMODE", value => SetNavMode((string)value));
-            shared.BindingMgr.AddGetter("NAVMODE", () => getNavMode().ToString().ToUpper());
+            shared.BindingMgr.AddSetter("SASMODE", value => SelectAutopilotMode(value));
+            shared.BindingMgr.AddGetter("SASMODE", () => GetAutopilotModeName());
+            shared.BindingMgr.AddSetter("NAVMODE", value => SetNavMode(value));
+            shared.BindingMgr.AddGetter("NAVMODE", () => getNavModeName());
         }
 
 
@@ -229,11 +229,11 @@ namespace kOS.Binding
 
         public string GetAutopilotModeName()
         {
-            // TODO: As of KSP 1.0.4, RadialIn and RadialOut are swapped.  Check if still true in future versions.
-            if (currentVessel.Autopilot.Mode == VesselAutopilot.AutopilotMode.RadialOut) { return "RadialIn"; }
-            if (currentVessel.Autopilot.Mode == VesselAutopilot.AutopilotMode.RadialIn) { return "RadialOut"; }
+            // TODO: As of KSP 1.1.2, RadialIn and RadialOut are still swapped.  Check if still true in future versions.
+            if (currentVessel.Autopilot.Mode == VesselAutopilot.AutopilotMode.RadialOut) { return "RADIALIN"; }
+            if (currentVessel.Autopilot.Mode == VesselAutopilot.AutopilotMode.RadialIn) { return "RADIALOUT"; }
 
-            return currentVessel.Autopilot.Mode.ToString();
+            return currentVessel.Autopilot.Mode.ToString().ToUpper();
         }
 
         public void SelectAutopilotMode(string autopilotMode)
@@ -288,7 +288,12 @@ namespace kOS.Binding
             }
         }
 
-  
+        public string getNavModeName()
+        {
+            return getNavMode().ToString().ToUpper();
+        }
+
+
         public FlightGlobals.SpeedDisplayModes getNavMode()
         {
             if (Shared.Vessel != FlightGlobals.ActiveVessel)
@@ -301,6 +306,11 @@ namespace kOS.Binding
         public void SetNavMode(FlightGlobals.SpeedDisplayModes navMode)
         {
             FlightGlobals.SetSpeedMode(navMode);
+        }
+
+        public void SetNavMode(object navMode)
+        {
+            SetNavMode((string)navMode);
         }
 
         public void SetNavMode(string navMode)
@@ -316,7 +326,7 @@ namespace kOS.Binding
             }
             else
             {
-                // determine the AutopilotMode to use
+                // determine the navigation mode to use
                 switch (navMode.ToLower())
                 {
                     case "orbit":


### PR DESCRIPTION
Added NAVMODE (navball mode, only accessible for the active vessel) 
(Fixes #1448 )

also slightly adjusted getting SASMODE due to still persisting RADIALIN/RADIALOUT inconsistency.