### PR TITLE
Exclude Targeting input lock

### DIFF
--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -250,6 +250,7 @@ namespace kOS.Screen
             cameraManager = CameraManager.Instance;
             cameraManager.enabled = false;
 
+            // Exclude the TARGETING ControlType so that we can set the target vessel with the terminal open.
             InputLockManager.SetControlLock(ControlTypes.All & ~ControlTypes.TARGETING, CONTROL_LOCKOUT);
 
             // Prevent editor keys from being pressed while typing

--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -250,7 +250,7 @@ namespace kOS.Screen
             cameraManager = CameraManager.Instance;
             cameraManager.enabled = false;
 
-            InputLockManager.SetControlLock(CONTROL_LOCKOUT);
+            InputLockManager.SetControlLock(ControlTypes.All & ~ControlTypes.TARGETING, CONTROL_LOCKOUT);
 
             // Prevent editor keys from being pressed while typing
             EditorLogic editor = EditorLogic.fetch;


### PR DESCRIPTION
Fixes #1634

TermWindow.cs
* Filter `SetControlLock` to exclude ControlTypes.TARGETING`.