### PR TITLE
Fix part mass modifications

### DIFF
--- a/doc/source/general/kospartmodule.rst
+++ b/doc/source/general/kospartmodule.rst
@@ -29,6 +29,12 @@ attached to the small disk shaped CPU part (KR-2402 b)::
 	    diskSpace = 5000
 	    ECPerBytePerSecond = 0
 	    ECPerInstruction = 0.000004
+        # Optional fields shown below with default value
+        baseDiskSpace = 0
+        diskSpaceCostFactor = 0.0244140625
+        baseModuleCost = 0
+        diskSpaceMassFactor = 0.0000048829
+        baseModuleMass = 0
     }
 
 If you add a section like that to the part.cfg, via directly editing it,
@@ -105,4 +111,64 @@ by a re-balancing mod by changing this value.  This value is
 multiplied by how much available space there is total (used + free),
 not just how much is currently in use.
 
-.. _electriccharge:
+.. _diskSpaceCostFactor:
+
+diskSpaceCostFactor:
+--------------------
+
+   - **Type:** float
+   - **Default if omitted:** 0.0244140625
+   - **Effect:** How much additional cost is incurred per
+     byte of disk space added via the editor tweakable.
+
+When using the editor tweakable to increase storage, cost is added to the
+module.  That additional cost is found by multiplying the number of additional
+bytes by this factor.The default value is balanced for approximately 100
+additional funds for 4096 Bytes.
+
+.. _baseModuleCost:
+
+baseModuleCost:
+---------------
+
+   - **Type:** float
+   - **Default if omitted:** 0.0
+   - **Effect:** How much cost is added to the part cost by including this
+     module.
+
+While kOS only includes kOSProcessor in dedicated parts, users may choose to add
+it to existing parts by editing cfg files or using a ModuleManager patch.  In
+cases where the cost of a part may depend on multiple PartModules this allows
+you to specify the cost for the kOSProcessor itself without changing the part's
+cost directly.
+
+.. _diskSpaceMassFactor:
+
+diskSpaceMassFactor:
+--------------------
+
+   - **Type:** float
+   - **Default if omitted:** 0.0000048829
+   - **Effect:** How much additional cost is incurred per
+     byte of disk space added via the editor tweakable.
+
+When using the editor tweakable to increase storage, mass is added to the
+module.  That additional mass is found by multiplying the number of additional
+bytes by this factor.  The default value is balanced for approximately 0.02kg
+of additional mass for 4096 Bytes.
+
+.. _baseModuleMass:
+
+baseModuleMass:
+---------------
+
+   - **Type:** float
+   - **Default if omitted:** 0.0
+   - **Effect:** How much mass is added to the part cost by including this
+     module.
+
+While kOS only includes kOSProcessor in dedicated parts, users may choose to add
+it to existing parts by editing cfg files or using a ModuleManager patch.  In
+cases where the mass of a part may depend on multiple PartModules this allows
+you to specify the mass for the kOSProcessor itself without changing the part's
+mass directly.

--- a/doc/source/general/kospartmodule.rst
+++ b/doc/source/general/kospartmodule.rst
@@ -124,7 +124,7 @@ diskSpaceCostFactor:
 
 When using the editor tweakable to increase storage, cost is added to the
 module.  That additional cost is found by multiplying the number of additional
-bytes by this factor.The default value is balanced for approximately 100
+bytes by this factor.  The default value is balanced for approximately 100
 additional funds for 4096 Bytes.
 
 .. _baseModuleCost:

--- a/doc/source/general/kospartmodule.rst
+++ b/doc/source/general/kospartmodule.rst
@@ -21,7 +21,8 @@ to the part (although this may cause strange interactions that are not
 officially supported).
 
 Here is an example of the kOS processor module : the one that is
-attached to the small disk shaped CPU part (KR-2402 b)::
+attached to the small disk shaped CPU part (KR-2402 b).  Optional fields
+have been added in comments for clarity::
 
     MODULE
     {
@@ -30,11 +31,11 @@ attached to the small disk shaped CPU part (KR-2402 b)::
         ECPerBytePerSecond = 0
         ECPerInstruction = 0.000004
         # Optional fields shown below with default value
-        baseDiskSpace = 0
-        diskSpaceCostFactor = 0.0244140625
-        baseModuleCost = 0
-        diskSpaceMassFactor = 0.0000048829
-        baseModuleMass = 0
+        # baseDiskSpace = 0
+        # diskSpaceCostFactor = 0.0244140625
+        # baseModuleCost = 0
+        # diskSpaceMassFactor = 0.0000048829
+        # baseModuleMass = 0
     }
 
 If you add a section like that to the part.cfg, via directly editing it,

--- a/doc/source/general/kospartmodule.rst
+++ b/doc/source/general/kospartmodule.rst
@@ -25,10 +25,10 @@ attached to the small disk shaped CPU part (KR-2402 b)::
 
     MODULE
     {
-	    name = kOSProcessor
-	    diskSpace = 5000
-	    ECPerBytePerSecond = 0
-	    ECPerInstruction = 0.000004
+        name = kOSProcessor
+        diskSpace = 5000
+        ECPerBytePerSecond = 0
+        ECPerInstruction = 0.000004
         # Optional fields shown below with default value
         baseDiskSpace = 0
         diskSpaceCostFactor = 0.0244140625

--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -67,11 +67,11 @@ namespace kOS.Module
         [KSPField(isPersistant = true, guiName = "kOS Base Disk Space", guiActive = false)]
         public int baseDiskSpace = 0;
 
-        [KSPField(isPersistant = true, guiName = "kOS Base Module Cost", guiActive = false)]
-        public float baseModuleCost = 0F;
+        [KSPField(isPersistant = false, guiName = "kOS Base Module Cost", guiActive = false)]
+        public float baseModuleCost = 0F;  // this is the base cost added to a part for including the kOSProcessor, default to 0.
 
-        [KSPField(isPersistant = true, guiName = "kOS Base Part Mass", guiActive = false)]
-        public float basePartMass = 0F;
+        [KSPField(isPersistant = true, guiName = "kOS Base Module Mass", guiActive = false)]
+        public float baseModuleMass = 0F;  // this is the base mass added to a part for including the kOSProcessor, default to 0.
 
         [KSPField(isPersistant = false, guiName = "kOS Disk Space", guiActive = false, guiActiveEditor = true), UI_ChooseOption(scene = UI_Scene.Editor)]
         public string diskSpaceUI = "1024";
@@ -81,6 +81,12 @@ namespace kOS.Module
 
         [KSPField(isPersistant = false, guiName = "CPU/Disk Upgrade Mass", guiActive = false, guiActiveEditor = true)]
         public float additionalMass = 0F;
+
+        [KSPField(isPersistant = false, guiActive = false, guiActiveEditor = false)]
+        public float diskSpaceCostFactor = 0.0244140625F; //implies approx 100funds for 4096bytes of diskSpace
+
+        [KSPField(isPersistant = false, guiActive = false, guiActiveEditor = false)]
+        public float diskSpaceMassFactor = 0.0000048829F;  //implies approx 20kg for 4096bytes of diskSpace
 
         [KSPField(isPersistant = true, guiActive = false)]
         public int MaxPartId = 100;
@@ -212,7 +218,7 @@ namespace kOS.Module
         {
             // the 'sit' arg is irrelevant to us, but the interface requires it.
 
-            return additionalCost;
+            return baseModuleCost + additionalCost;
         }
         //implement IPartMassModifier component
         public ModifierChangeWhen GetModuleCostChangeWhen()
@@ -222,13 +228,9 @@ namespace kOS.Module
 
         private void UpdateCostAndMass()
         {
-            const float DISK_SPACE_MASS_MULTIPLIER = 0.0000048829F; //implies approx 20kg for 4096bytes of diskSpace
-            const float DISK_SPACE_COST_MULTIPLIER = 0.0244140625F; //implies approx 100funds for 4096bytes of diskSpace
-
-            additionalCost = baseModuleCost + (float)System.Math.Round((diskSpace - baseDiskSpace) * DISK_SPACE_COST_MULTIPLIER, 0);
-            additionalMass = (diskSpace - baseDiskSpace) * DISK_SPACE_MASS_MULTIPLIER;
-
-            part.mass = basePartMass + additionalMass;
+            float spaceDelta = diskSpace - baseDiskSpace;
+            additionalCost = (float)System.Math.Round(spaceDelta * diskSpaceCostFactor, 0);
+            additionalMass = spaceDelta * diskSpaceMassFactor;
         }
 
         //implement IPartMassModifier component
@@ -236,8 +238,7 @@ namespace kOS.Module
         {
             // the 'sit' arg is irrelevant to us, but the interface requires it.
             
-            return part.mass - defaultMass; //copied this fix from ProceduralParts mod as we already changed part.mass
-            //return additionalMass;
+            return baseModuleMass + additionalMass;
         }
         //implement IPartMassModifier component
         public ModifierChangeWhen GetModuleMassChangeWhen()
@@ -252,16 +253,6 @@ namespace kOS.Module
             {
                 if (baseDiskSpace == 0)
                     baseDiskSpace = diskSpace;
-
-                if (System.Math.Abs(baseModuleCost) < 0.000001F)
-                    baseModuleCost = additionalCost;  //remember module cost before tweaks
-                else
-                    additionalCost = baseModuleCost; //reset module cost and update later in UpdateCostAndMass()
-
-                if (System.Math.Abs(basePartMass) < 0.000001F)
-                    basePartMass = part.mass;  //remember part mass before tweaks
-                else
-                    part.mass = basePartMass; //reset part mass to original value and update later in UpdateCostAndMass()
 
                 InitUI();
             }

--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -86,7 +86,7 @@ namespace kOS.Module
         public float diskSpaceCostFactor = 0.0244140625F; //implies approx 100funds for 4096bytes of diskSpace
 
         [KSPField(isPersistant = false, guiActive = false, guiActiveEditor = false)]
-        public float diskSpaceMassFactor = 0.0000048829F;  //implies approx 20kg for 4096bytes of diskSpace
+        public float diskSpaceMassFactor = 0.0000048829F;  //implies approx 0.020kg for 4096bytes of diskSpace
 
         [KSPField(isPersistant = true, guiActive = false)]
         public int MaxPartId = 100;

--- a/src/kOS/Utilities/PartUtilities.cs
+++ b/src/kOS/Utilities/PartUtilities.cs
@@ -7,17 +7,10 @@ namespace kOS.Utilities
     {
         public static float CalculateCurrentMass(this Part part)
         {
-            if (part.HasPhysics())
-            {
-                if (part.rb != null)
-                {
-                    // rb mass is one physics tick behind.  Use part.GetPhysicslessChildMass() if the
-                    // delay becomes a significant problem, but this should be good 99% of the time.
-                    return part.rb.mass;
-                }
-            }
-            // default to zero if the rigid body is not yet updated, or the part is physics-less
-            return 0;
+            // rb mass is one physics tick behind.  Use part.GetPhysicslessChildMass() if the
+            // delay becomes a significant problem, but this should be good 99% of the time.
+            // Default to zero if the rigid body is not yet updated, or the part is physics-less
+            return part.HasPhysics() && part.rb != null ? part.rb.mass : 0;
         }
 
         public static bool HasPhysics(this Part part)


### PR DESCRIPTION
Fixes #1643

Fixes #1115

kOSProcessor.cs
* Fix implementation of IPartMassModifier so that kOS does not change
the part's mass directly.
* Revise base mass/cost logic to allow for adding mass and cost when the
module is added to other parts.
* Pulled mass/cost multiplication factors out of constants and into the
part definition.  This way the part itself can define how much mass to
add (since the KAL9000's mass added is not in line with the initial
mass).
* Removed old logic for establishing the base cost based on additional
cost.

PartUtilities.cs
* Revise mass handling for parts so that physics-less parts are
accounted for
* Revise wet and dry mass calculation to use the new part mass
calculation.  This should make both the ship and part masses for each
correct.