### PR TITLE
Check volume range in ProcessElectricity

### DIFF
--- a/src/kOS.Safe/Exceptions/KOSVolumeOutOfRangeException.cs
+++ b/src/kOS.Safe/Exceptions/KOSVolumeOutOfRangeException.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace kOS.Safe.Exceptions
+{
+    public class KOSVolumeOutOfRangeException : KOSException
+    {
+        private const string TERSE_MSG_FMT = "The {0} volume is out of range and not accessible.";
+
+        public KOSVolumeOutOfRangeException()
+            :this("requested")
+        {
+        }
+
+        public KOSVolumeOutOfRangeException(string name)
+            :base(string.Format(TERSE_MSG_FMT, name))
+        {
+        }
+
+        public override string VerboseMessage
+        {
+            get { return "You have attempted to access a volume " +
+                         "which is currently out of range.  This " +
+                         "is usually the result of attempting to " +
+                         "access the archive volume while RemoteTech " +
+                         "does not show a connection."; }
+        }
+    }
+}

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Compilation\CompileCache.cs" />
     <Compile Include="Compilation\CompiledObject.cs" />
     <Compile Include="Compilation\CompilerOptions.cs" />
+    <Compile Include="Exceptions\KOSVolumeOutOfRangeException.cs" />
     <Compile Include="Exceptions\KOSYouShouldNeverSeeThisException.cs" />
     <Compile Include="Compilation\KS\BreakInfo.cs" />
     <Compile Include="Compilation\KS\Compiler.cs" />
@@ -272,7 +273,5 @@
   </Target>
   -->
   <ItemGroup />
-  <ItemGroup>
-    <Folder Include="Communication\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>

--- a/src/kOS/AddOns/RemoteTech/RemoteTechVolumeManager.cs
+++ b/src/kOS/AddOns/RemoteTech/RemoteTechVolumeManager.cs
@@ -26,7 +26,7 @@ namespace kOS.AddOns.RemoteTech
             {
                 return volume;
             }
-            throw new Exception("Volume is out of range");
+            throw new Safe.Exceptions.KOSVolumeOutOfRangeException();
         }
 
         // check the range on the current volume without calling GetVolumeWithRangeCheck

--- a/src/kOS/KSPLogger.cs
+++ b/src/kOS/KSPLogger.cs
@@ -23,7 +23,6 @@ namespace kOS
 
         public override void Log(string text)
         {
-            base.Log(text);
             UnityEngine.Debug.Log(string.Format("{0} {1}", LOGGER_PREFIX, text));
         }
 
@@ -64,17 +63,20 @@ namespace kOS
             // print the call stack
             UnityEngine.Debug.Log(e);
             
-            // print a fragment of the code where the exception ocurred
-            int logContextLines = 16;
-            #if DEBUG
-            logContextLines = 999999; // in debug mode let's just dump everything because it's easier that way.
-            #endif
-            List<string> codeFragment = Shared.Cpu.GetCodeFragment(logContextLines);
-            var messageBuilder = new StringBuilder();
-            messageBuilder.AppendLine("Code Fragment");
-            foreach (string instruction in codeFragment)
-                messageBuilder.AppendLine(instruction);
-            UnityEngine.Debug.Log(messageBuilder.ToString());
+            if (Shared != null && Shared.Cpu != null)
+            {
+                // print a fragment of the code where the exception ocurred
+                int logContextLines = 16;
+#if DEBUG
+                logContextLines = 999999; // in debug mode let's just dump everything because it's easier that way.
+#endif
+                List<string> codeFragment = Shared.Cpu.GetCodeFragment(logContextLines);
+                var messageBuilder = new StringBuilder();
+                messageBuilder.AppendLine("Code Fragment");
+                foreach (string instruction in codeFragment)
+                    messageBuilder.AppendLine(instruction);
+                UnityEngine.Debug.Log(messageBuilder.ToString());
+            }
         }
         
         /// <summary>

--- a/src/kOS/Logger.cs
+++ b/src/kOS/Logger.cs
@@ -44,11 +44,8 @@ namespace kOS
 
                 message += "\n" + LINE_RULE + "           VERBOSE DESCRIPTION\n";
                 
-                message += ((KOSException)e).VerboseMessage;
+                message += ((KOSException)e).VerboseMessage + "\n";
                 
-                // Fallback if there was no verbose message defined:
-                if (message == String.Empty)
-                    message += e.Message;
                 message += LINE_RULE;
                 
                 // Take on the URL if there is one:

--- a/src/kOS/Logger.cs
+++ b/src/kOS/Logger.cs
@@ -58,7 +58,7 @@ namespace kOS
                 message += LINE_RULE;
             }
 
-            if (SafeHouse.Config.AudibleExceptions)
+            if (SafeHouse.Config.AudibleExceptions && Shared != null && Shared.SoundMaker != null)
                 Shared.SoundMaker.BeginSound("error");
 
             LogToScreen(message);

--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -32,6 +32,8 @@ namespace kOS.Module
 
         public Harddisk HardDisk { get; private set; }
 
+        public Archive Archive { get; private set; }
+
         public MessageQueue Messages { get; private set; }
 
         public string Tag
@@ -343,8 +345,8 @@ namespace kOS.Module
             shared.Window.AttachTo(shared);
 
             // initialize archive
-            var archive = shared.Factory.CreateArchive();
-            shared.VolumeMgr.Add(archive);
+            Archive = shared.Factory.CreateArchive();
+            shared.VolumeMgr.Add(Archive);
 
             Messages = new MessageQueue();
 
@@ -361,7 +363,7 @@ namespace kOS.Module
                 // populate it with the boot file, but only if using a new disk and in PRELAUNCH situation:
                 if (vessel.situation == Vessel.Situations.PRELAUNCH && bootFile != "None" && !SafeHouse.Config.StartOnArchive)
                 {
-                    var bootVolumeFile = archive.Open(bootFile);
+                    var bootVolumeFile = Archive.Open(bootFile);
                     if (bootVolumeFile != null)
                     {
                         FileContent content = bootVolumeFile.ReadAll();
@@ -697,14 +699,23 @@ namespace kOS.Module
             if (ProcessorMode == ProcessorModes.OFF) return;
 
             double volumePower = 0;
-            var volume = shared.VolumeMgr.CurrentVolume;
-            if (volume.Name == "Archive")
+            if (shared.VolumeMgr.CheckCurrentVolumeRange(shared.Vessel))
             {
-                volumePower = ARCHIVE_EFFECTIVE_BYTES * ECPerBytePerSecond;
+                // If the current volume is in range, check the capacity and calculate power
+                var volume = shared.VolumeMgr.CurrentVolume;
+                if (volume.Name == "Archive")
+                {
+                    volumePower = ARCHIVE_EFFECTIVE_BYTES * ECPerBytePerSecond;
+                }
+                else
+                {
+                    volumePower = volume.Capacity * ECPerBytePerSecond;
+                }
             }
             else
             {
-                volumePower = volume.Capacity * ECPerBytePerSecond;
+                // if the volume isn't in range, assume it doesn't consume any power
+                volumePower = 0;
             }
 
             if (ProcessorMode == ProcessorModes.STARVED)
@@ -777,9 +788,7 @@ namespace kOS.Module
             switch (ProcessorMode)
             {
             case ProcessorModes.READY:
-                shared.VolumeMgr.SwitchTo(SafeHouse.Config.StartOnArchive
-                    ? shared.VolumeMgr.GetVolume(0)
-                    : HardDisk);
+                shared.VolumeMgr.SwitchTo(SafeHouse.Config.StartOnArchive ? (Volume)Archive : HardDisk);
                 if (shared.Cpu != null) shared.Cpu.Boot();
                 if (shared.Interpreter != null) shared.Interpreter.SetInputLock(false);
                 if (shared.Window != null) shared.Window.IsPowered = true;
@@ -817,10 +826,10 @@ namespace kOS.Module
 
         public bool CheckCanBoot()
         {
-            if (shared.VolumeMgr == null) { SafeHouse.Logger.Log("No volume mgr"); }
-            else if (!shared.VolumeMgr.CheckCurrentVolumeRange(shared.Vessel)) { SafeHouse.Logger.Log("Boot volume not in range"); }
-            else if (shared.VolumeMgr.CurrentVolume == null) { SafeHouse.Logger.Log("No current volume"); }
-            else if (shared.ScriptHandler == null) { SafeHouse.Logger.Log("No script handler"); }
+            if (shared.VolumeMgr == null) { shared.Logger.Log("No volume mgr"); }
+            else if (!shared.VolumeMgr.CheckCurrentVolumeRange(shared.Vessel)) { shared.Logger.Log(new Safe.Exceptions.KOSVolumeOutOfRangeException("Boot")); }
+            else if (shared.VolumeMgr.CurrentVolume == null) { shared.Logger.Log("No current volume"); }
+            else if (shared.ScriptHandler == null) { shared.Logger.Log("No script handler"); }
             else
             {
                 return true;


### PR DESCRIPTION
Fixes #1363

kOSProcessor.cs
* Add a check to the volume range before accessing the current volume in
Process electricity.
* This allows "start on archive" to properly work with RemoteTech, and
will simply skip the boot sequence if out of range.
* Add Archive property for storing the archive volume after creation.
* Log exception when boot volume is out of range (so that it is
displayed on the terminal too).
* Change CheckCanBoot logger calls to be shared.Logger, so that the
message displays on the terminal.

KOSVolumeOutOfRangeException
* Create new exception class to handle "volume out of range" exceptions.

RemoteTechVolumeManager.cs
* Use the new exception type.

kOS.Safe.csproj
* Add reference for new exception.

KSPLogger.cs
* Add null checks before attempting to create the code fragment message.
If called from the SafeHouse instance, Shared may be null.
* Remove call to base.Log(text) in Log(string text).  This forced the
logger to attempt to display the text on the screen as well as in the
log.  But the screen printing feature never got used, because the method
was only called on the SafeHouse instance (which has no Shared object
and therefore no Screen).

Logger.cs
* Add null checking to audible exceptions, because a call to the
SafeHouse instance may have a null Shared object.