### PR TITLE
add orbit constructor and velocityat/positionat

### DIFF
--- a/doc/source/commands/prediction.rst
+++ b/doc/source/commands/prediction.rst
@@ -55,7 +55,7 @@ These return predicted information about the future position and velocity of an 
     :type orbitable:  :struct:`Orbitable`
     :param time:    Time of prediction
     :type time:     :struct:`TimeSpan`
-    :return: An :ref:`ObitalVelocity <orbitablevelocity>` structure.
+    :return: An :ref:`OrbitalVelocity <orbitablevelocity>` structure.
 
     Returns a prediction of what the :ref:`Orbitable's <orbitable>` velocity will be at some :ref:`universal Timestamp <timestamp>`. If the :struct:`Orbitable` is a :struct:`Vessel`, and the :struct:`Vessel` has planned :struct:`maneuver nodes <Node>`, the prediction assumes they will be executed exactly as planned.
 

--- a/doc/source/structures/orbits/orbit.rst
+++ b/doc/source/structures/orbits/orbit.rst
@@ -17,6 +17,24 @@ Whenever you get the :struct:`Orbit` of a :struct:`Vessel`, be aware that its ju
 
     Some of the parameters listed here come directly from KSP's API and there is a bit of inconsistency with whether it uses radians or degrees for angles. As much as possible we have tried to present everything in kOS as degrees for consistency, but some of these may have slipped through. If you see any of these being reported in radians, please make a bug report.
 
+
+Creation
+--------
+
+.. function:: ORBIT(x, v, body, t)
+
+    :parameter x: (vector) position at time t
+    :parameter v: (vetor) velocity at time t
+    :parameter body: (String) central body of orbit
+    :parameter t: (scalar) universal time
+    :return: :struct:`Orbit`
+
+    This creates a new orbit around a body given the position and velocity at a given time::
+
+        SET o TO ORBIT( x, v, "kerbin", TIME:SECONDS ).
+
+    Here, a new :struct:`Orbit` called ``o`` is created.
+
 Structure
 ---------
 
@@ -78,9 +96,15 @@ Structure
         * - :attr:`POSITION`
           - :struct:`Vector`
           - The current position
+        * - :attr:`POSITIONAT(time)`
+          - :struct:`Vector`
+          - The position at the given time
         * - :attr:`VELOCITY`
           - :struct:`Vector`
           - The current velocity
+        * - :attr:`VELOCITYAT(time)`
+          - :struct:`Vector`
+          - The velocity at the given time
         * - :attr:`NEXTPATCH`
           - :struct:`Orbit`
           - Next :struct:`Orbit`
@@ -214,15 +238,41 @@ Structure
 
     :type: :struct:`Vector`
     :access: Get only
+    :return:        A position :struct:`Vector` expressed as the coordinates in the :ref:`ship-center-raw-rotation <ship-raw>` frame
 
-    The current position of whatever the object is that is in this orbit.
+    The current position of whatever the object is that is in this orbit.  This vector is relative to the :ref:`ship-center-raw-rotation <ship-raw>` frame.  It
+    may be more useful to subtract the orbit:body:position before using it to convert to a body-centric position.
+
+.. attribute:: Orbit:POSITIONAT
+
+    :type: :struct:`Vector`
+    :param time:    Time of prediction
+    :type time:     :struct:`TimeSpan`
+    :access: Get only
+    :return:        A position :struct:`Vector` expressed as the coordinates in the :ref:`ship-center-raw-rotation <ship-raw>` frame
+
+    Returns a prediction of where the object will be at some :ref:`universal Timestamp <timestamp>`.  This vector is relative to the
+    :ref:`ship-center-raw-rotation <ship-raw>` frame (at the current time).  It may be more useful to subtract the orbit:body:position before
+    using it to conver to a body-centric position.  This prediction does not take into account future maneuver nodes.
 
 .. attribute:: Orbit:VELOCITY
 
-    :type: :struct:`Vector`
+    :type: :struct:`OrbitalVelocity`
     :access: Get only
+    :return:        An :ref:`OrbitalVelocity <orbitablevelocity>` structure.
 
     The current velocity of whatever the object is that is in this orbit.
+
+.. attribute:: Orbit:VELOCITYAT
+
+    :type: :struct:`OrbitalVelocity`
+    :param time:    Time of prediction
+    :type time:     :struct:`TimeSpan`
+    :access: Get only
+    :return:        An :ref:`OrbitalVelocity <orbitablevelocity>` structure.
+
+    Returns a prediction of what the velocity of the object will be at some :ref:`universal Timestamp <timestamp>`.  This prediction does not take into account
+    future maneuver nodes.
 
 .. attribute:: Orbit:NEXTPATCH
 

--- a/kerboscript_tests/structures/orbit1.ks
+++ b/kerboscript_tests/structures/orbit1.ks
@@ -1,0 +1,90 @@
+// useful to debug:
+//
+//    set o to orbit(x, v, body, time:seconds).
+//    o:positionat(time:seconds + dt).
+//    o:velocityat(time:seconds + dt).
+//
+// creates a keosynchronous orbit of an object directly above the equatorial coordinates of
+// KSC and checks the position at the current time and 1/4 way around the orbit.
+
+// x0, v0 are what we use to build the orbit
+set x0 to latlng(0, -75.08333333333333333332):position - ship:body:position.
+set x0:mag to 3463334.06.
+set v0 to vcrs(kerbin:angularvel, x0).
+set v0:mag to sqrt(kerbin:mu / x0:mag).
+
+set keosynch to orbit(x0, v0, "kerbin", TIME:SECONDS).
+
+print "sma    : " + keosynch:semimajoraxis.
+print "ecc    : " + keosynch:eccentricity.
+print "lan    : " + keosynch:lan.
+print "arg    : " + keosynch:argumentofperiapsis.
+print "period : " + keosynch:period.
+
+set sidereal_day to 5*3600 + 59*60 + 9.4.
+
+// x1, v1 should recover the same, while x2, v2 should be 1/4 around the orbit
+set x1 to keosynch:positionat(time:seconds) - ship:body:position.
+set v1 to keosynch:velocityat(time:seconds):orbit.
+set x2 to keosynch:positionat(time:seconds + sidereal_day/4) - ship:body:position.
+set v2 to keosynch:velocityat(time:seconds + sidereal_day/4):orbit.
+
+print "x1 : " + x1:mag.
+print "v1 : " + v1:mag.
+print "x2 : " + x2:mag.
+print "v2 : " + v2:mag.
+
+// some handy vectors for debugging in case something goes wrong.
+set xvec1 to vecdraw(ship:body:position, x1, rgb(1,0,0), "x1", 1.0, true, 0.2).
+set vvec1 to vecdraw(ship:body:position + x1, 1000 * v1, rgb(1,0,0), "v1", 1.0, true, 0.2).
+set xvec2 to vecdraw(ship:body:position, x2, rgb(0,1,0), "x2", 1.0, true, 0.2).
+set vvec2 to vecdraw(ship:body:position + x2, 1000 * v2, rgb(0,1,0), "v2", 1.0, true, 0.2).
+
+// assertions
+
+if abs(keosynch:period - sidereal_day) > 1
+  exit.
+
+if abs(keosynch:eccentricity) > 0.000001
+  exit.
+
+if abs(keosynch:semimajoraxis - 3463334.06) > 0.1
+  exit.
+
+if abs(x0:mag - 3463334.06) > 0.1
+  exit.
+if abs(x1:mag - 3463334.06) > 0.1
+  exit.
+if abs(x2:mag - 3463334.06) > 0.1
+  exit.
+
+if abs(v0:mag - 1009.80) > 0.1
+  exit.
+if abs(v1:mag - 1009.80) > 0.1
+  exit.
+if abs(v2:mag - 1009.80) > 0.1
+  exit.
+
+if (x1 - x0):mag > 1
+  exit.
+
+if (v1 - v0):mag > 1
+  exit.
+
+// x2 should point in the v1 direction
+if abs(3463334.06 - vdot(x2, v1:normalized)) > 0.1
+  exit.
+
+// v2 should point in the -x1 direction
+if abs(1009.80 - vdot(v2, -x1:normalized)) > 0.1
+  exit.
+
+// all vectors should be normal to the angular vel of kerbin's rotation
+if vdot(x1:normalized, kerbin:angularvel:normalized) > 0.001
+  exit.
+if vdot(v1:normalized, kerbin:angularvel:normalized) > 0.001
+  exit.
+if vdot(x2:normalized, kerbin:angularvel:normalized) > 0.001
+  exit.
+if vdot(v2:normalized, kerbin:angularvel:normalized) > 0.001
+  exit.

--- a/src/kOS/Function/Suffixed.cs
+++ b/src/kOS/Function/Suffixed.cs
@@ -166,6 +166,21 @@ namespace kOS.Function
         }
     }
 
+    [Function("orbit")]
+    public class FunctionOrbit : FunctionBase
+    {
+        public override void Execute(SharedObjects shared)
+        {
+            var when = GetTimeSpan(PopValueAssert(shared));
+            string bodyName = PopValueAssert(shared).ToString();
+            Vector vel = GetVector(PopValueAssert(shared));
+            Vector pos = GetVector(PopValueAssert(shared));
+            AssertArgBottomAndConsume(shared);
+            var result = new OrbitInfo(pos, vel, VesselUtils.GetBodyByName(bodyName), when.ToUnixStyleTime(), shared);
+            ReturnValue = result;
+        }
+    }
+
     [Function("heading")]
     public class FunctionHeading : FunctionBase
     {
@@ -356,7 +371,7 @@ namespace kOS.Function
             AssertArgBottomAndConsume(shared);
             DoExecuteWork(shared, start, vec, rgba, str, scale, show, width);
         }
-        
+
         public void DoExecuteWork(SharedObjects shared, Vector start, Vector vec, RgbaColor rgba, string str, double scale, bool show, double width)
         {
             var vRend = new VectorRenderer( shared.UpdateHandler, shared )
@@ -369,7 +384,7 @@ namespace kOS.Function
                 };
             vRend.SetLabel( str );
             vRend.SetShow( show );
-            
+
             ReturnValue = vRend;
         }
     }
@@ -383,7 +398,7 @@ namespace kOS.Function
             VectorRenderer.ClearAll(shared.UpdateHandler);
         }
     }
-    
+
     [Function("positionat")]
     public class FunctionPositionAt : FunctionBase
     {
@@ -435,7 +450,7 @@ namespace kOS.Function
             ReturnValue = new OrbitInfo( what.GetOrbitAtUT(when.ToUnixStyleTime()), shared );
         }
     }
-    
+
     [Function("career")]
     public class FunctionCareer : FunctionBase
     {
@@ -445,7 +460,7 @@ namespace kOS.Function
             ReturnValue = new Career();
         }
     }
-    
+
     [Function("constant")]
     public class FunctionConstant : FunctionBase
     {
@@ -455,14 +470,14 @@ namespace kOS.Function
             ReturnValue = new ConstantValue();
         }
     }
-    
+
     [Function("allwaypoints")]
     public class FunctionAllWaypoints : FunctionBase
     {
         public override void Execute(SharedObjects shared)
         {
             AssertArgBottomAndConsume(shared); // no args
-            
+
             // ReSharper disable SuggestUseVarKeywordEvident
             ListValue<WaypointValue> returnList = new ListValue<WaypointValue>();
             // ReSharper enable SuggestUseVarKeywordEvident
@@ -485,7 +500,7 @@ namespace kOS.Function
             ReturnValue = returnList;
         }
     }
-    
+
     [Function("waypoint")]
     public class FunctionWaypoint : FunctionBase
     {
@@ -502,7 +517,7 @@ namespace kOS.Function
             // first time a contract with a waypoint is created).
             if (wpm == null)
                 throw new KOSInvalidArgumentException("waypoint", "\""+pointName+"\"", "no waypoints exist");
-            
+
             string baseName;
             int index;
             bool hasGreek = WaypointValue.GreekToInteger(pointName, out index, out baseName);
@@ -510,7 +525,7 @@ namespace kOS.Function
                 pointName = baseName;
             Waypoint point = wpm.Waypoints.FirstOrDefault(
                 p => string.Equals(p.name, pointName,StringComparison.CurrentCultureIgnoreCase) && (!hasGreek || p.index == index));
-            
+
             // We can't communicate the concept of a lookup fail to the script in a way it can catch (can't do
             // nulls), so bomb out here:
             if (point ==null)

--- a/src/kOS/Suffixed/Vector.cs
+++ b/src/kOS/Suffixed/Vector.cs
@@ -109,6 +109,11 @@ namespace kOS.Suffixed
             return new Vector3((float)X, (float)Y, (float)Z);
         }
 
+        public Vector SwapYZ() // Used for KSP APIs that swap Y and Z
+        {
+            return new Vector(X, Z, Y);
+        }
+
         public override string ToString()
         {
             return "V(" + X + ", " + Y + ", " + Z + ")";


### PR DESCRIPTION
adds a constructor for Orbit (OrbitInfo internally) structures so
that users can construct their own orbit objects.

this lets a function that can build a hohmann transfer node to the
mun's orbit also be reused to transfer to a keosynchronous orbit.

because the orbit structure has no associated orbitable body it is
not possible to use positionat(orbitable) and velocityat(orbitable)
functions, so therefore added positionat and velocityat functions
to the orbit object (APIs that do not take into account maneuver
nodes and are documented as such).

docs updates and kerboscript tests included.