### PR TITLE
Issue #1661 Force program abort

### DIFF
--- a/src/kOS.Safe.Test/Opcode/FakeCpu.cs
+++ b/src/kOS.Safe.Test/Opcode/FakeCpu.cs
@@ -249,5 +249,10 @@ namespace kOS.Safe.Test.Opcode
         {
             throw new NotImplementedException();
         }
+
+        public Compilation.Opcode GetCurrentOpcode()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/kOS.Safe/Execution/ICpu.cs
+++ b/src/kOS.Safe/Execution/ICpu.cs
@@ -43,6 +43,7 @@ namespace kOS.Safe.Execution
         bool BuiltInExists(string functionName);
         void BreakExecution(bool manual);
         void AddVariable(Variable variable, string identifier, bool local, bool overwrite = false);
+        Opcode GetCurrentOpcode();
         Opcode GetOpcodeAt(int instructionPtr);
         void Boot();
         int InstructionsThisUpdate { get; }

--- a/src/kOS/Function/Misc.cs
+++ b/src/kOS/Function/Misc.cs
@@ -391,7 +391,7 @@ namespace kOS.Function
                 AssertArgBottomAndConsume(shared); // not sure if this matters when rebooting anwyway.
                 shared.Processor.SetMode(ProcessorModes.OFF);
                 shared.Processor.SetMode(ProcessorModes.READY);
-                ((CPU)shared.Cpu).GetCurrentOpcode().AbortProgram = true;
+                shared.Cpu.GetCurrentOpcode().AbortProgram = true;
             }
         }
     }
@@ -403,7 +403,7 @@ namespace kOS.Function
         {
             AssertArgBottomAndConsume(shared); // not sure if this matters when shutting down anwyway.
             if (shared.Processor != null) shared.Processor.SetMode(ProcessorModes.OFF);
-            ((CPU)shared.Cpu).GetCurrentOpcode().AbortProgram = true;
+            shared.Cpu.GetCurrentOpcode().AbortProgram = true;
         }
     }
 

--- a/src/kOS/Suffixed/KUniverseValue.cs
+++ b/src/kOS/Suffixed/KUniverseValue.cs
@@ -51,6 +51,7 @@ namespace kOS.Suffixed
         {
             if (CanRevertToLaunch())
             {
+                shared.Cpu.GetCurrentOpcode().AbortProgram = true;
                 FlightDriver.RevertToLaunch();
             }
             else throw new KOSCommandInvalidHereException(LineCol.Unknown(), "REVERTTOLAUNCH", "When revert is disabled", "When revert is enabled");
@@ -61,6 +62,7 @@ namespace kOS.Suffixed
             if (CanRevvertToEditor())
             {
                 EditorFacility fac = ShipConstruction.ShipType;
+                shared.Cpu.GetCurrentOpcode().AbortProgram = true;
                 FlightDriver.RevertToPrelaunch(fac);
             }
             else throw new KOSCommandInvalidHereException(LineCol.Unknown(), "REVERTTOEDITOR", "When revert is disabled", "When revert is enabled");
@@ -85,6 +87,7 @@ namespace kOS.Suffixed
                         fac = EditorFacility.None;
                         break;
                 }
+                shared.Cpu.GetCurrentOpcode().AbortProgram = true;
                 FlightDriver.RevertToPrelaunch(fac);
             }
             else throw new KOSCommandInvalidHereException(LineCol.Unknown(), "REVERTTO", "When revert is disabled", "When revert is enabled");
@@ -218,6 +221,7 @@ namespace kOS.Suffixed
                 {
                     throw new KOSException("Error loading the quicksave file, the save file does not exist.");
                 }
+                shared.Cpu.GetCurrentOpcode().AbortProgram = true;
                 try
                 {
                     SaveGame("kos-backup-quicksave");
@@ -317,6 +321,7 @@ namespace kOS.Suffixed
             preFlightCheck.AddTest(new NoControlSources(manifest));
             preFlightCheck.AddTest(new LaunchSiteClear(launchSiteName, HighLogic.CurrentGame));
             preFlightCheck.RunTests();
+            shared.Cpu.GetCurrentOpcode().AbortProgram = true;
             SafeHouse.Logger.Log("Craft waiting for preflight checks!");
         }
     }


### PR DESCRIPTION
Fixes #1661

ICpu.cs
* Expose "GetCurrentOpcode" on the ICpu interface

FakeCpu.cs
* Add "GetCurrentOpcode" (throws not implemented exception)

Misc.cs
* Remove casting ICpu to CPU.

KuniverseValue.cs
* Abort the current program when reverting the game
* Abort the current program when launching a new craft (because it will kill the program anyways)
* Abort the program when loading a quick save.