### PR TITLE
Fix VolumePath on Windows archive

### DIFF
--- a/src/kOS.Safe.Test/kOS.Safe.Test.csproj
+++ b/src/kOS.Safe.Test/kOS.Safe.Test.csproj
@@ -101,13 +101,12 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <ItemGroup>
-    <Folder Include="Serialization\" />
-    <Folder Include="Communication\" />
-    <Folder Include="Persistence\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <Content Include="ProfilingSessions\Session20160127_233127.sdps" />
     <Content Include="ProfilingSessions\Session20160127_233506.sdps" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
 </Project>

--- a/src/kOS.Safe/Persistence/Archive.cs
+++ b/src/kOS.Safe/Persistence/Archive.cs
@@ -75,7 +75,7 @@ namespace kOS.Safe.Persistence
                 }
                 else if (fileSystemInfo is FileInfo)
                 {
-                    VolumePath filePath = VolumePath.FromString(fileSystemInfo.FullName.Substring(ArchiveFolder.Length));
+                    VolumePath filePath = VolumePath.FromString(fileSystemInfo.FullName.Substring(ArchiveFolder.Length).Replace(Path.DirectorySeparatorChar, VolumePath.PathSeparator));
                     return new ArchiveFile(this, fileSystemInfo as FileInfo, filePath);
                 }
                 else {


### PR DESCRIPTION
Fixes #1672

Archive.cs
* Fix parsing of VolumePath information on windows by replacing directory separators.

kOS.Safe.Test.csproj
* Project file updated by editor.
* ItemGroup folders removed because each file is independently referenced
* Add Service info which speeds up loading tests at least for Visual Studio 2013+