### PR TITLE
Fixes #1677 : Edits to docs (I grep'ed for all 'run' instances

### DIFF
--- a/doc/source/general/compiling.rst
+++ b/doc/source/general/compiling.rst
@@ -14,11 +14,11 @@ When you run your Kerboscript programs, behind the scenes they get compiled into
 
 The commands you actually write when you say something like ``SET X TO 1.0.`` are really a euphemism for these "machine language" opcodes under the surface.
 
-When you try to "RUN" your script, the first thing that kOS does is transform your script into this ancient and arcane "machine language" form, storing it in its memory, and from then on it runs using that.
+When you try to run your script, the first thing that kOS does is transform your script into this ancient and arcane "machine language" form, storing it in its memory, and from then on it runs using that.
 
 This process of transforming your script into Machine Language, or "ML" is called "Compiling".
 
-The "RUN" command does this silently, without telling you. This is why you may have noticed the universe slightly stutter for a moment when you first run your program. Compiling is hard work for the universe to do.
+The "RUN" and "RUNPATH" commands do this silently, without telling you. This is why you may have noticed the universe slightly stutter for a moment when you first run your program. Compiling is hard work for the universe to do.
 
 Why Do I Care?
 ~~~~~~~~~~~~~~
@@ -33,7 +33,7 @@ So, given that the compiled "ML" codes are the only thing your program really ne
 
 And THAT is the purpose of the COMPILE command.
 
-It does some, but not all, of the compiling work that the RUN command does, and then stores the results in a file that you can run instead of running the original script.
+It does some, but not all, of the compiling work that the RUN (or RUNPATH) command does, and then stores the results in a file that you can run instead of running the original script.
 
 The output of the COMPILE command is a file in what we call KSM format.
 
@@ -48,13 +48,13 @@ Let's say that you have 3 programs your probe needs, called:
 -  myprog2.ks
 -  myprog3.ks
 
-And that myprog1 calls myprog2 and myprog3, and you normall would call the progam this way::
+And that myprog1 calls myprog2 and myprog3, and you normally would call the progam this way::
 
     SWITCH TO 1.
     COPY myprog1 from ARCHIVE.
     COPY myprog2 from ARCHIVE.
     COPY myprog3 from ARCHIVE.
-    RUN myprog1(1,2,"hello").
+    RUNPATH(myprog1, 1, 2, "hello").
 
 Then you can put just the compiled KSM versions of them on your vessel and run it this way::
 
@@ -70,18 +70,25 @@ Then you can put just the compiled KSM versions of them on your vessel and run i
     COPY myprog2.ksm to 1.
 
     SWITCH TO 1.
-    RUN myprog1(1,2,"hello").
+    RUNPATH(myprog1, 1, 2, "hello").
 
 Default File Naming Conventions
 -------------------------------
 
-When you have both a .ks and a .ksm file, the RUN command allows you to specify which one you meant explicitly, like so::
+When you have both a .ks and a .ksm file, the RUN (or RUNPATH) command allows you to specify which one you meant explicitly, like so::
 
+    RUNPATH("myprog1.ks").
+    // or this alternate way to say it:
     RUN myprog1.ks.
+
+    RUNPATH("myprog1.ksm").
+    // or this alternate way to say it:
     RUM myprog1.ksm.
 
 But if you just leave the file extension off, and do this::
 
+    RUNPATH("myprog1").
+    // or this alternate way to say it:
     RUN myprog1.
 
 Then the RUN command will first try to run a file called "myprog1.ksm" and if it cannot find such a file, then it will try to run one called "myprog1.ks".

--- a/doc/source/language/user_functions.rst
+++ b/doc/source/language/user_functions.rst
@@ -112,25 +112,26 @@ programs.  At the top of your main script you can then "run" the
 other scripts containing the library of functions to get them
 compiled into memory.
 
-Using RUN ONCE
---------------
+Using RUN ONCE or RUNONCEPATH
+-----------------------------
 
 If you want to load a library of functions that ALSO perform some
 initialization mainline code, but you only want the mainline code
 to execute once when the library is first loaded, rather than 
 every time a subprogram runs your library, then use the 'once'
-keyword with the run command as follows::
+keyword with the RUN command, or the RUNONCEPATH command, as
+follows::
 
     // This will run mylib1 3 times, re-running the mainline code in it:`
     run mylib1.
     run mylib1.
-    run mylib1.
+    runpath("mylib1"). // just the same thing as 'run mylib1', really.
 
     // This will run mylib2 only one time, ignoring the additional
     // instances:
     run once mylib2.
     run once mylib2. // mylib2 was already run, will not be run again.
-    run once mylib2. // mylib2 was already run, will not be run again.
+    runoncepath("mylib2") // mylib2 was already run, will not be run again.
 
 Example:  Let's say you want to have a library that keeps a counter
 and always returns the next number up every time it's called.  You
@@ -152,7 +153,7 @@ another sub-program includes the library in its code.  So you have this:
 **subprogram, which ALSO calls counterlib:** ::
 
     // subprogram
-    run once counterlib.
+    runoncepath("counterlib"). // same as 'run once counterlib.'
 
     print "subprogram: next counter ID = " + counter_next().
     print "subprogram: next counter ID = " + counter_next().

--- a/doc/source/language/variables.rst
+++ b/doc/source/language/variables.rst
@@ -193,7 +193,7 @@ Optional Parameters (defaulted parameters)
 ::::::::::::::::::::::::::::::::::::::::::
 
 If you wish, you may make some of the parameters of a program or a user
-function optional by defaulting them to a starting value with the ``IS`` keyword, as follows:
+function optional by defaulting them to a starting value with the ``IS`` keyword, as follows::
 
     // Imagine this is a file called MYPROG
 
@@ -206,6 +206,7 @@ function optional by defaulting them to a starting value with the ``IS`` keyword
     run MYPROG(1,2).         // prints "1, 2, 0, cheese".
     run MYPROG(1,2,3).       // prints "1, 2, 3, cheese".
     run MYPROG(1,2,3,"hi").  // prints "1, 2, 3, hi".
+    runpath(MYPROG,1,2,3,"hi").  // also prints "1, 2, 3, hi".
 
 Whenever arguments are missing, the system always makes up the difference by
 using defaults for the lastmost parameters until the correct number have been

--- a/doc/source/tutorials/quickstart.rst
+++ b/doc/source/tutorials/quickstart.rst
@@ -86,6 +86,10 @@ And you will see the program run, showing the text on the screen like so.
 
 .. figure:: /_images/tutorials/quickstart/hello_world1.png
 
+Note, you can also type ``RUNPATH("hello")`` instead of ``RUN HELLO``.  The
+commands are slightly different but should have the same effect.  You can
+learn about the specific difference between them later.
+
 Step 7: Okay, but where is this program?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -231,7 +235,7 @@ Okay now go back into your *text editor of choice* and append a few more lines t
 Save this file to hellolaunch.ks again, and re-copy it to your vessel that should still be sitting on the launchpad, then run it, like so::
 
     COPY HELLOLAUNCH FROM 0.
-    RUN HELLOLAUNCH.
+    RUN HELLOLAUNCH. // You could also say RUNPATH("hellolaunch") here.
 
 .. figure:: /_images/tutorials/quickstart/example_2_2.png
     :width: 80 %
@@ -295,7 +299,7 @@ Again, copy this and run it, like before. If your craft crashed in the previous 
 
     SWITCH TO 1. // should be the default already, but just in case.
     COPY HELLOLAUNCH FROM 0.
-    RUN HELLOLAUNCH.
+    RUN HELLOLAUNCH. // You could also say RUNPATH("hellolaunch") here.
 
 .. figure:: /_images/tutorials/quickstart/example_2_3.png
     :width: 80 %


### PR DESCRIPTION
anywhere in the doc/source .rst files and examined them
by eye to see which might need editing.)

In addition to re-writing the docs section about RUN,
I made sure that in places where a lot of examples were
using the older RUN syntax, that I also provided examples
using the newer RUNPATH syntax as well.

Dangit:  Fixes #1677  (not 1667)
I had the wrong number in the title description.