### PR TITLE
prevent crash by InvalidOperationException

### DIFF
--- a/src/kOS/Screen/ToolbarWrapper.cs
+++ b/src/kOS/Screen/ToolbarWrapper.cs
@@ -726,9 +726,16 @@ namespace kOS.Screen {
 		}
 
 		internal static Type getType(string name) {
-			return AssemblyLoader.loadedAssemblies
-				.SelectMany(a => a.assembly.GetExportedTypes())
-				.SingleOrDefault(t => t.FullName == name);
+			foreach (AssemblyLoader.LoadedAssembly assembly in AssemblyLoader.loadedAssemblies) {
+				try {
+					var type = assembly.assembly.GetExportedTypes().SingleOrDefault(t => t.FullName == name);
+					if (type != null) {
+						return type;
+					}
+				} catch (InvalidOperationException) {
+				}
+			}
+			return null;
 		}
 
 		internal static PropertyInfo getProperty(Type type, string name) {


### PR DESCRIPTION
Modify `ToolbarTypes.getType()` in `ToolbarWrapper.cs` .

Otherwise, toolbar button may crash if there is a broken mod.