### PR TITLE
Fixes #1692: Just had to add a cast to (int)

### DIFF
--- a/src/kOS/Function/Math.cs
+++ b/src/kOS/Function/Math.cs
@@ -289,7 +289,7 @@ namespace kOS.Function
             string argument = PopValueAssert(shared).ToString();
             AssertArgBottomAndConsume(shared);
             char result = argument.ToCharArray()[0];
-            ReturnValue = ScalarValue.Create(result);
+            ReturnValue = ScalarValue.Create((int)result);
         }
     }
 }


### PR DESCRIPTION
Maybe we could later on add more integer types (like char, short, long) to the ScalarValue.Create() method, but for now, this fixes the problem fast and simply.

I'm going to add this to the v1.0.0 milestone because it's super simple to review and merge, and it's a bug fix, not a new feature, and it used to work before.  It's a bug we caused ourselves in a previous update (the bug was introduced in the update where we added all the conversions to `ScalarValue` and stopping exposing native C# types to the user on the kOS stack.)