### PR TITLE
Show boot file selector when there's exactly one boot file

### DIFF
--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -301,8 +301,8 @@ namespace kOS.Module
             bootFiles.AddRange(BootDirectoryFiles());
 
             //no need to show the control if there are no available boot files
-            options.controlEnabled = bootFiles.Count > 1;
-            field.guiActiveEditor = bootFiles.Count > 1;
+            options.controlEnabled = bootFiles.Count >= 1;
+            field.guiActiveEditor = bootFiles.Count >= 1;
             var availableOptions = bootFiles.Select(e => e.ToString()).ToList();
             var availableDisplays = bootFiles.Select(e => e.Name).ToList();
 


### PR DESCRIPTION
The code currently sets the boot file selector to be visible if `bootfiles.Count > 1`. If the count is equal to 1 (i.e. if there's exactly one script in `0:/boot/`), we probably want the UI to show up so we can choose between that file and no boot file. I changed the comparison from "greater than 1" to "greater than or equal to 1".