### PR TITLE
Fixes #1716.  Problem was caused by PR #1657.

### DIFF
--- a/src/kOS.Safe/Compilation/CompiledObject.cs
+++ b/src/kOS.Safe/Compilation/CompiledObject.cs
@@ -471,7 +471,8 @@ namespace kOS.Safe.Compilation
         /// Given a packed representation of the program, load it back into program form:
         /// </summary>
         /// <param name="path">path of file (with preceeding "volume:") that the program came from, for runtime error reporting.</param>
-        /// <param name="prefix">prepend this string to all labels in this program.</param>
+        /// <param name="prefix">prepend this string to all labels in this program, with the exception
+        /// of when this program is calling the @LR LoadRunner labels.</param>
         /// <param name="content">the file itself in ony big binary array.</param>
         /// <returns></returns>
         public static List<CodePart> UnPack(GlobalPath path, string prefix, byte[] content)
@@ -529,7 +530,7 @@ namespace kOS.Safe.Compilation
             }
             reader.Close();
 
-            PostReadProcessing(program, path, prefix, lineMap);
+            PostReadProcessing(program, path, lineMap);
                                                   
             return program;
         }
@@ -580,9 +581,8 @@ namespace kOS.Safe.Compilation
         /// </summary>
         /// <param name="program">recently built program parts to re-assign.</param>
         /// <param name="path">path of file (with preceeding volume:) that the compiled code came from, for rutime error reporting purposes.</param>
-        /// <param name="prefix">a string to prepend to the labels in the program.</param>
         /// <param name="lineMap">describes the mapping of line numbers to code locations.</param>
-        private static void PostReadProcessing(IEnumerable<CodePart> program, GlobalPath path, string prefix, DebugLineMap lineMap)
+        private static void PostReadProcessing(IEnumerable<CodePart> program, GlobalPath path, DebugLineMap lineMap)
         {
             //TODO:prefix is never used.
             SortedList<IntRange,int> lineLookup = lineMap.BuildInverseLookup();
@@ -665,7 +665,8 @@ namespace kOS.Safe.Compilation
         /// <param name="reader">binary reader to read from.</param>
         /// <param name="codeStartPos">index into the stream where the first code block in the ML file started,
         /// for calculating indeces.</param>
-        /// <param name="prefix">prefix to prepend to all labels within this program.</param>
+        /// <param name="prefix">prefix to prepend to all labels within this program, with the
+        /// exception of cases where this program is calling the @LR load runner labels.</param>
         /// <param name="arguments">argument dictionary to pull arguments from.</param>
         /// <param name="argIndexSize">number of bytes the argument indeces are packed into.</param>
         /// <returns>list of opcodes generated</returns>
@@ -705,7 +706,11 @@ namespace kOS.Safe.Compilation
                     if (argInfo.NeedReindex)
                     {                                              
                         val = arguments[argIndex];
-                        if ( val is string && ((string)val).StartsWith("@") && (((string)val).Length > 1) )
+                        if (val is string &&
+                            ((string)val).StartsWith("@") &&
+                            (((string)val).Length > 1) &&
+                            !((string)val).StartsWith("@LR") // Do not re-assign calls to the LoadRunner global label that resides outside this KSM file.
+                           )
                         {
                             val = "@" + prefix + "_" + ((string)val).Substring(1);
                         }


### PR DESCRIPTION
PR #1657 made a lot of changes to how programs are
loaded and run.  Prior to #1657, every single ``run``
statement caused the existence of its own new copy
of some standard boilerplate code to be inserted
into the top of the compiled program, with the
only difference being the hardcoded name of the
program file being loaded.  If you had a program
that did 4 different 'run' commands, it copied that
code 4 times, which was wasteful, and was also the
reason for the need to hardcode the filenames at
runtime.  The change was made to move all this to
a single global run function that exists exactly
once, no matter how many times you run things, and
it takes the program name as an argument.  BUT,
the KSM loader didn't know about this change (I
forgot to edit how it worked too).  It was still
trying to unconditionally "move" all the labels it
saw the KSM file trying to call, even the call to
the (now global and not relocating with the rest
of the program) load/run function.

Basically, I just told it to stop trying to insert the "num_"
prefix onto the label being called by a ``call``, if that
label happens to begin with ``@LR`` which is the magic name
for the Load/Run global routine.  That seems to have fixed
this.

A more complete solution for the future might be to
invent a scheme in which we can generically speficy "labels
that look like such-and-such are globals that should never
get reassigned on loading".  Right now the ``@LRnn`` labels
are the only ones like this but who knows, we may add more
along those lines later.