### PR TITLE
Fixes #1713 anon functions implicit returns.

### DIFF
--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -1267,10 +1267,18 @@ namespace kOS.Safe.Compilation.KS
                 Opcode skipPastFunctionBody = AddOpcode(new OpcodeBranchJump());
                 string functionStartLabel = GetNextLabel(false);
                 
+                needImplicitReturn = true;
                 nextBraceIsFunction = true;
                 VisitNode(node.Nodes[0]); // the braces of the anonymous function and its contents get compiled in-line here.
                 nextBraceIsFunction = false;
-
+                if (needImplicitReturn)
+                    // needImplicitReturn is unconditionally true here, but it's being used anyway so we'll find this block
+                    // of code later when we search for "all the places using needImplicitReturn" and perform a refactor
+                    // of the logic for adding implicit returns.
+                {
+                    AddOpcode(new OpcodePush(0)); // Functions must push a dummy return val when making implicit returns. Locks already leave an expr atop the stack.
+                    AddOpcode(new OpcodeReturn(0));
+                }
                 Opcode afterFunctionBody = AddOpcode(new OpcodePushDelegateRelocateLater(null,true), functionStartLabel);
                 skipPastFunctionBody.DestinationLabel = afterFunctionBody.Label;
             }


### PR DESCRIPTION
Now anonymous functions follow the same logic as is
used in named functions, for handling the implicit
returns when an explicit return is missing.

Note, this system is a bit wonky at the moment, but
does work (I'm imitating what happens with named functions,
which is a bit in need of a refactor, as I described
in separate issue #1722.)

Fixes #1713