### PR TITLE
Fixes #1714 , the infinite exception problem, but...

### DIFF
--- a/src/kOS.Safe/Execution/CPU.cs
+++ b/src/kOS.Safe/Execution/CPU.cs
@@ -1310,7 +1310,7 @@ namespace kOS.Safe.Execution
             GlobalPath currentSourcePath = currentContext.Program[currentContext.InstructionPointer].SourcePath;
 
             while (currentContext.InstructionPointer < currentContext.Program.Count &&
-                currentContext.Program[currentContext.InstructionPointer].SourcePath == currentSourcePath)
+                   currentSourcePath.Equals(currentContext.Program[currentContext.InstructionPointer].SourcePath))
             {
                 currentContext.InstructionPointer++;
             }


### PR DESCRIPTION
... it exposed a problem under the hood.  The notion of throwing an exception inside a function that's in the interpreter is a bit messy to deal with.  In a program, it throws the program away when there's an exception.  In the interpreter, it doesn't.  And if we did throw it away and start over, that would mean any previously typed-in functions would disappear.

I really think this can't be fully made to work unless we design a try/catch system in kerboscript, because we'd have to pop the call stack back and make the stack proper in order to return to the right point and continue from there without throwing away the program.... and that's essentially exception handling.

For now I'm happy with this "fix" because it puts it back the way it was before the subdirectories change broke it.  The problem now where the stack is left with cruft still on the stack is a problem that always existed if you tried using functions made in the interpreter and they threw an exception.

Fixes #1714