### PR TITLE
Fix nag messages when loading other mods

### DIFF
--- a/src/kOS.Safe/Function/FunctionManager.cs
+++ b/src/kOS.Safe/Function/FunctionManager.cs
@@ -37,31 +37,6 @@ namespace kOS.Safe.Function
             }
         }
 
-        public static void WalkAssemblies()
-        {
-            rawAttributes.Clear();
-            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
-            {
-                if (!assembly.GlobalAssemblyCache)
-                {
-                    WalkAssembly(assembly);
-                }
-            }
-        }
-
-        public static void WalkAssembly(Assembly assembly)
-        {
-            foreach (Type type in assembly.GetTypes())
-            {
-                var attr = (FunctionAttribute)type.GetCustomAttributes(typeof(FunctionAttribute), true).FirstOrDefault();
-                if (attr == null) continue;
-                if (!rawAttributes.ContainsKey(attr))
-                {
-                    rawAttributes.Add(attr, type);
-                }
-            }
-        }
-
         public static void RegisterMethod(Attribute attr, Type type)
         {
             var funcAttr = attr as FunctionAttribute;

--- a/src/kOS.Safe/Utilities/AssemblyWalkAttribute.cs
+++ b/src/kOS.Safe/Utilities/AssemblyWalkAttribute.cs
@@ -13,7 +13,7 @@ namespace kOS.Safe.Utilities
     /// in the currently loaded assemblies (excluding the GAC) will be checked for this attribute,
     /// and then a 2nd time for the type conditions of each AssemblyWalkAttribute found. Each Type
     /// matching a condition of the attribute will be passed to the StaticRegisterMethod. Optionally,
-    /// defining StaticWalkMethod will let the manager walk the assemblies itself, allowing for mor
+    /// defining StaticWalkMethod will let the manager walk the assemblies itself, allowing for more
     /// complicated conditions
     /// </summary>
     [AttributeUsage((AttributeTargets.Class | AttributeTargets.Struct), Inherited = false, AllowMultiple = false)]
@@ -53,14 +53,20 @@ namespace kOS.Safe.Utilities
         public static void Walk()
         {
             SafeHouse.Logger.Log("AssemblyWalkAttribute begin walking");
-            LoadWalkAttributes();
-            WalkAllAssemblies();
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            Walk(assemblies);
         }
 
-        public static void LoadWalkAttributes()
+        public static void Walk(Assembly[] assemblies)
         {
-            AllWalkAttributes.Clear();
-            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            SafeHouse.Logger.Log("AssemblyWalkAttribute begin walking");
+            LoadWalkAttributes(assemblies);
+            WalkAssemblies(assemblies);
+        }
+
+        public static void LoadWalkAttributes(Assembly[] assemblies)
+        {
+            SafeHouse.Logger.SuperVerbose("Begin loading AssemblyWalkAttributes.");
             foreach (Assembly assembly in assemblies)
             {
                 // Don't check the assembly if it's in the GAC.
@@ -179,10 +185,9 @@ namespace kOS.Safe.Utilities
             }
         }
 
-        public static void WalkAllAssemblies()
+        public static void WalkAssemblies(Assembly[] assemblies)
         {
             SafeHouse.Logger.SuperVerbose("Begin walking assemblies.");
-            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
             foreach (Assembly assembly in assemblies)
             {
                 if (!assembly.GlobalAssemblyCache)
@@ -196,7 +201,7 @@ namespace kOS.Safe.Utilities
                     {
                         string message = string.Format(assemblyLoadErrorFormat, assembly.FullName, assembly.Location);
                         SafeHouse.Logger.LogError(message);
-                        Debug.AddNagMessage(Debug.NagType.NAGFOREVER, message);
+                        Debug.AddNagMessage(Debug.NagType.NAGONCE, message);
                         SafeHouse.Logger.LogError(string.Format("Exception: {0}\nStack Trace:\n{1}", ex.Message, ex.StackTrace));
                     }
                 }

--- a/src/kOS/Module/Bootstrapper.cs
+++ b/src/kOS/Module/Bootstrapper.cs
@@ -25,7 +25,7 @@ namespace kOS.Module
 
             CheckForLegacyArchive();
             
-            var assemblies = AssemblyLoader.loadedAssemblies.Where(a => a.dllName.StartsWith("kOS.") || a.dependencies.Where(d => d.name.Equals("kOS")).Any()).Select(a => a.assembly).ToArray();
+            var assemblies = AssemblyLoader.loadedAssemblies.Where(a => a.dllName.StartsWith("kOS.") || a.dllName.Equals("kOS") || a.dependencies.Where(d => d.name.Equals("kOS")).Any()).Select(a => a.assembly).ToArray();
             AssemblyWalkAttribute.Walk(assemblies);
         }
 

--- a/src/kOS/Module/Bootstrapper.cs
+++ b/src/kOS/Module/Bootstrapper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using kOS.Safe.Persistence;
 using kOS.Safe.Utilities;
 using kOS.Suffixed;
@@ -23,8 +24,9 @@ namespace kOS.Module
             BuildLogger();
 
             CheckForLegacyArchive();
-
-            AssemblyWalkAttribute.Walk();
+            
+            var assemblies = AssemblyLoader.loadedAssemblies.Where(a => a.dllName.StartsWith("kOS.") || a.dependencies.Where(d => d.name.Equals("kOS")).Any()).Select(a => a.assembly).ToArray();
+            AssemblyWalkAttribute.Walk(assemblies);
         }
 
         private void BuildEnvironment()


### PR DESCRIPTION
Fixes #1718

AssemblyWalkAttribute.cs
* Modify logic to allow Walk to accept a array of assemblies, so that we don't have to walk every assembly in the AppDomain
* Leave a version of Walk that takes no parameters and still walks the entire AppDomain, for future use in an external tool
* Converted Nag messages to NAGONCE so that you can still run kOS by power cycling the cpu

Bootstrapper.cs
* Call the new Walk using assemblies, filtered to start with "kOS." or declare "kOS" as a dependency.