### PR TITLE
Add boot script migration

### DIFF
--- a/doc/source/general/volumes.rst
+++ b/doc/source/general/volumes.rst
@@ -185,7 +185,7 @@ migration.
         the archive root, and finally it will check the boot directory again
         after stripping :code:`boot` or :code:`boot_` from the beginning of the name.
         Vessels in flight will continue to work with the existing structure, so
-        long as :attr:`CONFIG:ARCH` is set to false.  If:attr:`CONFIG:ARCH` is
+        long as :attr:`CONFIG:ARCH` is set to false.  If :attr:`CONFIG:ARCH` is
         set to true, you will need to leave copies of the originally named boot
         files in your archive root for ships already in flight to access.
 

--- a/doc/source/general/volumes.rst
+++ b/doc/source/general/volumes.rst
@@ -150,7 +150,7 @@ volume but with the following exceptions:
    choice and edit them directly, and the KOS Mod will see those changes
    in its archive immediately. Files stored in other volumes, on the
    other hand, are stored inside the vessel's data in the persistence
-   file of the saved game and are quite a bit bit harder to edit there.
+   file of the saved game and are quite a bit harder to edit there.
    Editing the files in the Archive directory is allowed and in fact is
    an officially accepted way to use the plugin. Editing the section in
    a persistence file, on the other hand, is a bad idea and probably
@@ -167,7 +167,27 @@ was introduced. If you have at least 1 file in the :code:`boot` directory on
 your Archive volume, you will be presented with the option to choose one of
 those files as a boot script for your kOS CPU.
 
+
 .. image:: http://i.imgur.com/05kp7Sy.jpg
+
+The first time that you load kOS without a directory named
+:code:`boot` in the archive root, kOS will prompt you for automatic
+migration.
+
+.. warning::
+    .. versionadded:: v1.0.0
+        Older versions of kOS used file names starting with the word "boot" to
+        determine which files should be considered as boot files.  When support
+        was added for directories, it made sense to instead use a directory
+        named :code:`boot`.  Care was taken to maximize backwards compatibility:
+        if an existing craft file is opened in the editor, kOS will first look
+        for the saved boot file name in the boot directory, then it will check
+        the archive root, and finally it will check the boot directory again
+        after stripping :code:`boot` or :code:`boot_` from the beginning of the name.
+        Vessels in flight will continue to work with the existing structure, so
+        long as :attr:`CONFIG:ARCH` is set to false.  If:attr:`CONFIG:ARCH` is
+        set to true, you will need to leave copies of the originally named boot
+        files in your archive root for ships already in flight to access.
 
 As soon as you vessel leaves VAB/SPH and is being initialised on the launchpad
 (e.g. its status is PRELAUNCH) the assigned script will be copied to CPU's
@@ -188,4 +208,3 @@ Possible uses for boot scripts:
   * Create basic station-keeping scripts - you will only have to focus your probes once in a while and let the boot script do the orbit adjustment automatically.
   * Create multi-CPU vessels with certain cores dedicated to specific tasks, triggered by user input or external events (Robotic-heavy Vessels)
   * Anything else you can come up with
-

--- a/src/kOS/Module/Bootstrapper.cs
+++ b/src/kOS/Module/Bootstrapper.cs
@@ -15,6 +15,16 @@ namespace kOS.Module
         private const string LEGACY_KOS_EXTENSION = ".txt";
         private readonly string backupFolder = GameDatabase.Instance.PluginDataFolder + "/GameData/kOS/Backup_" + DateTime.Now.ToFileTimeUtc();
 
+        private const string LEGACY_KOS_FOLDER_DESC = "The kOS v0.15 update has moved the archive folder to /Ships/Script/ and " +
+                                                      "changed the file extension from *.txt to *.ks to be more in line with " +
+                                                      "squad's current folder structure. Would you like us to attempt to migrate " +
+                                                      "your existing scripts?";
+        private const string LEGACY_KOS_BOOT_DESC = "The kOS v1.0.0 update has updated how boot files are handled.  Boot file are " +
+                                                    "now expected to within a boot folder on the archive.  Would you like us to " +
+                                                    "attempt to migrate your existing scripts?  See the warning regarding the boot " +
+                                                    "directory at http://kos.github.io/KOS_DOC/general/volumes.html#special-handling-of-files-in-the-boot-directory " +
+                                                    "for more details.";
+
         private bool backup = true;
         
         public void Start()
@@ -49,27 +59,57 @@ namespace kOS.Module
         {
             if (!Directory.Exists(legacyArchiveFolder))
             {
+                CheckForLegacyBoot();
                 return;
             }
 
             if (Directory.Exists(SafeHouse.ArchiveFolder))
             {
+                CheckForLegacyBoot();
                 return;
             }
+            
+            PopupDialog.SpawnPopupDialog(
+                new MultiOptionDialog(
+                    LEGACY_KOS_FOLDER_DESC,
+                    "kOS",
+                    HighLogic.UISkin,
+                    new DialogGUIButton("Yes, Do it!", MigrateScripts, true),
+                    new DialogGUIButton("No, I'll do it myself", CheckForLegacyBoot, true),
+                    new DialogGUIToggle(true, "Backup my scripts first", (bool val) => backup = val)
+                    ),
+                true,
+                HighLogic.UISkin
+                );
+        }
 
-            //TODO: 1.1 TODO
-            //PopupDialog.SpawnPopupDialog(
-            //    new MultiOptionDialog(
-            //        "The kOS v0.15 update has moved the archive folder to /Ships/Script/ and changed the file extension from *.txt to *.ks to be more in line with squad's current folder structure. Would you like us to attempt to migrate your existing scripts?",
-            //        () => backup = GUILayout.Toggle(backup, "Backup My scripts first"),
-            //        "kOS",
-            //        HighLogic.Skin, 
-            //        new DialogOption("Yes, Do it!", MigrateScripts, true),
-            //        new DialogOption("No, I'll do it myself", () => { }, true)
-            //        ),
-            //    true,
-            //    HighLogic.Skin
-            //    );
+        private void CheckForLegacyBoot()
+        {
+            string bootDirectory = Path.Combine(SafeHouse.ArchiveFolder, "boot");
+            // if the boot directory exists, we presume the migration has already been done.
+            if (Directory.Exists(bootDirectory))
+                return;
+            Directory.CreateDirectory(bootDirectory);
+
+            // if there aren't any files to migrate, don't bother showing the migration option.
+            if (Directory.GetFiles(SafeHouse.ArchiveFolder, "boot*").Length == 0)
+                return;
+
+            backup = true;
+
+            PopupDialog.SpawnPopupDialog(
+                new MultiOptionDialog(
+                    LEGACY_KOS_BOOT_DESC,
+                    "kOS",
+                    HighLogic.UISkin,
+                    new DialogGUIButton("Yes, and strip \"boot\" prefixes", MigrateBootAndRename, true),
+                    new DialogGUIButton("Yes, but don't rename", MigrateBootNoRename, true),
+                    new DialogGUIButton("No, I'll handle it myself", () => { }, true),
+                    new DialogGUIToggle(backup, "Copy the scripts, don't move them", (bool val) => backup = val)
+                    ),
+                true,
+                HighLogic.UISkin
+                );
         }
 
         private void MigrateScripts()
@@ -97,11 +137,11 @@ namespace kOS.Module
                 {
                     var bareFilename = Path.GetFileNameWithoutExtension(fileName);
                     const string NEW_EXTENSION = Archive.KERBOSCRIPT_EXTENSION;
-                    newFileName = string.Format("{0}/{1}.{2}", Safe.Utilities.SafeHouse.ArchiveFolder, bareFilename, NEW_EXTENSION);
+                    newFileName = string.Format("{0}/{1}.{2}", SafeHouse.ArchiveFolder, bareFilename, NEW_EXTENSION);
                 }
                 else
                 {
-                    newFileName = Safe.Utilities.SafeHouse.ArchiveFolder + Path.DirectorySeparatorChar + Path.GetFileName(fileName);
+                    newFileName = SafeHouse.ArchiveFolder + Path.DirectorySeparatorChar + Path.GetFileName(fileName);
                 }
 
                 SafeHouse.Logger.Log("ScriptMigrate moving: " + fileName + " to: " + newFileName);
@@ -109,6 +149,8 @@ namespace kOS.Module
             }
 
             SafeHouse.Logger.Log("ScriptMigrate END");
+
+            CheckForLegacyBoot();
         }
 
         private void BackupScripts()
@@ -128,6 +170,56 @@ namespace kOS.Module
                 SafeHouse.Logger.Log("copying: " + fileName + " to: " + newFileName);
                 File.Copy(fileName, newFileName);
             }
-        }        
+        }
+
+        private void MigrateBootAndRename()
+        {
+            SafeHouse.Logger.Log("MigrateBootAndRename START");
+            string destDirectory = Path.Combine(SafeHouse.ArchiveFolder, "boot");
+            if (!Directory.Exists(destDirectory))
+                Directory.CreateDirectory(destDirectory);
+            string sourceDirectory = SafeHouse.ArchiveFolder;
+
+            var files = Directory.GetFiles(sourceDirectory, "boot*");
+            foreach (var fileName in files)
+            {
+                var fileInfo = new FileInfo(fileName);
+                string newFilename = fileInfo.Name;
+
+                if (!newFilename.Equals("boot.ks", StringComparison.OrdinalIgnoreCase))
+                {
+                    newFilename = newFilename.Substring(4);
+                    if (newFilename.StartsWith("_"))
+                    {
+                        newFilename = newFilename.Substring(1);
+                    }
+                }
+                newFilename = Path.Combine(destDirectory, newFilename);
+                if (backup)
+                    File.Copy(fileName, newFilename);
+                else
+                    File.Move(fileName, newFilename);
+            }
+        }
+
+        private void MigrateBootNoRename()
+        {
+            SafeHouse.Logger.Log("MigrateBootNoRename START");
+            string destDirectory = Path.Combine(SafeHouse.ArchiveFolder, "boot");
+            if (!Directory.Exists(destDirectory))
+                Directory.CreateDirectory(destDirectory);
+            string sourceDirectory = SafeHouse.ArchiveFolder;
+
+            var files = Directory.GetFiles(sourceDirectory, "boot*");
+            foreach (var fileName in files)
+            {
+                var fileInfo = new FileInfo(fileName);
+                string newFilename = Path.Combine(destDirectory, fileInfo.Name);
+                if (backup)
+                    File.Copy(fileName, newFilename);
+                else
+                    File.Move(fileName, newFilename);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #1678

Bootstrapper.cs
* Re-enabled the legacy script folder migration popup
* Add popup window for migrating boot scripts
* Options for migrating with the same names, or with stripping "boot"
* Default option to copy the files rather than move them

volumes.rst
* Document migration to the new boot directory and explain the only broken use case (boot files starting on the archive).