### PR TITLE
Fix PATH:COMBINE

### DIFF
--- a/src/kOS.Safe/Persistence/PathValue.cs
+++ b/src/kOS.Safe/Persistence/PathValue.cs
@@ -64,12 +64,20 @@ namespace kOS.Safe
             AddSuffix("ISPARENT", new OneArgsSuffix<BooleanValue, PathValue>((p) => Path.IsParent(p.Path)));
             AddSuffix("CHANGENAME", new OneArgsSuffix<PathValue, StringValue>((n) => FromPath(Path.ChangeName(n))));
             AddSuffix("CHANGEEXTENSION", new OneArgsSuffix<PathValue, StringValue>((e) => FromPath(Path.ChangeExtension(e))));
-            AddSuffix("COMBINE", new VarArgsSuffix<PathValue, StringValue>(Combine));
+            AddSuffix("COMBINE", new VarArgsSuffix<PathValue, Structure>(Combine));
+        }
+        public PathValue Combine(params Structure[] segments)
+        {
+            if (segments.All(s => s.GetType() == typeof(StringValue)))
+            {
+                return Combine(segments.Cast<StringValue>().ToArray());
+            }
+            throw new Exceptions.KOSInvalidArgumentException("PATH:COMBINE", "SEGMENTS", "all segments must be strings");
         }
 
         public PathValue Combine(params StringValue[] segments)
         {
-            return FromPath(Path.Combine(segments.Cast<string>().ToArray()));
+            return FromPath(Path.Combine(segments.Select(s => s.ToString()).ToArray()));
         }
 
         public override Dump Dump()


### PR DESCRIPTION
PathValue.cs
* Switch suffix to use variable `Structure` arguments
* New `Structure` argument method that converts to `StringValue`s
* New method also checks to make sure all values are `StringValue`
* Fix issue with casting `StringValue` to `string`