### PR TITLE
Fix abstract inheritance

### DIFF
--- a/src/kOS.Safe/Utilities/AssemblyWalkAttribute.cs
+++ b/src/kOS.Safe/Utilities/AssemblyWalkAttribute.cs
@@ -252,7 +252,7 @@ namespace kOS.Safe.Utilities
                                     }
                                     else if (walkAttribute.InherritedType != null)
                                     {
-                                        if (!type.IsAbstract && walkAttribute.InherritedType.IsAssignableFrom(type))
+                                        if (walkAttribute.InherritedType.IsAssignableFrom(type))
                                         {
                                             managerRegisterMethod.Invoke(null, new[] { attr, type });
                                             walkAttribute.LoadedCount++;
@@ -284,7 +284,7 @@ namespace kOS.Safe.Utilities
                             }
                             else if (walkAttribute.InherritedType != null)
                             {
-                                if (!type.IsAbstract && walkAttribute.InherritedType.IsAssignableFrom(type))
+                                if (walkAttribute.InherritedType.IsAssignableFrom(type))
                                 {
                                     managerRegisterMethod.Invoke(null, new[] { type });
                                     walkAttribute.LoadedCount++;


### PR DESCRIPTION
Fixes #1734

AssemblyWalkAttribute.cs
* Remove `Type.IsAbstract` restriction which prevented abstract structures from showing up in the inheritance tree of KOSNomenclature