### PR TITLE
Fixes #1745 by applying a built-in pathname to @LR.

### DIFF
--- a/src/kOS.Safe/Execution/InternalPath.cs
+++ b/src/kOS.Safe/Execution/InternalPath.cs
@@ -9,6 +9,11 @@ namespace kOS.Safe.Execution
         {
 
         }
+        
+        public InternalPath(string volumeId) : base(volumeId)
+        {
+
+        }
 
         public abstract string Line(int line);
     }

--- a/src/kOS/KSPLogger.cs
+++ b/src/kOS/KSPLogger.cs
@@ -113,13 +113,11 @@ namespace kOS
                     // as the logic to check if the program needs compiling is implemented as a
                     // separate kRISC function that gets called from the main code.  Therefore to
                     // avoid the same RUN statement giving two nested levels on the call trace,
-                    // only print the firstmost instance of a contiguous part of the call stack that
-                    // comes from the same source line:
+                    // skip the level of the stack trace that passes through the boilerplate
+                    // load runner code:
                     if (index > 0)
                     {
-                        Opcode prevOpcode = Shared.Cpu.GetOpcodeAt(trace[index-1]);
-                        if (prevOpcode.SourcePath.Equals(thisOpcode.SourcePath) &&
-                            prevOpcode.SourceLine == thisOpcode.SourceLine)
+                        if (thisOpcode.SourcePath == null || thisOpcode.SourcePath.VolumeId.Equals(ProgramBuilder.BuiltInFakeVolumeId))
                         {
                             continue;
                         }
@@ -187,9 +185,11 @@ namespace kOS
 
             Volume vol;
 
-            try {
+            try
+            {
                 vol = Shared.VolumeMgr.GetVolumeFromPath(path);
-            } catch (KOSPersistenceException)
+            }
+            catch (KOSPersistenceException)
             {
                 return returnVal;
             }


### PR DESCRIPTION
In addition to fixing the problem, the stack trace will now no longer be blank for the filename of the loadrunner boilerplate.

Here's the way the error message looks now:

![screenshot19](https://cloud.githubusercontent.com/assets/5216848/17005607/d1acae42-4ea0-11e6-9a30-77d266ee0360.png)

Now the stack trace looks like this:
```
System.Exception: Tried to push Infinity into the stack.
  at kOS.Safe.Execution.Stack.ThrowIfInvalid (System.Object item) [0x00000] in <filename unknown>:0
  at kOS.Safe.Execution.Stack.Push (System.Object item) [0x00000] in <filename unknown>:0
  at kOS.Safe.Execution.CPU.PushStack (System.Object item) [0x00000] in <filename unknown>:0
  at kOS.Safe.Compilation.BinaryOpcode.Execute (ICpu cpu) [0x00000] in <filename unknown>:0
  at kOS.Safe.Execution.CPU.ExecuteInstruction (IProgramContext context, Boolean doProfiling) [0x00000] in <filename unknown>:0

(Filename: C:/buildslave/unity/build/artifacts/generated/common/runtime/UnityEngineDebugBindings.gen.cpp Line: 64)

Code Fragment
File                 Line:Col IP   label   opcode operand
====                 ====:=== ==== ================================
                        0:0   0000         jump +27
[built-in]              0:0   0001 @LR00   pushscope -999 0
[built-in]              0:0   0002 @LR01   push $runonce
[built-in]              0:0   0003 @LR02   swap
[built-in]              0:0   0004 @LR03   storelocal
[built-in]              0:0   0005 @LR04   push $filename
[built-in]              0:0   0006 @LR05   swap
[built-in]              0:0   0007 @LR06   storelocal
[built-in]              0:0   0008 @LR07   push _KOSArgMarker_
[built-in]              0:0   0009 @LR08   push $filename
[built-in]              0:0   0010 @LR09   eval
[built-in]              0:0   0011 @LR10   push True
[built-in]              0:0   0012 @LR11   push null
[built-in]              0:0   0013 @LR12   call load()
[built-in]              0:0   0014 @LR13   br.false +6
[built-in]              0:0   0015 @LR14   push $runonce
[built-in]              0:0   0016 @LR15   br.false +4
[built-in]              0:0   0017 @LR16   pop
[built-in]              0:0   0018 @LR17   push 0
[built-in]              0:0   0019 @LR18   return 1 deep
[built-in]              0:0   0020 @LR19   push $entrypoint
[built-in]              0:0   0021 @LR20   swap
[built-in]              0:0   0022 @LR21   storelocal
[built-in]              0:0   0023 @LR22   call $entrypoint
[built-in]              0:0   0024 @LR23   pop
[built-in]              0:0   0025 @LR24   push 0
[built-in]              0:0   0026 @LR25   return 1 deep
[Boot sequence]         1:1   0027 @0001   push _KOSArgMarker_
[Boot sequence]         1:1   0028 @0002   push _KOSArgMarker_
[Boot sequence]         1:1   0029 @0003   push False
[Boot sequence]         1:5   0030 @0004   push /boot/test.ks
[Boot sequence]         1:5   0031 @0005   eval
[Boot sequence]         1:5   0032 @0006   call 1
[Boot sequence]         1:5   0033 @0007   pop
                        0:0   0034         pop
                        0:0   0035         EOP
1:/boot/test.ks         1:1   0036 @0008   argbottom
1:/boot/test.ks         1:1   0037 @0009   push $core
1:/boot/test.ks         1:6   0038 @0010   push doevent
1:/boot/test.ks         1:6   0039 @0011   getmethod
1:/boot/test.ks         1:13  0040 @0012   push _KOSArgMarker_
1:/boot/test.ks         1:14  0041 @0013   push Open Terminal
1:/boot/test.ks         1:14  0042 @0014   call <indirect>
1:/boot/test.ks         1:14  0043 @0015   pop
1:/boot/test.ks         2:6   0044 @0016   push 0
1:/boot/test.ks         2:6   0045 @0017   wait
1:/boot/test.ks         3:1   0046 @0018   push _KOSArgMarker_
1:/boot/test.ks         3:1   0047 @0019   call clearscreen()
1:/boot/test.ks         3:1   0048 @0020   pop
1:/boot/test.ks         4:5   0049 @0021   push $x
1:/boot/test.ks         4:10  0050 @0022   push 1
1:/boot/test.ks         4:12  0051 @0023   push 0
1:/boot/test.ks         4:11  0052 @0024   div <<--INSTRUCTION POINTER--
1:/boot/test.ks         4:11  0053 @0025   store
                        0:0   0054         push 0
                        0:0   0055         return 0 deep
```
Fixes #1745 