### PR TITLE
Issue 1752 steering issues again

### DIFF
--- a/src/kOS/Control/SteeringManager.cs
+++ b/src/kOS/Control/SteeringManager.cs
@@ -529,7 +529,9 @@ namespace kOS.Control
                 angularAcceleration = new Vector3d(angularAcceleration.x, angularAcceleration.z, angularAcceleration.y);
             }
             
-            momentOfInertia = shared.Vessel.MOI;
+            // TODO: This is a temporary fix for the Moment of Inertial  This can be removed after the next KSP release.
+            //momentOfInertia = shared.Vessel.MOI;
+            momentOfInertia = FindMoI();
             adjustTorque = Vector3d.zero;
             measuredTorque = Vector3d.Scale(momentOfInertia, angularAcceleration);
 
@@ -605,6 +607,61 @@ namespace kOS.Control
             if (controlTorque.y < minTorque) controlTorque.y = minTorque;
             if (controlTorque.z < minTorque) controlTorque.z = minTorque;
         }
+
+        #region TEMPORARY MOI CALCULATION
+        // TODO: This is a temporary fix for the Moment of Inertial  This can be removed after the next KSP release.
+        public Vector3 FindMoI()
+        {
+            var tensor = Matrix4x4.zero;
+            Matrix4x4 partTensor = Matrix4x4.identity;
+            Matrix4x4 inertiaMatrix = Matrix4x4.identity;
+            Matrix4x4 productMatrix = Matrix4x4.identity;
+            foreach (var part in Vessel.Parts)
+            {
+                if (part.rb != null)
+                {
+                    KSPUtil.ToDiagonalMatrix2(part.rb.inertiaTensor, ref partTensor);
+
+                    Quaternion rot = Quaternion.Inverse(vesselRotation) * part.transform.rotation * part.rb.inertiaTensorRotation;
+                    Quaternion inv = Quaternion.Inverse(rot);
+
+                    Matrix4x4 rotMatrix = Matrix4x4.TRS(Vector3.zero, rot, Vector3.one);
+                    Matrix4x4 invMatrix = Matrix4x4.TRS(Vector3.zero, inv, Vector3.one);
+
+                    // add the part inertiaTensor to the ship inertiaTensor
+                    KSPUtil.Add(ref tensor, rotMatrix * partTensor * invMatrix);
+
+                    Vector3 position = vesselTransform.InverseTransformDirection(part.rb.position - centerOfMass);
+
+                    // add the part mass to the ship inertiaTensor
+                    KSPUtil.ToDiagonalMatrix2(part.rb.mass * position.sqrMagnitude, ref inertiaMatrix);
+                    KSPUtil.Add(ref tensor, inertiaMatrix);
+
+                    // add the part distance offset to the ship inertiaTensor
+                    OuterProduct2(position, -part.rb.mass * position, ref productMatrix);
+                    KSPUtil.Add(ref tensor, productMatrix);
+                }
+            }
+            return KSPUtil.Diag(tensor);
+        }
+
+        /// <summary>
+        /// Construct the outer product of two 3-vectors as a 4x4 matrix
+        /// DOES NOT ZERO ANY THINGS WOT ARE ZERO OR IDENTITY INNIT
+        /// </summary>
+        public static void OuterProduct2(Vector3 left, Vector3 right, ref Matrix4x4 m)
+        {
+            m.m00 = left.x * right.x;
+            m.m01 = left.x * right.y;
+            m.m02 = left.x * right.z;
+            m.m10 = left.y * right.x;
+            m.m11 = left.y * right.y;
+            m.m12 = left.y * right.z;
+            m.m20 = left.z * right.x;
+            m.m21 = left.z * right.y;
+            m.m22 = left.z * right.z;
+        }
+        #endregion
 
         public Transform FindParentTransform(Transform transform, string name, Transform topLevel)
         {

--- a/src/kOS/Control/SteeringManager.cs
+++ b/src/kOS/Control/SteeringManager.cs
@@ -204,7 +204,7 @@ namespace kOS.Control
         private Vector3d omega = Vector3d.zero; // x: pitch, y: yaw, z: roll
         private Vector3d lastOmega = Vector3d.zero;
         private Vector3d angularAcceleration = Vector3d.zero;
-        private Vector3d momentOfInertia = Vector3d.zero; // x: pitch, y: yaw, z: roll
+        private Vector3d momentOfInertia = Vector3d.zero; // x: pitch, z: yaw, y: roll
         private Vector3d measuredMomentOfInertia = Vector3d.zero;
         private Vector3d measuredTorque = Vector3d.zero;
         private Vector3d controlTorque = Vector3d.zero; // x: pitch, z: yaw, y: roll
@@ -606,6 +606,14 @@ namespace kOS.Control
             if (controlTorque.z < minTorque) controlTorque.z = minTorque;
         }
 
+        public Transform FindParentTransform(Transform transform, string name, Transform topLevel)
+        {
+            if (transform.parent.name == name) return transform.parent;
+            else if (transform.parent == null) return null;
+            else if (transform.parent == topLevel) return null;
+            else return FindParentTransform(transform.parent, name, topLevel);
+        }
+
         // Update prediction based on PI controls, sets the target angular velocity and the target torque for the vessel
         public void UpdatePredictionPI()
         {
@@ -625,8 +633,8 @@ namespace kOS.Control
 
             // Calculate the maximum allowable angular velocity and apply the limit, something we can stop in a reasonable amount of time
             maxPitchOmega = controlTorque.x * MaxStoppingTime / momentOfInertia.x;
-            maxYawOmega = controlTorque.z * MaxStoppingTime / momentOfInertia.y;
-            maxRollOmega = controlTorque.y * MaxStoppingTime / momentOfInertia.z;
+            maxYawOmega = controlTorque.z * MaxStoppingTime / momentOfInertia.z;
+            maxRollOmega = controlTorque.y * MaxStoppingTime / momentOfInertia.y;
 
             double sampletime = shared.UpdateHandler.CurrentFixedTime;
             // Because the value of phi is already error, we say the input is -error and the setpoint is 0 so the PID has the correct sign
@@ -644,8 +652,8 @@ namespace kOS.Control
 
             // Calculate target torque based on PID
             tgtPitchTorque = pitchPI.Update(sampletime, omega.x, tgtPitchOmega, momentOfInertia.x, controlTorque.x);
-            tgtYawTorque = yawPI.Update(sampletime, omega.y, tgtYawOmega, momentOfInertia.y, controlTorque.z);
-            tgtRollTorque = rollPI.Update(sampletime, omega.z, tgtRollOmega, momentOfInertia.z, controlTorque.y);
+            tgtYawTorque = yawPI.Update(sampletime, omega.y, tgtYawOmega, momentOfInertia.z, controlTorque.z);
+            tgtRollTorque = rollPI.Update(sampletime, omega.z, tgtRollOmega, momentOfInertia.y, controlTorque.y);
 
             //tgtPitchTorque = pitchPI.Update(sampletime, pitchRate.Update(omega.x), tgtPitchOmega, momentOfInertia.x, controlTorque.x);
             //tgtYawTorque = yawPI.Update(sampletime, yawRate.Update(omega.y), tgtYawOmega, momentOfInertia.z, controlTorque.z);
@@ -932,7 +940,7 @@ namespace kOS.Control
             shared.Screen.Print("    Yaw Values:");
             shared.Screen.Print(string.Format("phiYaw: {0}", phiYaw * RadToDeg));
             //shared.Screen.Print(string.Format("phiYaw: {0}", deltaRotation.eulerAngles.y));
-            shared.Screen.Print(string.Format("I yaw: {0}", momentOfInertia.y));
+            shared.Screen.Print(string.Format("I yaw: {0}", momentOfInertia.z));
             shared.Screen.Print(string.Format("torque yaw: {0}", controlTorque.z));
             shared.Screen.Print(string.Format("maxYawOmega: {0}", maxYawOmega));
             shared.Screen.Print(string.Format("tgtYawOmega: {0}", tgtYawOmega));
@@ -942,7 +950,7 @@ namespace kOS.Control
             shared.Screen.Print("    Roll Values:");
             shared.Screen.Print(string.Format("phiRoll: {0}", phiRoll * RadToDeg));
             //shared.Screen.Print(string.Format("phiRoll: {0}", deltaRotation.eulerAngles.z));
-            shared.Screen.Print(string.Format("I roll: {0}", momentOfInertia.z));
+            shared.Screen.Print(string.Format("I roll: {0}", momentOfInertia.y));
             shared.Screen.Print(string.Format("torque roll: {0}", controlTorque.y));
             shared.Screen.Print(string.Format("maxRollOmega: {0}", maxRollOmega));
             shared.Screen.Print(string.Format("tgtRollOmega: {0}", tgtRollOmega));


### PR DESCRIPTION
Fixes #1752

Rather than figure out exactly what's wrong with the stock Moment of Inertia calculation, I just reverted us back to our old calculation which appears to behave much better in my testing tonight.

Using this pull request, a normal straight facing reference frame should result in the exact same Moment of Inertia as what stock shows.  But when you use "control from" it differs from stock (in a good way, since the stock value seems to be messed up.

My best test case was to take a long and slender-ish rocket, and stick docking ports out the side.  Using the natural up reference frame the stock and kOS calculations matched.  But when controlling from the side mounted docking port, stock was reporting that the roll direction still had a very low moment of inertia (which should have essentially been swapped with the yaw direction).  Using the kOS calculation this appears to perform correctly.

**This should be tested with as many ships/applications as possible, by as many users as possible, to confirm I got it right this time**