### PR TITLE
Fixes #1764 with an axes swap for sun's velocity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 kOS Mod Changelog
 =================
 
+# v1.0.0 (for KSP 1.1.3) Hey let's stop calling it Beta.
+
+### BREAKING CHANGES
+
+// MERGE CONFLICT EXPECTED HERE
+// ============================
+// NOTE TO WHOMEVER MERGES THIS!  I fully expect this will
+// cause a merge conflict with the other PR that edits the
+// changelog.  When you see the conflict, just append the following
+// bullet point to the rest of the list of breaking changes, and
+// remove this comment entirely.
+
+* Previously the Y and Z axes of SUN:VELOCITY:ORBIT were swapped.
+  (https://github.com/KSP-KOS/KOS/issues/1764)
+  This has been fixed so it is now the same as for any other body,
+  however scripts might exist that had previously been swapping them
+  back to compensate for this, and if there were they would now break
+  since that swapping is no longer needed.
+
+
 # v0.20.1 KSP 1.1.2 and bug repair
 
 The biggest reason for this release is to handle two game-breaking

--- a/doc/source/structures/orbits/orbitablevelocity.rst
+++ b/doc/source/structures/orbits/orbitablevelocity.rst
@@ -32,6 +32,16 @@ When any :struct:`Orbitable` object returns its :attr:`VELOCITY <Orbitable:VELOC
 
     Returns the surface-frame velocity. Note that this is the surface velocity relative to the surface of the SOI body, not the orbiting object itself. (i.e. Mun:VELOCITY:SURFACE returns the Mun's velocity relative to the surface of its SOI body, Kerbin).
 
+    **Special case instance, the Sun:**: Because the Sun has no parent
+    SoI body that it orbits around (Kerbal Space Program does not
+    simulate the existence of anything outside the one solar system),
+    that means that the Sun's surface velocity is just hardcoded to
+    be the same thing as its orbital velocity.  This may or may not be
+    entirely correct, but the "correct" answer to the question, "What is
+    sun:velocity:surface?" would technically be "I refuse to answer.
+    That's an invalid question." Rather than crash or throw an exception,
+    kOS just returns the same as the orbital velocity in this case.
+
 Examples::
 
     SET VORB TO SHIP:VELOCITY:ORBIT

--- a/src/kOS/Suffixed/BodyTarget.cs
+++ b/src/kOS/Suffixed/BodyTarget.cs
@@ -51,7 +51,9 @@ namespace kOS.Suffixed
                     futureOrbitalVel = soiBody.orbit.GetFrameVelAtUT(timeStamp.ToUnixStyleTime());
                 else
                     futureOrbitalVel = -1 * new VesselTarget(Shared.Vessel, Shared).GetVelocitiesAtUT(timeStamp).Orbital.ToVector3D();
-                return new OrbitableVelocity(new Vector(futureOrbitalVel), new Vector(0.0, 0.0, 0.0));
+                Vector swappedVel = new Vector(futureOrbitalVel.x, futureOrbitalVel.z, futureOrbitalVel.y); // swap Y and Z because KSP API is weird.
+                 // Also invert directions because the above gives vel of my body rel to sun, and I want vel of sun rel to my body:
+                return new OrbitableVelocity( -swappedVel, -swappedVel);
             }
 
             var orbVel = new Vector(Orbit.getOrbitalVelocityAtUT(timeStamp.ToUnixStyleTime()));

--- a/src/kOS/Suffixed/OrbitableVelocity.cs
+++ b/src/kOS/Suffixed/OrbitableVelocity.cs
@@ -35,7 +35,7 @@ namespace kOS.Suffixed
             CelestialBody parent = b.KOSExtensionGetParentBody();
             Surface = (parent != null) ?
                 new Vector(b.orbit.GetVel() - parent.getRFrmVel(b.position)) :
-                new Vector(Vector3d.zero);
+                new Vector(Orbital); // return same velocity as orbit when no parent body to compare against.
             InitializeSuffixes();
         }
 

--- a/src/kOS/Utilities/Utils.cs
+++ b/src/kOS/Utilities/Utils.cs
@@ -246,10 +246,16 @@ namespace kOS.Utilities
             // When we can't use body.orbit, then manually perform the work that (probably) body.orbit.GetVel()
             // is doing itself.  This isn't DRY, but SQUAD made it impossible to be DRY when they didn't implement
             // the algorithm for the Sun so we have to repeat it again ourselves:
-            
+
+            // If we assume this happens when the body is the sun, then the sun's body is the
+            // reference frame of the SOI's rotation            
             CelestialBody soiBody = shared.Vessel.mainBody;
             if (soiBody.orbit != null)
-                return soiBody.orbit.GetFrameVel();
+            {
+                Vector3d wonkyAxesVel = soiBody.orbit.GetFrameVel();
+                Vector3d correctedVel = new Vector3d(wonkyAxesVel.x, wonkyAxesVel.z, wonkyAxesVel.y); // have to swap axes because KSP API is weird.
+                return -correctedVel; // invert direction because the above gives vel of my body rel to sun, and I want vel of sun rel to my body.
+            }
             return (-1)*shared.Vessel.obt_velocity;
         }
 


### PR DESCRIPTION
I also noticed what people are talking about with
velocityat() being totally messed up.
Hypothetically velocityat(whatever,time:seconds) should
be the same as whatever:velocity:orbit, with a small error
due to it using the prediction algorithm.  But in reality
they're totally different from each other.  Not just a small
error, but a huge one. with the vector aimed off
by a good 70 degrees or so.

But that's another issue for another time - not part of
this issue.