### PR TITLE
fix for #1771 Added a Floor

### DIFF
--- a/src/kOS/Suffixed/Timespan.cs
+++ b/src/kOS/Suffixed/Timespan.cs
@@ -46,7 +46,7 @@ namespace kOS.Suffixed
             AddSuffix("MINUTE", new Suffix<ScalarValue>(CalculateMinute));
             AddSuffix("SECOND", new Suffix<ScalarValue>(CalculateSecond));
             AddSuffix("SECONDS", new Suffix<ScalarValue>(() => span));
-            AddSuffix("CLOCK", new Suffix<StringValue>(() => string.Format("{0:00}:{1:00}:{2:00}", CalculateHour(), CalculateMinute(), CalculateSecond())));
+            AddSuffix("CLOCK", new Suffix<StringValue>(() => string.Format("{0:00}:{1:00}:{2:00}", (int)CalculateHour(), (int)CalculateMinute(), (int)CalculateSecond())));
             AddSuffix("CALENDAR", new Suffix<StringValue>(() => "Year " + CalculateYear() + ", day " + CalculateDay()));
         }
 

--- a/src/kOS/Suffixed/Timespan.cs
+++ b/src/kOS/Suffixed/Timespan.cs
@@ -80,7 +80,7 @@ namespace kOS.Suffixed
 
         private ScalarValue CalculateSecond()
         {
-            return span%SECONDS_IN_MINUTE;
+            return (int)Math.Floor(span % SECONDS_IN_MINUTE);
         }
 
         public double ToUnixStyleTime()


### PR DESCRIPTION
Added a Floor so that the seconds are displayed without decimals.

There is one thing i couldn't fix
if the time is say: 01:01:01 then it's printed as 1:1:1. maybe someone else could have a look at it?

Fixes #1771