### PR TITLE
Fixes #1565 - moved the "invalid target" logic.

### DIFF
--- a/src/kOS.Safe/Exceptions/KOSInvalidTargetException.cs
+++ b/src/kOS.Safe/Exceptions/KOSInvalidTargetException.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace kOS.Safe.Exceptions
+{
+    /// <summary>
+    /// Description of KOSInvalidTargetException.
+    /// </summary>
+    public class KOSInvalidTargetException : KOSException
+    {
+        public KOSInvalidTargetException(string msg) : base(msg)
+        {
+        }
+    }
+}

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Compilation\CompiledObject.cs" />
     <Compile Include="Compilation\CompilerOptions.cs" />
     <Compile Include="Exceptions\KOSAtmosphereObsoletionException.cs" />
+    <Compile Include="Exceptions\KOSInvalidTargetException.cs" />
     <Compile Include="Exceptions\KOSObsoletionException.cs" />
     <Compile Include="Exceptions\KOSPatchesObsoletionException.cs" />
     <Compile Include="Exceptions\KOSVolumeOutOfRangeException.cs" />

--- a/src/kOS/Binding/MissionSettings.cs
+++ b/src/kOS/Binding/MissionSettings.cs
@@ -22,7 +22,7 @@ namespace kOS.Binding
                 var targetable = val as IKOSTargetable;
                 if (targetable != null)
                 {
-                    VesselUtils.SetTarget(targetable);
+                    VesselUtils.SetTarget(targetable, shared.Vessel);
                     return;
                 }
 
@@ -31,14 +31,14 @@ namespace kOS.Binding
                     var body = VesselUtils.GetBodyByName(val.ToString());
                     if (body != null)
                     {
-                        VesselUtils.SetTarget(body);
+                        VesselUtils.SetTarget(body, shared.Vessel);
                         return;
                     }
 
                     var vessel = VesselUtils.GetVesselByName(val.ToString(), shared.Vessel);
                     if (vessel != null)
                     {
-                        VesselUtils.SetTarget(vessel);
+                        VesselUtils.SetTarget(vessel, shared.Vessel);
                         return;
                     }
                 }

--- a/src/kOS/Utilities/VesselUtils.cs
+++ b/src/kOS/Utilities/VesselUtils.cs
@@ -125,7 +125,7 @@ namespace kOS.Utilities
 
         private static Vessel TryGetVesselByName(string name, Vessel origin)
         {
-            return FlightGlobals.Vessels.FirstOrDefault(v => v != origin && v.vesselName.ToUpper() == name.ToUpper());
+            return FlightGlobals.Vessels.FirstOrDefault(v => v.vesselName.ToUpper() == name.ToUpper());
         }
 
         public static CelestialBody GetBodyByName(string name)
@@ -144,11 +144,11 @@ namespace kOS.Utilities
             return vessel;
         }
 
-        public static void SetTarget(IKOSTargetable val)
+        public static void SetTarget(IKOSTargetable val, Vessel currentVessel)
         {
             if (val.Target != null)
             {
-                SetTarget(val.Target);
+                SetTarget(val.Target, currentVessel);
             }
             else
             {
@@ -156,8 +156,13 @@ namespace kOS.Utilities
             }
         }
 
-        public static void SetTarget(ITargetable val)
+        public static void SetTarget(ITargetable val, Vessel currentVessel)
         {
+            if (val is Vessel && val == currentVessel)
+                throw new kOS.Safe.Exceptions.KOSInvalidTargetException("A ship cannot set TARGET to itself.");
+            else if (val is ITargetable && ((ITargetable)val).GetVessel() == currentVessel)
+                throw new kOS.Safe.Exceptions.KOSInvalidTargetException("A ship cannot set TARGET to a part of itself.");
+            
             FlightGlobals.fetch.SetVesselTarget(val);
         }
 


### PR DESCRIPTION
The problem was caused by having the "invalid target" logic at too "deep" a level of the code, such that not only was it preventing you from selecting your own ship as a your target, but it was also preventing you from EVER using your own ship in the Vessel() constructor at all.

I had to move the logic that prevents invalid targets a bit higher up, getting it out of the low level constructor so it's possible to construct a Vessel() of your own ship.