### PR TITLE
Enable yielding in opcodes and functions

### DIFF
--- a/doc/source/structures/vessels/stage.rst
+++ b/doc/source/structures/vessels/stage.rst
@@ -5,44 +5,74 @@ Stage
 
 *Contents*
 
-    - :global:`EXAMPLE`
-    - :struct:`Stage`
+    - :ref:`Staging Example <stagingExample>`
+    - :ref:`Staging Function <StageFunction>`
+    - :ref:`Staging Structure <stageStructure>`
 
-You access the current stage for the vessel the kOS core is attached to with the STAGE: command.
+.. _StagingExample:
 
-.. global::EXAMPLE	
-	
-	
-    A very simple auto-stager using :READY
-	
-	LIST ENGINES IN elist.
+Staging Example
+---------------
 
-	UNTIL false {
-	    PRINT "Stage: " + STAGE:NUMBER AT (0,0).
-		FOR e IN elist {
-			IF e:FLAMEOUT {
-				STAGE.
-				PRINT "STAGING!" AT (0,0).
-				
-				UNTIL STAGE:READY {	} 
-				
-				LIST ENGINES IN elist.
-				CLEARSCREEN.
-				BREAK.    
-			}
-		}
-	}
 
-.. global::NUMBER
+    A very simple auto-stager using :attr:`:READY <stage:ready>`
+    ::
 
-	Every craft has a current stage, and that stage is represented by a number, this is it!
-	
-.. global::RESOURCES
-    
-	
-	
-Structure
----------
+        LIST ENGINES IN elist.
+
+        UNTIL false {
+            PRINT "Stage: " + STAGE:NUMBER AT (0,0).
+            FOR e IN elist {
+                IF e:FLAMEOUT {
+                    STAGE.
+                    PRINT "STAGING!" AT (0,0).
+
+                    UNTIL STAGE:READY {
+                        WAIT 0.
+                    }
+
+                    LIST ENGINES IN elist.
+                    CLEARSCREEN.
+                    BREAK.
+                }
+            }
+        }
+
+.. _StageFunction:
+
+Stage Function
+--------------
+
+.. global:: Stage
+
+    :return: None
+
+    Activates the next stage if the cpu vessel is the active vessel.  This will
+    trigger engines, decouplers, and any other parts that would normally be
+    triggered by manually staging.  The default equivalent key binding is the
+    space bar.  As with other parameter-less functions, both ``STAGE.`` and
+    ``STAGE().`` are acceptable ways to call the function.
+
+    .. note::
+        .. versionchanged:: 1.0.1
+
+            The stage function will automatically pause execution until the next
+            tick.  This is because some of the results of the staging event take
+            effect immediately, while others do not update until the next time
+            that physics are calculated.  Calling ``STAGE.`` is essentially
+            equivalent to::
+
+                STAGE.
+                WAIT 0.
+
+    .. warning::
+        Calling the :global:`Stage` function on a vessel other than the active
+        vessel will throw an exception.
+
+.. _StageStructure:
+
+Stage Structure
+---------------
 
 .. structure:: Stage
 
@@ -56,11 +86,11 @@ Structure
           - Description
 
         * - :attr:`READY`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Get only
           - Is the craft ready to activate the next stage.
         * - :attr:`NUMBER`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Get only
           - The current stage number for the craft
         * - :attr:`RESOURCES`
@@ -75,15 +105,15 @@ Structure
 .. attribute:: Stage:READY
 
     :access: Get only
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
 
-	Kerbal Space Program enforces a small delay between staging commands, this is to allow the last staging command to complete. This bool value will let you know if kOS can activate the next stage.
+    Kerbal Space Program enforces a small delay between staging commands, this is to allow the last staging command to complete. This bool value will let you know if kOS can activate the next stage.
 
 .. attribute:: Stage:NUMBER
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
-	
+    :type: :struct:`Scalar`
+
     Every craft has a current stage, and that stage is represented by a number, this is it!
 
 .. attribute:: Stage:Resources

--- a/kerboscript_tests/triggers/testtrigger5.ks
+++ b/kerboscript_tests/triggers/testtrigger5.ks
@@ -1,0 +1,30 @@
+print "YOU SHOULD SEE THE MESSAGES".
+print "IN THE RIGHT ORDER AND TIMING:".
+print "These are a complex set of triggers with waits.".
+print "that should print the messages in order despite".
+print "them being from different triggers and main code.".
+print " ".
+
+set start_time to time:seconds.
+
+function timestamp_msg {
+  parameter msg.
+  print round(time:seconds - start_time, 2) + ": " + msg. 
+}
+
+set rightaway to true.
+when rightaway then {
+  timestamp_msg("msg02: Should be after one 'tick'.").
+  wait 3.
+  timestamp_msg("msg03: Should be after 3s+1tick.").  
+}
+set twosecondslater to time:seconds+2.
+when time:seconds > twosecondslater then {
+  timestamp_msg("msg04: Despite trigger call getting put on stack at 2s, it won't start until the other trigger's wait is over, so this should be after 3s.").
+  wait 2.
+  timestamp_msg("msg05: Should be after 5s.").
+}
+
+timestamp_msg("msg01: Program starting.").
+wait 6.
+timestamp_msg("msg06: Program ending after 6s."). 

--- a/src/kOS.Safe.Test/Opcode/FakeCpu.cs
+++ b/src/kOS.Safe.Test/Opcode/FakeCpu.cs
@@ -179,16 +179,6 @@ namespace kOS.Safe.Test.Opcode
             throw new NotImplementedException();
         }
 
-        public double StartWait(double waitTime)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void EndWait()
-        {
-            throw new NotImplementedException();
-        }
-
         public void CallBuiltinFunction(string functionName)
         {
             throw new NotImplementedException();
@@ -197,6 +187,11 @@ namespace kOS.Safe.Test.Opcode
         public bool BuiltInExists(string functionName)
         {
             throw new NotImplementedException();
+        }
+        
+        public void YieldProgram(YieldFinishedDetector yieldTracker)
+        {
+            throw new NotImplementedException();            
         }
 
         public void BreakExecution(bool manual)

--- a/src/kOS.Safe/Execution/CPU.cs
+++ b/src/kOS.Safe/Execution/CPU.cs
@@ -1258,7 +1258,10 @@ namespace kOS.Safe.Execution
                 opcode.AbortContext = false;
                 opcode.AbortProgram = false;
 
-                opcode.Execute(this);
+                if (opcode.IsYielding)
+                    opcode.CheckYield(this);
+                else
+                    opcode.Execute(this);
 
                 if (doProfiling)
                 {

--- a/src/kOS.Safe/Execution/CPU.cs
+++ b/src/kOS.Safe/Execution/CPU.cs
@@ -15,15 +15,18 @@ namespace kOS.Safe.Execution
 {
     public class CPU : ICpu
     {
-        private enum Status
+        private enum Section
         {
-            Running = 1,
-            Waiting = 2
+            Main = 1,
+            Trigger = 2
         }
 
         private readonly IStack stack;
         private readonly VariableScope globalVariables;
-        private Status currentStatus;
+        private Section currentRunSection;
+        private List<YieldFinishedDetector> triggerYields;
+        private List<YieldFinishedDetector> mainYields;
+        
         private double currentTime;
         private readonly SafeSharedObjects shared;
         private readonly List<ProgramContext> contexts;
@@ -54,12 +57,6 @@ namespace kOS.Safe.Execution
             set { currentContext.InstructionPointer = value; }
         }
         
-        /// <summary>
-        /// Where was the instruction pointer at the time this update
-        /// first started?
-        /// </summary>
-        int firstInstructionPointerInUpdate;
-
         public double SessionTime { get { return currentTime; } }
         
         public List<string> ProfileResult { get; private set; }
@@ -71,6 +68,8 @@ namespace kOS.Safe.Execution
             stack = new Stack();
             globalVariables = new VariableScope(0, -1);
             contexts = new List<ProgramContext>();
+            mainYields = new List<YieldFinishedDetector>();
+            triggerYields = new List<YieldFinishedDetector>();
             if (this.shared.UpdateHandler != null) this.shared.UpdateHandler.AddFixedObserver(this);
         }
 
@@ -80,7 +79,7 @@ namespace kOS.Safe.Execution
             currentContext = null;
             contexts.Clear();
             PushInterpreterContext();
-            currentStatus = Status.Running;
+            currentRunSection = Section.Main;
             currentTime = 0;
             maxUpdateTime = 0.0;
             maxExecutionTime = 0.0;
@@ -237,6 +236,7 @@ namespace kOS.Safe.Execution
                 returnVal = PopStack();
                 --howMany;
             }
+
             return returnVal;
         }
 
@@ -376,7 +376,7 @@ namespace kOS.Safe.Execution
             SafeHouse.Logger.Log(string.Format("Breaking Execution {0} Contexts: {1}", manual ? "Manually" : "Automatically", contexts.Count));
             if (contexts.Count > 1)
             {
-                EndWait();
+                AbortAllYields();
 
                 if (SafeHouse.Config.ShowStatistics)
                     CalculateProfileResult();
@@ -409,6 +409,70 @@ namespace kOS.Safe.Execution
             }
         }
 
+        /// <summary>
+        /// Call when you want to suspend execution of the Opcodes until some
+        /// future condition becomes true.  The CPU will call yieldTracker.Begin()
+        /// right away, and then after that call yieldTracker.IsFinished() again and
+        /// again until it returns true.  Until IsFinished() returns true, the CPU
+        /// will not advance any further into the program in its current "mode".
+        /// Note that the CPU will track "trigger" and "mainline" code separately for
+        /// this purpose.  Waiting in mainline code will still allow triggers to run.
+        /// </summary>
+        /// <param name="yieldTracker"></param>
+        public void YieldProgram(YieldFinishedDetector yieldTracker)
+        {
+            switch (currentRunSection)
+            {
+                case Section.Main:
+                    mainYields.Add(yieldTracker);
+                    break;
+                case Section.Trigger:
+                    triggerYields.Add(yieldTracker);
+                    break;
+                default:
+                    // Should hypothetically be impossible unless we add more values to the enum.
+                    break;
+            }
+            yieldTracker.creationTimeStamp = currentTime;
+            yieldTracker.Begin(shared);
+        }
+
+        private bool IsYielding()
+        {
+            List<YieldFinishedDetector> yieldTrackers;
+            
+            // Decide if we should operate on the yield trackers that are
+            // at the main code level or the ones that are at the trigger
+            // level:
+            switch (currentRunSection)
+            {
+                case Section.Main:
+                    yieldTrackers = mainYields;
+                    break;
+                case Section.Trigger:
+                    yieldTrackers = triggerYields;
+                    break;
+                default:
+                    // Should hypothetically be impossible unless we add more values to the enum.
+                    return false;
+            }
+            // Query the yield trackers and remove all the ones that claim they are finished.
+            // Always treat them as unfinished if this is the same fixed time stamp as the
+            // one in which the yield got Begin()'ed regardless of what their IsFinished() claims,
+            // because all waits will always wait at least one tick, according to all our docs.
+            yieldTrackers.RemoveAll((t) => t.creationTimeStamp != currentTime && t.IsFinished());
+            
+            // If any are still present, that means not all yielders in this context (main or trigger)
+            // are finished and we should still return that we are waiting:
+            return yieldTrackers.Count > 0;
+        }
+        
+        private void AbortAllYields()
+        {
+            mainYields.Clear();
+            triggerYields.Clear();
+        }
+        
         public void PushStack(object item)
         {
             stack.Push(item);
@@ -1021,27 +1085,6 @@ namespace kOS.Safe.Execution
             currentContext.RemoveTrigger(triggerFunctionPointer);
         }
 
-        /// <summary>
-        /// Put the CPU into wait state for now, which will reset next Update.
-        /// Also, if given a number of seconds, return the number of seconds into
-        /// the future that is, in game-terms, for the sake of making a timestamp
-        /// of when the wait is expected to be over.
-        /// </summary>
-        /// <param name="waitTime"></param>
-        /// <returns></returns>
-        public double StartWait(double waitTime)
-        {
-            if (currentStatus == Status.Running)
-                currentStatus = Status.Waiting;
-            return currentTime + waitTime;
-        }
-
-        public void EndWait()
-        {
-            if (currentStatus == Status.Waiting)
-                currentStatus = Status.Running;
-        }
-
         public void KOSFixedUpdate(double deltaTime)
         {
             bool showStatistics = SafeHouse.Config.ShowStatistics;
@@ -1051,8 +1094,6 @@ namespace kOS.Safe.Execution
             instructionsPerUpdate = SafeHouse.Config.InstructionsPerUpdate;
             instructionsSoFarInUpdate = 0;
             var numMainlineInstructions = 0;
-
-            firstInstructionPointerInUpdate = InstructionPointer;
 
             if (showStatistics)
             {
@@ -1074,19 +1115,16 @@ namespace kOS.Safe.Execution
                 {
                     ProcessTriggers();
 
-                    if (currentStatus == Status.Running || currentStatus == Status.Waiting)
+                    if (showStatistics)
                     {
-                        if (showStatistics)
-                        {
-                            executionWatch.Start();
-                            instructionWatch.Start();
-                        }
-                        ContinueExecution(showStatistics);
-                        numMainlineInstructions = instructionsSoFarInUpdate;
-                        if (showStatistics)
-                        {
-                            executionWatch.Stop();
-                        }
+                        executionWatch.Start();
+                        instructionWatch.Start();
+                    }
+                    ContinueExecution(showStatistics);
+                    numMainlineInstructions = instructionsSoFarInUpdate;
+                    if (showStatistics)
+                    {
+                        executionWatch.Stop();
                     }
                 }
                 if (showStatistics)
@@ -1205,31 +1243,30 @@ namespace kOS.Safe.Execution
         {
             var executeNext = true;
             int howManyMainLine = 0;
-            bool reachedMainLine = false;
+            currentRunSection = Section.Trigger; // assume we begin with trigger mode until we hit mainline code.
+            
             executeLog.Remove(0, executeLog.Length); // In .net 2.0, StringBuilder had no Clear(), which is what this is simulating.
 
-            EndWait(); // Temporarily, perhaps. If the first thing it finds is the same OpcodeWait, it can revert back to wait mode.
-
-            while (currentStatus == Status.Running &&
-                   instructionsSoFarInUpdate < instructionsPerUpdate &&
+            while (instructionsSoFarInUpdate < instructionsPerUpdate &&
                    executeNext &&
                    currentContext != null)
             {
-                if (InstructionPointer == firstInstructionPointerInUpdate &&
-                    ! stack.HasTriggerContexts()) // This additional check is important.
-                                                 // Hypothetically it could be possible for trigger code to hit the same
-                                                 // IP as where mainline code was interrupted, if both trigger code and
-                                                 // mainline code make use of the same library function, and the
-                                                 // trigger interruption occurred when mainline code was in that
-                                                 // same library function.  This ensures that if so, that doesn't count.
-                                                 // It only counts when all the triggers have popped off the call stack.
+                if (! stack.HasTriggerContexts())
                 {
-                    reachedMainLine = true;
+                    currentRunSection = Section.Main;
                 }
-                executeNext = ExecuteInstruction(currentContext, doProfiling);
-                instructionsSoFarInUpdate++;
-                if (reachedMainLine)
-                  ++howManyMainLine;
+                
+                if (IsYielding())
+                {
+                    executeNext = false;
+                }
+                else
+                {
+                    executeNext = ExecuteInstruction(currentContext, doProfiling);
+                    instructionsSoFarInUpdate++;
+                    if (currentRunSection == Section.Main)
+                       ++howManyMainLine;
+                }
             }
 
             // As long as at least one line of actual main code was reached, then re-enable all
@@ -1237,7 +1274,7 @@ namespace kOS.Safe.Execution
             // ensures that a nested bunch of triggers interruping other triggers can't
             // *completely* starve mainline code of execution, no matter how invasive
             // and cpu-hogging the user may have been written them to be:
-            if (reachedMainLine)
+            if (currentRunSection == Section.Main)
                 currentContext.ActivatePendingTriggers();
 
             if (executeLog.Length > 0)
@@ -1247,7 +1284,7 @@ namespace kOS.Safe.Execution
         private bool ExecuteInstruction(IProgramContext context, bool doProfiling)
         {            
             Opcode opcode = context.Program[context.InstructionPointer];
-
+            
             if (SafeHouse.Config.DebugEachOpcode)
             {
                 executeLog.Append(string.Format("Executing Opcode {0:0000}/{1:0000} {2} {3}\n", context.InstructionPointer, context.Program.Count, opcode.Label, opcode));
@@ -1258,10 +1295,7 @@ namespace kOS.Safe.Execution
                 opcode.AbortContext = false;
                 opcode.AbortProgram = false;
 
-                if (opcode.IsYielding)
-                    opcode.CheckYield(this);
-                else
-                    opcode.Execute(this);
+                opcode.Execute(this);
 
                 if (doProfiling)
                 {

--- a/src/kOS.Safe/Execution/ICpu.cs
+++ b/src/kOS.Safe/Execution/ICpu.cs
@@ -37,11 +37,10 @@ namespace kOS.Safe.Execution
         List<string> ProfileResult { get; }
         void AddTrigger(int triggerFunctionPointer);
         void RemoveTrigger(int triggerFunctionPointer);
-        double StartWait(double waitTime);
-        void EndWait();
         void CallBuiltinFunction(string functionName);
         bool BuiltInExists(string functionName);
         void BreakExecution(bool manual);
+        void YieldProgram(YieldFinishedDetector yieldTracker);
         void AddVariable(Variable variable, string identifier, bool local, bool overwrite = false);
         Opcode GetCurrentOpcode();
         Opcode GetOpcodeAt(int instructionPtr);

--- a/src/kOS.Safe/Execution/YieldFinishedDetector.cs
+++ b/src/kOS.Safe/Execution/YieldFinishedDetector.cs
@@ -1,0 +1,57 @@
+﻿using System;
+
+namespace kOS.Safe.Execution
+{
+    /// <summary>
+    /// When telling kOS's CPU that it should yield, using the CPU.YieldProgram() method,
+    /// you make a new instance of a derivative of this class to manage the decision of
+    /// when it should resume again.  kOS's CPU will repeatedly re-check the instance of
+    /// this class whenever it wants to execute Opcodes, and only when this class says
+    /// so will it resume execution of the Opcodes.<br/>
+    /// <br/>
+    /// When you make a new instance of this class you should immediately "forget" it
+    /// after it is passed to YieldProgram() (i.e. don't hold a reference to it.)  If you
+    /// call YieldProgram() again, it should always be a with a new instance of this class.<br/>
+    /// <br/>
+    /// When you inherit from this class, you should store any data values that are part of
+    /// the decision "am I done waiting" as members of this class, such that each new instance
+    /// gets its own set of such fields and all instances can decide "am I done" indepentantly
+    /// of each other.<br/>
+    /// <br/>
+    /// The reason all the above instructions are relevant is that they allow the same Opcode,
+    /// or Built-in Function to cause more than one YieldProgram to exist similtaneously from
+    /// them.<br/>
+    /// (i.e. a Wait Opcode inside a function, and that function gets called from both the
+    /// mainline code and a trigger.  You want two different wait timers going for them
+    /// even though they're coming from the exact same OpcodeWait instance in the program.)<br/>
+    /// </summary>
+    public abstract class YieldFinishedDetector
+    {
+        // used for tracking by the CPU - don't mess with it.  It ensures that
+        // All yields must at least wait for the next tick, even the ones that
+        // return true immediately.
+        public double creationTimeStamp {get; set;}
+        
+        /// <summary>
+        /// When the CPU starts the yield, it will call Begin to tell you the shared
+        /// objects handle in case you need some information from it, and to let you
+        /// get anything you like started up, like a timer for example.<br/>
+        /// <br/>
+        /// You can be guaranteed that the CPU will call Begin() before it ever calls IsFinished(),
+        /// so it's safe for IsFinished() to use information that was obtained from Begin().
+        /// </summary>
+        /// <param name="shared"></param>
+        public abstract void Begin(SafeSharedObjects shared);
+
+        /// <summary>
+        /// Track whatever you feel like in this class to decide when the wait is over, but
+        /// this is how you tell the CPU the wait is over.  The CPU will call IsFinished()
+        /// over and over to find out when it's time to start executing opcodes again.<br/>
+        /// <br/>
+        /// You can be guaranteed that the CPU will call Begin() before it ever calls IsFinished(),
+        /// so it's safe for IsFinished() to use information that was obtained from Begin().
+        /// </summary>
+        /// <returns>false to keep waiting, true to resume (and stop checking this instance thereafter)</returns>
+        public abstract bool IsFinished();
+    }
+}

--- a/src/kOS.Safe/Execution/YieldFinishedDetector.cs
+++ b/src/kOS.Safe/Execution/YieldFinishedDetector.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace kOS.Safe.Execution
+﻿namespace kOS.Safe.Execution
 {
     /// <summary>
     /// When telling kOS's CPU that it should yield, using the CPU.YieldProgram() method,
@@ -30,8 +28,8 @@ namespace kOS.Safe.Execution
         // used for tracking by the CPU - don't mess with it.  It ensures that
         // All yields must at least wait for the next tick, even the ones that
         // return true immediately.
-        public double creationTimeStamp {get; set;}
-        
+        public double creationTimeStamp { get; set; }
+
         /// <summary>
         /// When the CPU starts the yield, it will call Begin to tell you the shared
         /// objects handle in case you need some information from it, and to let you

--- a/src/kOS.Safe/Execution/YieldFinishedGameTimer.cs
+++ b/src/kOS.Safe/Execution/YieldFinishedGameTimer.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace kOS.Safe.Execution
+﻿namespace kOS.Safe.Execution
 {
     /// <summary>
     /// A kind of YieldFinishedDetector for use when you just want a 'dumb' timer
@@ -15,7 +13,7 @@ namespace kOS.Safe.Execution
     {
         private SafeSharedObjects shared;
         private double endTime;
-        
+
         /// <summary>
         /// Make a new timer that will expire after the given number of seconds
         /// have passed in game-clock time (not real-world time).
@@ -28,7 +26,7 @@ namespace kOS.Safe.Execution
             // It will be added to current time in the Begin() method to get the real endTime.
             endTime = duration;
         }
-        
+
         /// <summary>
         /// Need to track the shared object in order to query current game time.  The timer
         /// starts "counting" from where the clock was when the CPU calls this (which it does
@@ -40,7 +38,7 @@ namespace kOS.Safe.Execution
             this.shared = shared;
             endTime += shared.UpdateHandler.CurrentFixedTime;
         }
-        
+
         /// <summary>
         /// Return true if the timer ran out, or false if the timer has not run out.
         /// </summary>

--- a/src/kOS.Safe/Execution/YieldFinishedGameTimer.cs
+++ b/src/kOS.Safe/Execution/YieldFinishedGameTimer.cs
@@ -1,0 +1,52 @@
+﻿using System;
+
+namespace kOS.Safe.Execution
+{
+    /// <summary>
+    /// A kind of YieldFinishedDetector for use when you just want a 'dumb' timer
+    /// based on the KSP game clock (note: uses the game's notion of simulated time rather
+    /// than the real-time wall clock.  I.e. the timer is frozen for the duration of
+    /// a FixedUpdate, and doesn't move at all if the game is paused, etc.).<br/>
+    /// <br/>
+    /// You'd have to make a slightly different derivative of YieldFinishedDetector in
+    /// order to base your timer on the out-of-game wall clock.<br/>
+    /// </summary>
+    public class YieldFinishedGameTimer : YieldFinishedDetector
+    {
+        private SafeSharedObjects shared;
+        private double endTime;
+        
+        /// <summary>
+        /// Make a new timer that will expire after the given number of seconds
+        /// have passed in game-clock time (not real-world time).
+        /// </summary>
+        /// <param name="shared"></param>
+        /// <param name="duration"></param>
+        public YieldFinishedGameTimer(double duration)
+        {
+            // This is temporarily incorrect until Begin() gets called.
+            // It will be added to current time in the Begin() method to get the real endTime.
+            endTime = duration;
+        }
+        
+        /// <summary>
+        /// Need to track the shared object in order to query current game time.  The timer
+        /// starts "counting" from where the clock was when the CPU calls this (which it does
+        /// as soon as you do a YieldProgram() call.)
+        /// </summary>
+        /// <param name="shared"></param>
+        public override void Begin(SafeSharedObjects shared)
+        {
+            this.shared = shared;
+            endTime += shared.UpdateHandler.CurrentFixedTime;
+        }
+        
+        /// <summary>
+        /// Return true if the timer ran out, or false if the timer has not run out.
+        /// </summary>
+        public override bool IsFinished()
+        {
+            return shared.UpdateHandler.CurrentFixedTime >= endTime;
+        }
+    }
+}

--- a/src/kOS.Safe/Execution/YieldFinishedNextTick.cs
+++ b/src/kOS.Safe/Execution/YieldFinishedNextTick.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace kOS.Safe.Execution
+﻿namespace kOS.Safe.Execution
 {
     /// <summary>
     /// A kind of YieldFinishedDetector for when you want to wait literaly just
@@ -11,7 +9,7 @@ namespace kOS.Safe.Execution
         public override void Begin(SafeSharedObjects shared)
         {
         }
-        
+
         public override bool IsFinished()
         {
             return true;

--- a/src/kOS.Safe/Execution/YieldFinishedNextTick.cs
+++ b/src/kOS.Safe/Execution/YieldFinishedNextTick.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace kOS.Safe.Execution
+{
+    /// <summary>
+    /// A kind of YieldFinishedDetector for when you want to wait literaly just
+    /// until the next tick, by returning true unconditionally when asked "are you done".
+    /// </summary>
+    public class YieldFinishedNextTick : YieldFinishedDetector
+    {
+        public override void Begin(SafeSharedObjects shared)
+        {
+        }
+        
+        public override bool IsFinished()
+        {
+            return true;
+        }
+    }
+}

--- a/src/kOS.Safe/Function/SafeFunctionBase.cs
+++ b/src/kOS.Safe/Function/SafeFunctionBase.cs
@@ -191,5 +191,13 @@ namespace kOS.Safe.Function
             }
             return funcName;
         }
+
+        protected void YieldProgram(SafeSharedObjects shared, Func<SafeSharedObjects, bool> isFinishedDelegate)
+        {
+            // setup the yield using an anonymous function so that the scope is tied to this specific call
+            // which prevents a potential issue if the function is called both in mainline code and in
+            // trigger code (though a potential conflict still exists if the exact same opcode is executed).
+            shared.Cpu.GetCurrentOpcode().YieldProgram(shared.Cpu, cpu => isFinishedDelegate(shared));
+        }
     }
 }

--- a/src/kOS.Safe/Function/SafeFunctionBase.cs
+++ b/src/kOS.Safe/Function/SafeFunctionBase.cs
@@ -191,13 +191,5 @@ namespace kOS.Safe.Function
             }
             return funcName;
         }
-
-        protected void YieldProgram(SafeSharedObjects shared, Func<SafeSharedObjects, bool> isFinishedDelegate)
-        {
-            // setup the yield using an anonymous function so that the scope is tied to this specific call
-            // which prevents a potential issue if the function is called both in mainline code and in
-            // trigger code (though a potential conflict still exists if the exact same opcode is executed).
-            shared.Cpu.GetCurrentOpcode().YieldProgram(shared.Cpu, cpu => isFinishedDelegate(shared));
-        }
     }
 }

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -175,6 +175,9 @@
     <Compile Include="Execution\SurboutineContext.cs" />
     <Compile Include="Execution\Variable.cs" />
     <Compile Include="Execution\VariableScope.cs" />
+    <Compile Include="Execution\YieldFinishedDetector.cs" />
+    <Compile Include="Execution\YieldFinishedGameTimer.cs" />
+    <Compile Include="Execution\YieldFinishedNextTick.cs" />
     <Compile Include="Function\FunctionAttribute.cs" />
     <Compile Include="Function\SafeFunctionBase.cs" />
     <Compile Include="Function\FunctionManager.cs" />

--- a/src/kOS/Function/Misc.cs
+++ b/src/kOS/Function/Misc.cs
@@ -127,6 +127,7 @@ namespace kOS.Function
             if (StageManager.CanSeparate && shared.Vessel.isActiveVessel)
             {
                 StageManager.ActivateNextStage();
+                YieldProgram(shared, sh => { return true; });
             }
             else if (!StageManager.CanSeparate)
             {

--- a/src/kOS/Function/Misc.cs
+++ b/src/kOS/Function/Misc.cs
@@ -127,7 +127,7 @@ namespace kOS.Function
             if (StageManager.CanSeparate && shared.Vessel.isActiveVessel)
             {
                 StageManager.ActivateNextStage();
-                YieldProgram(shared, sh => { return true; });
+                shared.Cpu.YieldProgram(new YieldFinishedNextTick());
             }
             else if (!StageManager.CanSeparate)
             {


### PR DESCRIPTION
Fixes #1805 

One of the few outstanding issues with this code is that it will technically crash in one very specific instance: if you call the exact same opcode while it is already waiting in mainline code, from a trigger.  In that case there should be a stack misalignment, because the trigger will have pushed something to the stack for the opcode, but then the opcode will return from the wait for the trigger before it returns to mainline code.  That means the trigger will attempt to continue to execute, without popping any previous arguments off of the stack first.  I'm not sure of a good solution for this issue, and more importantly I think that this is why we should make it clear to users that they need to be careful about executing the same section of code from inside of triggers and mainline code at the same time.

Opcode.cs
* Remove OpcodeEndWait which isn't used
* Add new method YieldProgram which starts waiting and registers the YieldFinishedDelegate
* Add new method CheckYield which evaluates YieldFinishedDelegate
* Add virtual BeginYield and EndYield methods so an opcode may override entering or leaving the yield condition.  This is mostly to allow opcodes that change DeltaInstructionPointer to still do so even if they use the new wait logic.

CPU.cs
* When executing opcodes, check for IsYielding and if so call CheckYield instead of Execute

SafeFunctionBase.cs
* Provide a method for functions to call Opcode.YieldProgram without accessing the opcode directly

Misc.cs
* Update the stage function to wait for one tick before returning to the program code.
* This is done because some things update immediately on stage (thrust) while others do not (position, mass).