### PR TITLE
Try to fix RemoteTech steering again

### DIFF
--- a/src/kOS/Module/kOSVesselModule.cs
+++ b/src/kOS/Module/kOSVesselModule.cs
@@ -282,7 +282,7 @@ namespace kOS.Module
         private void UnHookRemoteTechPilot()
         {
             RemoteTechHook.Instance.RemoveSanctionedPilot(parentVessel.id, HandleRemoteTechSanctionedPilot);
-            counterRemoteTechRefresh = 0;
+            counterRemoteTechRefresh = RemoteTechRehookPeriod - 2; // make sure it starts out ready to trigger soon
         }
 
         private void HookStockPilot()


### PR DESCRIPTION
Fixes #1806

RT seems to clear the sanctioned pilots list when the vessel unpacks.  There isn't a way for us to subscribe to an update to tell us when things get cleared, and there is no way to directly check the list.  Since RT checks the list of sanctioned pilots when we attempt to register, and only adds if our handler isn't already registered, we can simply keep calling the method to add a sanctioned pilot.  To cut down on the potential performance hit, I limited these calls to once every 25 ticks.

kOSVesselModule.cs
* Update some logging to simplify references
* Add counter to refresh RT sactioned pilot once every 25 ticks (1s real time in theory)