### PR TITLE
Fixes #1801 and Fixes #1784.

### DIFF
--- a/kerboscript_tests/user_functions/functest27.ks
+++ b/kerboscript_tests/user_functions/functest27.ks
@@ -2,7 +2,7 @@ print "running a test to see if you can call".
 print "a function from inside a KSM file.".
 
 print "Ensuring functest27_b.ksm is deleted:".
-log "" to "functest27_b.ksm". delete "functest27_b.ksm".
+log "" to "functest27_b.ksm". deletepath("functest27_b.ksm").
 
 print "Trying to compile functest27_b.ks to KSM file:".
 compile functest27_b.

--- a/kerboscript_tests/user_functions/functest28.ks
+++ b/kerboscript_tests/user_functions/functest28.ks
@@ -1,0 +1,42 @@
+// Testing issue 1801 - functions nested in anon functions.
+
+// global named function called from anon function:
+function foo_works1 { print "Global named func called from anon works.". }
+local fn_works1 is { foo_works1(). }.
+fn_works1().
+
+// anon function nested in anon function:
+local fn_works2 is {
+  local foo_works2 is {
+    print "Anon func nested in anon func works.".
+  }.
+  foo_works2().
+}.
+fn_works2().
+
+// nanmed function nested in named function:
+function fn_works3 {
+  function foo_works3 {
+    print "named func nested in named func works.".
+  }
+  foo_works3().
+}
+fn_works3().
+
+// named function inside anything that is not a function
+if true {
+  function func_inside_if {
+    print "named func nested in generic braces works.".
+  }
+  func_inside_if().
+}
+
+// named function nested in anon function:
+local fn_fails is {
+  function foo_fails {
+    print "named func nested in anon func works.".
+  }
+  foo_fails().
+}.
+fn_fails().
+

--- a/kerboscript_tests/user_functions/functest33.ks
+++ b/kerboscript_tests/user_functions/functest33.ks
@@ -1,0 +1,28 @@
+// Testing that anon functions can have locks in them.
+// (Test added in response to issue #1801).
+
+// Tests that the compiler will properly recurse into
+// all the weird places an anon function might be,
+// which is pretty much *any* expression, and walk
+// their contents looking for LOCK statements.
+
+function named_func { lock foo to 1. }
+
+function func_that_invokes_delegate { parameter del.  del().  }
+function func_that_returns_delegate { return {lock foo to 1.}. }
+
+global declare_global_anon_func is { lock foo to 1. }.
+
+set set_stmt_anon_func to { lock foo to 1. }.
+
+print "Should see no output, no errors.  Just program end".
+print "==================================================".
+named_func().
+declare_global_anon_func().
+set_stmt_anon_func().
+{ // do-nothing nested braces for local scoping.
+  local declare_local_anon_func is { lock foo to 1. }.
+  declare_local_anon_func().
+}
+func_that_invokes_delegate( { lock foo to 1. } ).
+func_that_invokes_delegate( func_that_returns_delegate() ).

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -253,6 +253,8 @@ namespace kOS.Safe.Compilation.KS
                 case TokenType.for_stmt:
                 case TokenType.on_stmt:
                 case TokenType.when_stmt:
+                case TokenType.declare_identifier_clause:
+                case TokenType.expr:
                 case TokenType.declare_function_clause:
                     foreach (ParseNode childNode in node.Nodes)
                         IterateUserFunctions(childNode, action);

--- a/src/kOS.Safe/Compilation/ProgramBuilder.cs
+++ b/src/kOS.Safe/Compilation/ProgramBuilder.cs
@@ -250,7 +250,7 @@ namespace kOS.Safe.Compilation
                     labels.Add(program[index].Label, index);
                 }
             }
-
+ 
             // replace destination labels with the corresponding index
             for (int index = 0; index < program.Count; index++)
             {


### PR DESCRIPTION
The problem in issue #1801 was that the logic in the Compiler's IterateuserFunctions() that does a tree walk through everywhere a ``function`` statement might exist to preform function preprocessing on it, was failing to descend into the ``instruction_block`` of an anon function.

This was because the ``instruction_block`` of an anon function is a kind of ``expr`` instead of being a kind of ``instruction``, and the case statement wasn't set up to descend into ``expr``'s.

It turns out that, as a bonus, this also fixed issue #1784 as well, for the same reason.

Fixes #1784
Fixes #1801