### PR TITLE
Fixes #1796 by giving OpcodeLabelResets a linenum.

### DIFF
--- a/src/kOS.Safe/Compilation/CompiledObject.cs
+++ b/src/kOS.Safe/Compilation/CompiledObject.cs
@@ -297,7 +297,7 @@ namespace kOS.Safe.Compilation
                 else if ( (! string.IsNullOrEmpty(op.Label)) &&
                           (op.Label != expectedLabel) )
                 {
-                    op = new OpcodeLabelReset(op.Label);
+                    op = new OpcodeLabelReset(op.Label) { SourcePath = op.SourcePath, SourceLine = op.SourceLine } ;
                     --index;
                     justInsertedLabel = true;
                 }


### PR DESCRIPTION
The problem ultimately was caused by the fact that the ``OpcodeLabelReset`` opcodes that get inserted when compiling to KSM don't have their SourceLine field populated (because they didn't directly come from the user's source code but from the KSM building step).

The OpcodeLabelReset's were all being falsely attributed to having come from "line 0", and that's how it was trying to store it in the KSM file in the debugLineMap section (the %D part).  Thus it was trying to make the DebugLineMap store the case where there were more than 255 different noncontiguous sections of the program that all allegedly came from the same source line (line 0).  This is a condition that would be really ridiculous to have happen from a *real* line of code - normally the compiler might make maybe 3 or 4 different sections at max from a single line of code.  But with this "fake line 0" information, it was treating it as if this had been exactly what happened.  The count of how many such sections there are is stored in only 1 byte, so trying to have more than 255 of them overflowed the byte and led to bogus information about how many bytes to read before encountering the next line number's header data in the %D section.  Thus it got misaligned and started reading really bogus data out of the KSM file.

The fix was to stop claiming all OpcodeLabelReset's "came from line 0".  This had been used as a flag to help indicate that they were "internal" errors if an exception happens in them and the error message should give the "see the devs" note.  But these don't really ever throw exceptions at runtime because they're stripped out and are gone by the time the program runs so they don't need that.

So the fix was to just populate their SourceLine data by inheriting it from whatever opcode they were resetting the label on behalf of.