### PR TITLE
Gives some keyboard input abilities.

### DIFF
--- a/doc/source/structures/misc/terminal.rst
+++ b/doc/source/structures/misc/terminal.rst
@@ -59,6 +59,11 @@ Structure
 	  - get and set
 	  - Height of a character cell in pixels.
 
+        * - :attr:`INPUT`
+	  - :struct:`TerminalInput`
+	  - get
+	  - Used to read user's input into the terminal.
+
 .. attribute:: Terminal:WIDTH
 
     :access: Get/Set
@@ -172,3 +177,11 @@ Structure
     Warning: Features related to the in-game terminal GUI may change
     when KSP 1.1 comes out, as we may redesign some of the user
     interface.
+
+.. attribute:: Terminal:INPUT
+
+    :access: Get
+    :type: :struct:`TerminalInput`
+
+    This gives you a :struct:`TerminalInput` structure, which can be
+    used to read user's input into the kOS terminal.

--- a/doc/source/structures/misc/terminalinput.rst
+++ b/doc/source/structures/misc/terminalinput.rst
@@ -1,0 +1,286 @@
+.. _terminalinput:
+
+
+Terminal Input
+==============
+
+You can read the user's keyboard input into the kOS terminal
+using this structure.  You obtain this structure by calling
+:attr:`Terminal:INPUT`.
+
+Input is buffered
+-----------------
+
+Input is buffered if the user types faster than you process
+the input.  (For example, if you have code that reads 1
+character per second, and the user types faster than 1
+character per second, then the letters they typed "in between"
+your reads are not lost.  It just takes time for your
+program to catch up to the backlog and finish processing them
+all.)
+
+Input is blocking
+-----------------
+
+If you attempt to read a character of input and there are
+none available (because the user hasn't typed anything
+yet for you to read), then your program will pause and
+get stuck there until the user presses a key.  If you want
+to check first to find out if a key is available before
+you read it, use the :attr:`HASCHAR` suffix described below.
+
+Detecting special keys
+----------------------
+
+You can detect some special keys that don't form normal
+ASCII codes, such as the Left arrow, Page Up, and so on.
+
+Internally KOS uses its own mapping of these characters to
+its own Unicode codes.  (This is part of the system it uses
+to support a few different types of terminal in the telnet
+module).  You can see some of these code names and use them
+to test against your input characters.  Some of the
+suffixes to :struct:`TerminalInput` are for this purpose.
+
+example::
+
+    set ch to terminal:input:getchar().
+
+    if ch = terminal:input:DOWNCURSORONE {
+      print "You typed the down-arrow key.".
+    }
+    if ch = terminal:input:UPCURSORONE {
+      print "You typed the up-arrow key.".
+    }
+
+Cannot read control-C
+---------------------
+
+You cannot read the control-C character in your program, because it
+causes your program to break.
+
+Cannot read "shift" or "alt"
+----------------------------
+
+You cannot read the "shift" or "alt" keypresses pressed by themselves
+because they send no characters to the terminal until combined with
+other characters.  (For example "shift A" sends an "A" character, while
+"A" without shift sends a "a" character, but you can't just read the
+shift key itself.)  This is a deliberate decision because the kOS
+terminal in the game is supposed to be identical to a telnet terminal
+window, and you can't "send" these sorts of keypresses as characters
+down a stream.
+
+Structure
+---------
+
+.. structure:: TerminalInput
+
+    .. list-table:: Members
+        :header-rows: 1
+        :widths: 2 1 1 4
+
+	* - Suffix
+	  - Type
+	  - Get/Set
+	  - Description
+
+        * - :attr:`GETCHAR`
+	  - :struct:`String`
+	  - Get
+	  - (Blocking) I/O to read the next character of terminal input.
+
+        * - :attr:`HASCHAR`
+	  - :struct:`Boolean`
+	  - Get
+	  - True if there is at least 1 character of input waiting.
+
+        * - :attr:`CLEAR`
+	  - n/a (void)
+	  - n/a
+	  - Call this method to throw away all waiting input characters, flushing the input queue.
+
+        * - :attr:`BACKSPACE`
+          - :struct:`String`
+          - Get
+          - A string for testing if the character read is a backspace.
+
+        * - :attr:`DELETERIGHT`
+          - :struct:`String`
+          - Get
+          - A string for testing if the character read is the delete (to the right) key.
+
+        * - :attr:`RETURN`
+          - :struct:`String`
+          - Get
+          - A string for testing if the character read is the return key.
+
+        * - :attr:`ENTER`
+          - :struct:`String`
+          - Get
+          - An alias for :attr:`RETURN`
+
+        * - :attr:`UPCURSORONE`
+          - :struct:`String`
+          - Get
+          - A string for testing if the character read is the up-arrow key.
+
+        * - :attr:`DOWNCURSORONE`
+          - :struct:`String`
+          - Get
+          - A string for testing if the character read is the down-arrow key.
+
+        * - :attr:`LEFTCURSORONE`
+          - :struct:`String`
+          - Get
+          - A string for testing if the character read is the left-arrow key.
+
+        * - :attr:`RIGHTCURSORONE`
+          - :struct:`String`
+          - Get
+          - A string for testing if the character read is the right-arrow key.
+
+        * - :attr:`HOMECURSOR`
+          - :struct:`String`
+          - Get
+          - A string for testing if the character read is the HOME key.
+
+        * - :attr:`ENDCURSOR`
+          - :struct:`String`
+          - Get
+          - A string for testing if the character read is the END key.
+
+        * - :attr:`PAGEUPCURSOR`
+          - :struct:`String`
+          - Get
+          - A string for testing if the character read is the PageUp key.
+
+        * - :attr:`PAGEDOWNCURSOR`
+          - :struct:`String`
+          - Get
+          - A string for testing if the character read is the PageDown key.
+
+.. attribute:: TerminalInput:GETCHAR
+
+    :access: Get (Method call)
+    :type: :struct:`String`
+
+    Read the next character of terminal input.  If the user hasn't typed
+    anything in that is still waiting to be read, then this will "block"
+    (meaning it will pause the execution of the program) until there
+    is a character that has been typed that can be processed.
+
+    The character will be expressed in a string containing 1 char.
+
+    If you need to check against "unprintable" characters such as
+    backspace (control-H) and so on, you can do so with the
+    :func:`unchar` function, or by using the aliases described elsewhere
+    in this structure.
+
+.. attribute:: TerminalInput:HASCHAR
+
+    :access: Get (method call)
+    :type: :struct:`Boolean`
+
+    True if there is at least 1 character of input waiting.  If this is
+    false then that would mean that an attempt to call :attr:`GETCHAR`
+    would block and wait for user input.  If this is true then an attempt
+    to call :attr:`GETCHAR` would return immediately with an answer.
+
+    You can simulate non-blocking I/O like so::
+
+        // Read a char if it exists, else just keep going:
+        if terminal:input:haschar {
+          process_one_char(terminal:input:getchar()).
+        }
+
+.. attribute:: TerminalInput:CLEAR
+
+    :access: Get (method call)
+    :type: n/a (void)
+
+    Call this method to throw away all waiting input characters, flushing
+    the input queue.
+
+.. attribute:: TerminalInput:BACKSPACE
+
+    :access: Get
+    :type: :struct:`String`
+
+    A string for testing if the character read is a backspace.
+
+.. attribute:: TerminalInput:DELETERIGHT
+
+    :access: Get
+    :type: :struct:`String`
+
+    A string for testing if the character read is the delete (to the right) key.
+
+.. attribute:: TerminalInput:RETURN
+
+    :access: Get
+    :type: :struct:`String`
+
+    A string for testing if the character read is the return key.
+
+.. attribute:: TerminalInput:ENTER
+
+    :access: Get
+    :type: :struct:`String`
+
+.. attribute:: TerminalInput:UPCURSORONE
+
+    :access: Get
+    :type: :struct:`String`
+
+    A string for testing if the character read is the up-arrow key.
+
+.. attribute:: TerminalInput:DOWNCURSORONE
+
+    :access: Get
+    :type: :struct:`String`
+
+    A string for testing if the character read is the down-arrow key.
+
+.. attribute:: TerminalInput:LEFTCURSORONE
+
+    :access: Get
+    :type: :struct:`String`
+
+    A string for testing if the character read is the left-arrow key.
+
+.. attribute:: TerminalInput:RIGHTCURSORONE
+
+    :access: Get
+    :type: :struct:`String`
+
+    A string for testing if the character read is the right-arrow key.
+
+.. attribute:: TerminalInput:HOMECURSOR
+
+    :access: Get
+    :type: :struct:`String`
+
+    A string for testing if the character read is the HOME key.
+
+.. attribute:: TerminalInput:ENDCURSOR
+
+    :access: Get
+    :type: :struct:`String`
+
+    A string for testing if the character read is the END key.
+
+.. attribute:: TerminalInput:PAGEUPCURSOR
+
+    :access: Get
+    :type: :struct:`String`
+
+    A string for testing if the character read is the PageUp key.
+
+.. attribute:: TerminalInput:PAGEDOWNCURSOR
+
+    :access: Get
+    :type: :struct:`String`
+
+    A string for testing if the character read is the PageDown key.
+

--- a/src/kOS.Safe/Encapsulation/TerminalInput.cs
+++ b/src/kOS.Safe/Encapsulation/TerminalInput.cs
@@ -1,0 +1,97 @@
+﻿using kOS.Safe.Encapsulation;
+using kOS.Safe.Encapsulation.Suffixes;
+using kOS.Safe.UserIO;
+using kOS.Safe.Execution;
+using System;
+
+namespace kOS.Safe.Encapsulation
+{
+    /// <summary>
+    /// Handles the keyboard (any maybe other types later??) input
+    /// into the terminal.
+    /// </summary>
+    [kOS.Safe.Utilities.KOSNomenclature("TerminalInput")]
+    public class TerminalInput : Structure
+    {
+        private SafeSharedObjects shared;
+        
+        /// <summary>
+        /// The subset of values within the UnicodeCommand enum that
+        /// we want to expose to kOS scripts to see as suffixes
+        /// to TerminalInput.
+        /// </summary>
+        private static UnicodeCommand[] codesToExpose =
+            {
+                UnicodeCommand.UPCURSORONE,
+                UnicodeCommand.DOWNCURSORONE, 
+                UnicodeCommand.LEFTCURSORONE, 
+                UnicodeCommand.RIGHTCURSORONE, 
+                UnicodeCommand.HOMECURSOR,
+                UnicodeCommand.ENDCURSOR,
+                UnicodeCommand.PAGEUPCURSOR,
+                UnicodeCommand.PAGEDOWNCURSOR,
+                UnicodeCommand.DELETERIGHT
+            };
+        
+        public TerminalInput(SafeSharedObjects shared)
+        {
+            this.shared = shared;
+            InitializeSuffixes();
+        }
+
+        private void InitializeSuffixes()
+        {
+            AddSuffix("GETCHAR", new Suffix<StringValue>(GetChar));
+            AddSuffix("HASCHAR", new Suffix<BooleanValue>(HasChar));
+            AddSuffix("CLEAR", new NoArgsVoidSuffix(Clear));
+            
+            // Aliases for special characters:
+            foreach (UnicodeCommand code in codesToExpose)
+            {
+                AddSuffix(code.ToString(), new Suffix<StringValue>(() => new StringValue((char)code)));
+            }
+            AddSuffix("BACKSPACE", new Suffix<StringValue>(() => new StringValue((char)0x008)));
+            AddSuffix( new[] {"RETURN", "ENTER"}, new Suffix<StringValue>(() => new StringValue((char)0x00D)));
+        }
+        
+        /// <summary>
+        /// Get the next char in the keyboard input queue.  This is a blocking
+        /// I/O if called from a kerboscript opcode.  It will pause the program
+        /// until such a time as input exists.
+        /// </summary>
+        /// <returns></returns>
+        public StringValue GetChar()
+        {
+            var q = shared.Screen.CharInputQueue;
+            if (q.Count >0)
+            {
+                // Just return the input char now without wait.
+                return new StringValue(q.Dequeue());
+            }
+            else
+            {
+                // Blocks until input exists.
+                shared.Cpu.YieldProgram(new YieldFinishedGetChar());
+
+                // Note the user should never see this value.  The value will
+                // get popped from the stack and replaced by the real value.  This
+                // is done by YieldFinishedGetChar when it is finished waiting:
+                return new StringValue((char)0);
+            }
+        }
+        
+        public void Clear()
+        {
+            shared.Screen.CharInputQueue.Clear();
+        }
+        
+        public BooleanValue HasChar()
+        {
+            var q = shared.Screen.CharInputQueue;
+            if (q.Count > 0)
+                return true;
+            else
+                return false;
+        }
+    }
+}

--- a/src/kOS.Safe/Encapsulation/TerminalStruct.cs
+++ b/src/kOS.Safe/Encapsulation/TerminalStruct.cs
@@ -6,6 +6,7 @@ namespace kOS.Safe.Encapsulation
     public class TerminalStruct : Structure
     {
         private readonly SafeSharedObjects shared;
+        private TerminalInput terminalInput = null;
 
         // Some sanity values to prevent the terminal display from getting garbled up:
         // They may have to change after experimentation.
@@ -72,6 +73,14 @@ namespace kOS.Safe.Encapsulation
                                                                     MAXCHARPIXELS,
                                                                     2,
                                                                     "Character height on in-game terminal screen in pixels"));
+            AddSuffix("INPUT", new Suffix<TerminalInput>(GetTerminalInputInstance));
+        }
+        
+        public TerminalInput GetTerminalInputInstance()
+        {
+            if (terminalInput == null)
+                terminalInput = new TerminalInput(shared);
+            return terminalInput;
         }
         
         public override string ToString()

--- a/src/kOS.Safe/Execution/YieldFinishedGetChar.cs
+++ b/src/kOS.Safe/Execution/YieldFinishedGetChar.cs
@@ -1,0 +1,41 @@
+﻿using kOS.Safe.Encapsulation;
+using System.Collections.Generic;
+using System;
+
+namespace kOS.Safe.Execution
+{
+    /// <summary>
+    /// Description of YieldFinishedGetChar.
+    /// </summary>
+    public class YieldFinishedGetChar : YieldFinishedDetector
+    {
+        private SafeSharedObjects shared;
+        
+        public override void Begin(SafeSharedObjects shared)
+        {
+            this.shared = shared;
+        }
+        
+        public override bool IsFinished()
+        {
+            Queue<char> q = shared.Screen.CharInputQueue;
+            
+            if (q.Count > 0)
+            {
+                char ch = q.Dequeue();
+                
+                // Replace the dummy return value the suffix
+                // left atop the stack with the real return value.
+                // Now that we're done waiting, the next Opcode
+                // (that expects the expression atop the stack to be
+                // the char that was read) is going to execute:
+                shared.Cpu.PopStack();
+                shared.Cpu.PushStack(new StringValue(ch));
+
+                return true;
+            }
+            else
+                return false;
+        }
+    }
+}

--- a/src/kOS.Safe/Screen/IInterpreter.cs
+++ b/src/kOS.Safe/Screen/IInterpreter.cs
@@ -9,7 +9,7 @@ namespace kOS.Safe.Screen
         string GetCommandHistoryAbsolute(int absoluteIndex);
         void SetInputLock(bool isLocked);
         bool IsAtStartOfCommand();
-        bool isWaitingForCommand();
+        bool IsWaitingForCommand();
         void Reset();
     }
 }

--- a/src/kOS.Safe/Screen/IInterpreter.cs
+++ b/src/kOS.Safe/Screen/IInterpreter.cs
@@ -9,6 +9,7 @@ namespace kOS.Safe.Screen
         string GetCommandHistoryAbsolute(int absoluteIndex);
         void SetInputLock(bool isLocked);
         bool IsAtStartOfCommand();
+        bool isWaitingForCommand();
         void Reset();
     }
 }

--- a/src/kOS.Safe/Screen/IScreenBuffer.cs
+++ b/src/kOS.Safe/Screen/IScreenBuffer.cs
@@ -15,6 +15,7 @@ namespace kOS.Safe.Screen
         int BeepsPending {get; set;}
         bool ReverseScreen {get; set;}
         bool VisualBeep {get; set;}
+        Queue<char> CharInputQueue { get; }
         int TopRow {get;}
         void SetSize(int rowCount, int columnCount);
         int ScrollVertical(int deltaRows);

--- a/src/kOS.Safe/Screen/ScreenBuffer.cs
+++ b/src/kOS.Safe/Screen/ScreenBuffer.cs
@@ -13,6 +13,8 @@ namespace kOS.Safe.Screen
         private int topRow;
         private readonly List<IScreenBufferLine> buffer;
         private readonly List<SubBuffer> subBuffers;
+
+        public Queue<char> CharInputQueue { get; private set; }
         
         public int BeepsPending {get; set;}
         
@@ -64,6 +66,8 @@ namespace kOS.Safe.Screen
             Notifyees = new List<ResizeNotifier>();
 
             subBuffers = new List<SubBuffer>();
+            
+            CharInputQueue = new Queue<char>();
 
             RowCount = DEFAULT_ROWS;
             ColumnCount = DEFAULT_COLUMNS;

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Compilation\CompileCache.cs" />
     <Compile Include="Compilation\CompiledObject.cs" />
     <Compile Include="Compilation\CompilerOptions.cs" />
+    <Compile Include="Encapsulation\TerminalInput.cs" />
     <Compile Include="Exceptions\KOSAtmosphereObsoletionException.cs" />
     <Compile Include="Exceptions\KOSInvalidTargetException.cs" />
     <Compile Include="Exceptions\KOSObsoletionException.cs" />
@@ -178,6 +179,7 @@
     <Compile Include="Execution\VariableScope.cs" />
     <Compile Include="Execution\YieldFinishedDetector.cs" />
     <Compile Include="Execution\YieldFinishedGameTimer.cs" />
+    <Compile Include="Execution\YieldFinishedGetChar.cs" />
     <Compile Include="Execution\YieldFinishedNextTick.cs" />
     <Compile Include="Function\FunctionAttribute.cs" />
     <Compile Include="Function\SafeFunctionBase.cs" />

--- a/src/kOS/Screen/Interpreter.cs
+++ b/src/kOS/Screen/Interpreter.cs
@@ -157,6 +157,12 @@ namespace kOS.Screen
             }
         }
 
+        public bool isWaitingForCommand()
+        {
+            IProgramContext context = ((CPU)Shared.Cpu).GetInterpreterContext();
+            return context.Program[context.InstructionPointer] is OpcodeEOF;
+        }
+
         public void SetInputLock(bool isLocked)
         {
             locked = isLocked;

--- a/src/kOS/Screen/Interpreter.cs
+++ b/src/kOS/Screen/Interpreter.cs
@@ -157,7 +157,7 @@ namespace kOS.Screen
             }
         }
 
-        public bool isWaitingForCommand()
+        public bool IsWaitingForCommand()
         {
             IProgramContext context = ((CPU)Shared.Cpu).GetInterpreterContext();
             return context.Program[context.InstructionPointer] is OpcodeEOF;

--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -295,6 +295,8 @@ namespace kOS.Screen
         void OnGUI()
         {
             if (!IsOpen) return;
+            
+            ProcessUnconsumedInput();
 
             if (isLocked) ProcessKeyEvents();
             
@@ -543,7 +545,9 @@ namespace kOS.Screen
         /// <param name="ch">The character, which might be a UnicodeCommand char</param>
         /// <param name="whichTelnet">If this came from a telnet session, which one did it come from?
         /// Set to null in order to say it wasn't from a telnet but was from the interactive GUI</param>
-        public void ProcessOneInputChar(char ch, TelnetSingletonServer whichTelnet)
+        /// <param name="doQueuing">true if the keypress should get queued if we're not ready for it
+        /// right now.  If false, then the keypress will be ignored if we're not ready for it.</param>
+        public void ProcessOneInputChar(char ch, TelnetSingletonServer whichTelnet, bool doQueuing = true)
         {
             // Weird exceptions for multi-char data combos that would have been begun on previous calls to this method:
             switch (inputExpected)
@@ -568,7 +572,7 @@ namespace kOS.Screen
             // bigger task than it may first seem.)
             if (0x0020 <= ch && ch <= 0x007f)
             {
-                 Type(ch);
+                 Type(ch, doQueuing);
             }
             else
             {
@@ -578,13 +582,15 @@ namespace kOS.Screen
                     // maps directly into nicely, otherwise just pass it through to SpecialKey():
 
                     case (char)UnicodeCommand.DELETELEFT:
-                        Type((char)8);
+                    case (char)8:
+                        Type((char)8, doQueuing);
                         break;
                     case (char)UnicodeCommand.STARTNEXTLINE:
-                        Type('\r');
+                    case '\r':
+                        Type('\r', doQueuing);
                         break;
                     case '\t':
-                        Type('\t');
+                        Type('\t', doQueuing);
                         break;
                     case (char)UnicodeCommand.RESIZESCREEN:
                         inputExpected = ExpectNextChar.RESIZEWIDTH;
@@ -615,7 +621,7 @@ namespace kOS.Screen
                     // Typical case is to just let SpecialKey do the work:
                     
                     default:
-                        SpecialKey(ch);
+                        SpecialKey(ch, doQueuing);
                         break;
                 }
             }
@@ -623,37 +629,69 @@ namespace kOS.Screen
             // else ignore it - unimplemented char.
         }
 
-        void Type(char ch)
+        void Type(char ch, bool doQueuing = true)
         {
             if (shared != null)
             {
-                if (shared.Interpreter != null && shared.Interpreter.isWaitingForCommand())
+                if (shared.Interpreter != null && shared.Interpreter.IsWaitingForCommand())
                 {
                     shared.Interpreter.Type(ch);
-                    if (IsOpen && keyClickEnabled)
-                         shared.SoundMaker.BeginSound("click");
                 }
-                else 
+                else if (doQueuing)
                 {
                     shared.Screen.CharInputQueue.Enqueue(ch);
                 }
+                if (IsOpen && keyClickEnabled)
+                    shared.SoundMaker.BeginSound("click");
             }
         }
 
-        void SpecialKey(char key)
+        void SpecialKey(char key, bool doQueuing = true)
         {
             if (shared != null)
             {
+                bool wasUsed = false;
+                
                 if (shared.Interpreter != null && 
-                    (shared.Interpreter.isWaitingForCommand() || (key == (char)UnicodeCommand.BREAK)))
+                    (shared.Interpreter.IsWaitingForCommand() || (key == (char)UnicodeCommand.BREAK)))
                 {
-                    bool wasUsed = shared.Interpreter.SpecialKey(key);
-                    if (IsOpen && keyClickEnabled && wasUsed)
-                        shared.SoundMaker.BeginSound("click");
+                    wasUsed = shared.Interpreter.SpecialKey(key);
                 }
-                else
+                else if (doQueuing)
                 {
                     shared.Screen.CharInputQueue.Enqueue(key);
+                    wasUsed = true;
+                }
+                if (IsOpen && keyClickEnabled && wasUsed)
+                    shared.SoundMaker.BeginSound("click");
+            }
+        }
+        
+        /// <summary>
+        /// When the input queue is not empty and the program or command is done such that
+        /// the input cursor is now all the way back to the interpreter awaiting new input,
+        /// send that queue out to the interpreter.  This allows you to type the next command
+        /// blindly while waiting for the previous one to finish.
+        /// This is how people used to terminals would expect things to work.
+        /// </summary>
+        void ProcessUnconsumedInput()
+        {
+            if (shared != null && shared.Interpreter != null && shared.Interpreter.IsWaitingForCommand())
+            {
+                Queue<char> q = shared.Screen.CharInputQueue;
+                
+                while (q.Count > 0 && shared.Interpreter.IsWaitingForCommand())
+                {
+                    // Setting doQueuing to false here just as an
+                    // additional safety measure.  Hypothetically it
+                    // should never re-queue this input because we're
+                    // in the condition where it will consume it right
+                    // away.  But just in case there's some error in
+                    // that logic, we want to avoid an infinite loop here
+                    // (which could happen if we kept re-queuing the
+                    // chars every time we processed one in this loop.)
+                    char key = q.Dequeue();
+                    ProcessOneInputChar(key, null, false);
                 }
             }
         }

--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -641,7 +641,7 @@ namespace kOS.Screen
                 {
                     shared.Screen.CharInputQueue.Enqueue(ch);
                 }
-                if (IsOpen && keyClickEnabled)
+                if (IsOpen && keyClickEnabled && doQueuing)
                     shared.SoundMaker.BeginSound("click");
             }
         }
@@ -662,7 +662,7 @@ namespace kOS.Screen
                     shared.Screen.CharInputQueue.Enqueue(key);
                     wasUsed = true;
                 }
-                if (IsOpen && keyClickEnabled && wasUsed)
+                if (IsOpen && keyClickEnabled && wasUsed && doQueuing)
                     shared.SoundMaker.BeginSound("click");
             }
         }

--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -625,21 +625,36 @@ namespace kOS.Screen
 
         void Type(char ch)
         {
-            if (shared != null && shared.Interpreter != null)
+            if (shared != null)
             {
-                shared.Interpreter.Type(ch);
-                if (IsOpen && keyClickEnabled)
-                    shared.SoundMaker.BeginSound("click");
+                if (shared.Interpreter != null && shared.Interpreter.isWaitingForCommand())
+                {
+                    shared.Interpreter.Type(ch);
+                    if (IsOpen && keyClickEnabled)
+                         shared.SoundMaker.BeginSound("click");
+                }
+                else 
+                {
+                    shared.Screen.CharInputQueue.Enqueue(ch);
+                }
             }
         }
 
         void SpecialKey(char key)
         {
-            if (shared != null && shared.Interpreter != null)
+            if (shared != null)
             {
-                bool wasUsed = shared.Interpreter.SpecialKey(key);
-                if (IsOpen && keyClickEnabled && wasUsed)
-                    shared.SoundMaker.BeginSound("click");
+                if (shared.Interpreter != null && 
+                    (shared.Interpreter.isWaitingForCommand() || (key == (char)UnicodeCommand.BREAK)))
+                {
+                    bool wasUsed = shared.Interpreter.SpecialKey(key);
+                    if (IsOpen && keyClickEnabled && wasUsed)
+                        shared.SoundMaker.BeginSound("click");
+                }
+                else
+                {
+                    shared.Screen.CharInputQueue.Enqueue(key);
+                }
             }
         }
         


### PR DESCRIPTION
Note I didn't add the ability to get a whole string at a time
yet, but that's an uglier problem and what's here is good
by itself as a useful feature, so it's worth looking at it
as a separate PR without line input.

In the end I decided to go with this method and abandon the
"everything is a file" approach to key input, because the way
the file reading libraries in kOS got made just aren't
compatible with this style of thinking.

I also abandoned the notion of handling input on top of
the comms system because I realized that would prevent it
from working in a command-line only way (it would have
tied user input to the Vessel and PartModule objects and
thus prevented it from being in kOS.Safe).