### PR TITLE
Fixed forum links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ kOS is a scriptable autopilot Mod for Kerbal Space Program. It allows you write 
 
 Documentation : http://ksp-kos.github.io/KOS_DOC/
 
-Addon release thread: http://forum.kerbalspaceprogram.com/index.php?/topic/61827-/
+Addon release thread: http://forum.kerbalspaceprogram.com/index.php?/topic/61827--/
 
-Addon development thread: http://forum.kerbalspaceprogram.com/index.php?/topic/61834-/
+Addon development thread: http://forum.kerbalspaceprogram.com/index.php?/topic/61834--/
 
 Curse Forge page: http://kerbal.curseforge.com/projects/kos-scriptable-autopilot-system?gameCategorySlug=ksp-mods&projectID=220265
 


### PR DESCRIPTION
Fixes #1841 
Added an extra `-` to the end of the ksp forum links as for some reason they need to have something after the first one to go to the thread instead of the forum home page.
The `-` can be swapped out for anything else I just thought that it looked neater.