### PR TITLE
Control Surfaces and Roll Control

### DIFF
--- a/doc/source/structures/misc/steeringmanager.rst
+++ b/doc/source/structures/misc/steeringmanager.rst
@@ -41,6 +41,7 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
     :attr:`YAWTS`                        :struct:`scalar` (s)      Settling time for the yaw torque calculation.
     :attr:`ROLLTS`                       :struct:`scalar` (s)      Settling time for the roll torque calculation.
     :attr:`MAXSTOPPINGTIME`              :struct:`scalar` (s)      The maximum amount of stopping time to limit angular turn rate.
+    :attr:`ROLLCONTROLANGLERANGE`        :struct:`scalar` (deg)    The maximum value of :attr:`ANGLEERROR` for which to control roll.
     :attr:`ANGLEERROR`                   :struct:`scalar` (deg)    The angle between vessel:facing and target directions
     :attr:`PITCHERROR`                   :struct:`scalar` (deg)    The angular error in the pitch direction
     :attr:`YAWERROR`                     :struct:`scalar` (deg)    The angular error in the yaw direction
@@ -168,6 +169,20 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
     .. note::
 
         This setting affects all three of the :ref:`rotational velocity PID's <cooked_omega_pid>` at once (pitch, yaw, and roll), rather than affecting the three axes individually one at a time.
+
+.. attribute:: SteeringManager:ROLLCONTROLANGLERANGE
+
+    :type: :ref:`scalar <scalar>` (deg)
+    :access: Get/Set
+
+    The maximum value of :attr:`ANGLEERROR<SteeringManager:ANGLEERROR>` for
+    which kOS will attempt to respond to error along the roll axis.  If this
+    is set to 5 (the default value), the facing direction will need to be within
+    5 degrees of the target direction before it actually attempts to roll the
+    ship.  Setting the value to 180 will effectivelly allow roll control at any
+    error amount.  When :attr:`ANGLEERROR<SteeringManager:ANGLEERROR>` is
+    greater than this value, kOS will only attempt to kill all roll angular
+    velocity.  The value is clamped between 180 and 1e-16.
 
 .. attribute:: SteeringManager:ANGLEERROR
 

--- a/src/kOS/Control/SteeringManager.cs
+++ b/src/kOS/Control/SteeringManager.cs
@@ -342,7 +342,7 @@ namespace kOS.Control
             AddSuffix("YAWTORQUEFACTOR", new SetSuffix<ScalarValue>(() => YawTorqueFactor, value => YawTorqueFactor = value));
             AddSuffix("ROLLTORQUEFACTOR", new SetSuffix<ScalarValue>(() => RollTorqueFactor, value => RollTorqueFactor = value));
             AddSuffix("AVERAGEDURATION", new Suffix<ScalarValue>(() => AverageDuration.Mean));
-            AddSuffix("ROLLCONTROLANGLERANGE", new Suffix<ScalarValue>(() => AverageDuration.Mean));
+            AddSuffix("ROLLCONTROLANGLERANGE", new SetSuffix<ScalarValue>(() => RollControlAngleRange, value => RollControlAngleRange = value));
 #if DEBUG
             AddSuffix("MOI", new Suffix<Vector>(() => new Vector(momentOfInertia)));
             AddSuffix("ACTUATION", new Suffix<Vector>(() => new Vector(accPitch, accRoll, accYaw)));

--- a/src/kOS/Control/SteeringManager.cs
+++ b/src/kOS/Control/SteeringManager.cs
@@ -595,7 +595,13 @@ namespace kOS.Control
             {
                 var tp = torqueProviders[pm];
                 tp.GetPotentialTorque(out pos, out neg);
-                rawTorque += pos;
+                // It is possible for the torque returned to be negative.  It's also possible
+                // for the positive and negative actuation to differ.  Below averages the value
+                // for positive and negative actuation in an attempt to compensate for some issues
+                // of differing signs and asymmetric torque.
+                rawTorque.x += (Math.Abs(pos.x) + Math.Abs(neg.x)) / 2;
+                rawTorque.y += (Math.Abs(pos.y) + Math.Abs(neg.y)) / 2;
+                rawTorque.z += (Math.Abs(pos.z) + Math.Abs(neg.z)) / 2;
             }
 
             rawTorque.x = (rawTorque.x + PitchTorqueAdjust) * PitchTorqueFactor;


### PR DESCRIPTION
Fixes #1852 

Rework the torque logic to average the positive and negative directions, using absolute values to make sure that the torque PI is fed good data.

Fixes #1777 

Add a new suffix `ROLLCONTROLANGLERANGE` which defines the `ANGLEERROR` at which the roll direction will be controlled.