### PR TITLE
Broken harddisk file load and gzip ksm files

### DIFF
--- a/src/kOS.Safe/Persistence/PersistenceUtilities.cs
+++ b/src/kOS.Safe/Persistence/PersistenceUtilities.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using ICSharpCode.SharpZipLib.GZip;
+using ICSharpCode.SharpZipLib.Zip.Compression;
 using kOS.Safe.Compilation;
 using kOS.Safe.Exceptions;
 using kOS.Safe.Utilities;
@@ -11,6 +12,7 @@ namespace kOS.Safe.Persistence
 {
     public static class PersistenceUtilities
     {
+        public static readonly byte[] GzipHeader = new byte[] { (GZipConstants.GZIP_MAGIC >> 8), (GZipConstants.GZIP_MAGIC & 0xff), Deflater.DEFLATED, 0 };
         public static bool IsBinary(FileCategory category)
         {
             return category == FileCategory.BINARY || category == FileCategory.KSM;
@@ -30,7 +32,7 @@ namespace kOS.Safe.Persistence
             Array.Copy(firstBytes, 0, firstFour, 0, atMostFour);
             var returnCat = atMostFour < 4 ? FileCategory.TOOSHORT : FileCategory.BINARY; // default if none of the conditions pass
 
-            if (firstFour.SequenceEqual(CompiledObject.MagicId))
+            if (firstFour.SequenceEqual(CompiledObject.MagicId) || firstFour.SequenceEqual(GzipHeader))
             {
                 returnCat = FileCategory.KSM;
             }
@@ -183,20 +185,24 @@ namespace kOS.Safe.Persistence
             byte[] inputBuffer = Convert.FromBase64String(massagedInput);
 
             using (var inputStream = new MemoryStream(inputBuffer))
+            {
                 // mono requires an installed zlib library for GZipStream to work :(
                 //using (var zipStream = new GZipStream(inputStream, CompressionMode.Decompress))
-            using (var zipStream = new GZipInputStream(inputStream))
-            using (var decompressedStream = new MemoryStream())
-            {
-                var buffer = new byte[4096];
-                int read;
-
-                while ((read = zipStream.Read(buffer, 0, buffer.Length)) > 0)
+                using (var zipStream = new GZipInputStream(inputStream))
                 {
-                    decompressedStream.Write(buffer, 0, read);
-                }
+                    using (var decompressedStream = new MemoryStream())
+                    {
+                        var buffer = new byte[4096];
+                        int read;
 
-                return decompressedStream.ToArray();
+                        while ((read = zipStream.Read(buffer, 0, buffer.Length)) > 0)
+                        {
+                            decompressedStream.Write(buffer, 0, read);
+                        }
+
+                        return decompressedStream.ToArray();
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #1857 

To fix the underlying problem, I modified the `Decode` method in `PersistenceExtensions.cs` to catch any `Exception` type, which should prevent a failed decode from destroying a valid text file, and protect the loading of other files.  But to fix the issue where we're using an exception to determine valid state I needed to modify how files are stored in the save file.  For the sake of backwards compatibility, the current node key of "line" remains valid for loading and we will load any node containing a "line" essentially the same way we do now, with the above fix.  But when saving files the code now uses keys of "ascii" and "binary" based on the type of data being stored.  This way the decoding logic is able to determine if the file needs to be Base64 decoded and decompressed without needing to try to perform either operation.

If "Use Compressed Persistence" is enabled, ASCII files are still saved using the gzip compression but they get saved using the "binary" key instead.  Because the actual `FileContent` object is agnostic of the data it contains (the "category" is determined based on the actual byte content at any given time) we don't need any special handling when dealing with zipped ASCII data, it simply is unzipped and passed into the constructor.

As an added bonus, I figured out that we can add gzip compression directly to ksm files for a very noticable space savings without changing anything in the format itself.  Since I was looking at it, I fixed that at the same time.