### PR TITLE
Fix #1866: Permit read locks on archive file write

### DIFF
--- a/src/kOS.Safe/Persistence/ArchiveFile.cs
+++ b/src/kOS.Safe/Persistence/ArchiveFile.cs
@@ -33,7 +33,7 @@ namespace kOS.Safe.Persistence
             }
 
             byte[] bytes = Archive.ConvertToWindowsNewlines(content);
-            using (FileStream stream = fileInfo.Open(FileMode.Append, FileAccess.Write))
+            using (FileStream stream = fileInfo.Open(FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
             {
                 stream.Write(bytes, 0, bytes.Length);
                 stream.Flush();


### PR DESCRIPTION
Prevents C# from insisting on a write-only lock when writing to the file
system. This means external programs (a simple `tail -f $FILE` for example) can
receive data from a running kOS program without causing errors.