### PR TITLE
Issue 1869 duplicate fuctions break ksm

### DIFF
--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -537,7 +537,7 @@ namespace kOS.Safe.Compilation.KS
         private string ConcatenateNodes(ParseNode node)
         {
             LineCol whereNodeIs = GetLineCol(node);
-            return string.Format("{0}{1}{2}{3}{4}",
+            return string.Format("{0}L{1}C{2}{3}{4}",
                                  context.NumCompilesSoFar,
                                  whereNodeIs.Line,
                                  whereNodeIs.Column,

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -536,7 +536,13 @@ namespace kOS.Safe.Compilation.KS
         /// </summary>
         private string ConcatenateNodes(ParseNode node)
         {
-            return string.Format("{0}{1}{2}", context.NumCompilesSoFar, GetContainingScopeId(node), ConcatenateNodesRecurse(node));
+            LineCol whereNodeIs = GetLineCol(node);
+            return string.Format("{0}{1}{2}{3}{4}",
+                                 context.NumCompilesSoFar,
+                                 whereNodeIs.Line,
+                                 whereNodeIs.Column,
+                                 GetContainingScopeId(node),
+                                 ConcatenateNodesRecurse(node));
         }
         
         private string ConcatenateNodesRecurse(ParseNode node)


### PR DESCRIPTION
Fixes #1869 : Added line/col to the string that gets hashed to determine a function's identifying hash code.  This makes it so if the same body appears in two places it won't quite be the same hash.

One small downside is that previously if you had said `lock throttle to 0.` in two places *in the same scope*, they'd have only made 1 actual function for it and it would do double-duty for both of them.  This optimization had to go away to fix this bug - now there will still be 2 redundant instances in that case.

In fact, I'm now beginning to wonder if we shouldn't do a refactor later that just completely removes the hash system altogether.  The entire point of it was to deliberately quash two instances of the same function body together for efficiency.  If we removed that, then why use the hash?  But that's something I can look at later - it does work with this PR as-is.