### PR TITLE
Fixes #1873 : Seems to be working.

### DIFF
--- a/doc/source/math/geocoordinates.rst
+++ b/doc/source/math/geocoordinates.rst
@@ -70,6 +70,14 @@ Structure
           - `Vector` (3D Ship-Raw coords)
 	  - :ref:`scalar <scalar>` (altitude above sea level)
           - Position of a point above (or below) the surface point, by giving the altitude number.
+        * - :attr:`VELOCITY`
+          - :struct:`OrbitableVelocity`
+	  - none
+          - Velocity of the surface at this point (due to the rotation of the planet/moon).
+        * - :attr:`ALTITUDEVELOCITY`
+          - :struct:`OrbitableVelocity`
+	  - :ref:`scalar <scalar>` (altitude above sea level)
+          - Velocity of a point above (or below) the surface point, by giving the altitude number.
 
 .. note::
 
@@ -106,6 +114,29 @@ Structure
 .. attribute:: GeoCoordinates:ALTITUDEPOSITION (altitude)
 
     The ship-raw 3D position above or below the surface of the body, relative to the current ship's Center of mass.  You pass in an altitude number for the altitude above "sea" level of the desired location.
+
+.. attribute:: GeoCoordinates:VELOCITY
+
+    The (linear) velocity of this spot on the surface of the planet/moon, due to the rotation of the
+    body causing that spot to move though space.
+    (For example, on Kerbin at a sea level location, it would be 174.95 m/s eastward, and slightly
+    more at higher terrain spots above sea level.)
+    Note that this is returned as an :struct:`OrbitableVelocity`, meaning it isn't a vector but a
+    pair of vectors, one called ``:orbit`` and one called ``:surface``.  Note that the
+    surface-relative velocity you get from the ``:surface`` suffix isn't always zero like you might
+    intuit because ``:surface`` gives you the velocity relative to the surface reference frame
+    where ``SHIP`` is, which might not be the same latitude/longitude/altitude as where this
+    Geocoordinates is.
+
+.. attribute:: GeoCoordinates:ALTITUDEVELOCITY (altitude)
+
+    This is the same as :attr:`GeoCoordinates:VELOCITY`, except that it lets you specify some
+    altitude other than the surface terrain height.  You specify a (sea-level) altitude,
+    and it will calculate based on a point at that altitude which may be above or below
+    the actual surface at this latitude and longitude.  It will calculate as if you had some
+    point fixed to the ground, like an imaginary tower bolted to the surface, but not at the
+    ground's altitude.  (The body's rotation will impart a larger magnitude linear velocity
+    on a locaton affixed to the body the farther that location is from the body's center).
 
 Example Usage
 -------------

--- a/src/kOS/Suffixed/GeoCoordinates.cs
+++ b/src/kOS/Suffixed/GeoCoordinates.cs
@@ -229,6 +229,32 @@ namespace kOS.Suffixed
             Vector3d hereCoords = Shared.Vessel.CoMD;
             return new Vector(latLongCoords - hereCoords);
         }
+        
+        /// <summary>
+        ///   The pair of velocities representing this spot's velocity due to
+        ///   planetary rotation.
+        /// </summary>
+        /// <returns>velocities pair</returns>
+        public OrbitableVelocity GetVelocities()
+        {
+            return GetAltitudeVelocities(GetTerrainAltitude());
+        }
+
+        /// <summary>
+        ///   The pair of velocities representing this spot's velocity due to
+        ///   planetary rotation, at this (sea level) altitude:
+        /// </summary>
+        /// <returns>velocities pair </returns>
+        public OrbitableVelocity GetAltitudeVelocities(ScalarValue altitude)
+        {
+            Vector3d pos = Body.GetWorldSurfacePosition(Latitude, Longitude, altitude);
+            Vector3d vel = Body.getRFrmVel(pos);
+            CelestialBody shipBody = Shared.Vessel.orbit.referenceBody;
+            if (shipBody == null)
+                return new OrbitableVelocity(new Vector(vel), new Vector(vel));
+            Vector3d srfVel = vel - shipBody.getRFrmVel(Shared.Vessel.CoMD);
+            return new OrbitableVelocity(new Vector(vel), new Vector(srfVel));
+        }
 
         private void GeoCoordsInitializeSuffixes()
         {
@@ -242,9 +268,15 @@ namespace kOS.Suffixed
             AddSuffix("POSITION", new Suffix<Vector>(GetPosition,
                                                      "Get the 3-D space position relative to the ship center, of this lat/long, " +
                                                      "at a point on the terrain surface"));
+            AddSuffix("VELOCITY", new Suffix<OrbitableVelocity>(GetVelocities,
+                                                     "Get the 3-D velocity vectors pair (surface and orbit) at a point on the terrain surface. " +
+                                                     "This is the movement of that spot on the ground due to planetary rotation."));
             AddSuffix("ALTITUDEPOSITION", new OneArgsSuffix<Vector,ScalarValue>(GetAltitudePosition,
                                                                            "Get the 3-D space position relative to the ship center, " +
                                                                            "of this lat/long, at this (sea level) altitude"));
+            AddSuffix("ALTITUDEVELOCITY", new OneArgsSuffix<OrbitableVelocity,ScalarValue>(GetAltitudeVelocities,
+                                                     "Get the 3-D velocity vectors pair (surface and orbit) of this lat/lont at this (sea level) altitude. " +
+                                                     "This is the movement of that spot due to planetary rotation."));
         }
 
         public override string ToString()


### PR DESCRIPTION
Test case examples:

```
// Should (if on kerbin near KSC) draw a white vector straight east
// at magnitude 174.94 m :
set vd1 to vecdraw(
  v(0,0,0),
  ship:geoposition:velocity:orbit,
  white,"velocity here",1,true).

// Should (if on kerbin near KSC) draw a nearly zero vector because
// surface-relative velocity of the ground right under me is negligable:
set vd1_s to vecdraw(
  v(0,0,0),
  ship:geoposition:velocity:surface,
  white,"srf velocity here",1,true).

// Should (if on kerbin near KSC) draw a surface vector like vd1 above,
// but longer in length because it's the rotational effect with a radius
// that's 200,000m bigger:
set vd2 to vecdraw(
  v(0,0,0),
  ship:geoposition:altitudevelocity(200000):orbit,
  green,"geoposition velocity higher up above me",1,true).

// Should (if on kerbin near KSC) draw a vector angled upward by
// 30 degreees because it's the velocity of the ground 30 longitude
// degrees west of the current position:
set vd3 to vecdraw(
  v(0,0,0),
  latlng(ship:latitude, ship:longitude-30),
  red,"velocity 30 degrees west of here",1,true).

// Should (if on kerbin near KSC) draw a vector angled upward by
// 30 degreees like above,  but this time it should be a much
// shorter vector because it's how fast the surface of the
// planet is moving much higher north, near the pole:
set vd4 to vecdraw(
  v(0,0,0),
  latlng(ship:latitude-80, ship:longitude-30),
  yellow,"velocity 30 deg west and 80 deg north of here",1,true).
```

Fixes #1873