### PR TITLE
Issue 1890 trigger unlock error

### DIFF
--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -568,7 +568,8 @@ namespace kOS.Safe.Compilation.KS
             ParseNode bodyNode;
             
             ParseNode lastSubNode = node.Nodes[node.Nodes.Count-1];
-            if (IsLockStatement(node))
+            bool isLock = IsLockStatement(node);
+            if (isLock)
             {
                 funcIdentifier = lastSubNode.Nodes[1].Token.Text;
                 bodyNode = lastSubNode.Nodes[3];
@@ -585,6 +586,7 @@ namespace kOS.Safe.Compilation.KS
                 context.UserFunctions.GetUserFunction(funcIdentifier, storageType == StorageModifier.GLOBAL ? (Int16)0 : GetContainingScopeId(node), node);
             int expressionHash = ConcatenateNodes(bodyNode).GetHashCode();
             userFuncObject.GetUserFunctionOpcodes(expressionHash);
+            userFuncObject.IsFunction = !isLock;
             if (userFuncObject.IsSystemLock())
                 BuildSystemTrigger(userFuncObject);
         }

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -694,7 +694,7 @@ namespace kOS.Safe.Compilation.KS
                 bodyNode = lastSubNode.Nodes[2]; // The INSTRUCTION_BLOCK of: DEFINE FUNCTION IDENT INSTRUCTION_BLOCK.
             }
             else
-                return; // In principle this shouldn't have ever been called in this case.
+                return; // Should only be the case when scanning elements for anonymous functions
 
             UserFunction userFuncObject = context.UserFunctions.GetUserFunction(
                 userFuncIdentifier,

--- a/src/kOS.Safe/Compilation/ProgramBuilder.cs
+++ b/src/kOS.Safe/Compilation/ProgramBuilder.cs
@@ -257,6 +257,15 @@ namespace kOS.Safe.Compilation
                 Opcode opcode = program[index];
                 if (string.IsNullOrEmpty(opcode.DestinationLabel)) continue;
 
+                if (!labels.ContainsKey(opcode.DestinationLabel))
+                {
+                    Utilities.SafeHouse.Logger.LogError("=====Relabeled Program so far is: =========");
+                    Utilities.SafeHouse.Logger.LogError(Utilities.Debug.GetCodeFragment(program));
+
+                    throw new Exceptions.KOSCompileException(LineCol.Unknown(), string.Format(
+                        "ProgramBuilder.ReplaceLabels: Cannot find label {0}.  Opcode: {1}", opcode.DestinationLabel, opcode.ToString()));
+
+                }
                 int destinationIndex = labels[opcode.DestinationLabel];
                 if (opcode is BranchOpcode)
                 {


### PR DESCRIPTION
Fixe #1890

Set the `IsFunction` flag during `IdentifyUserFunctions` to prevent errors when ulocking inside of triggers.  This is because the trigger code will Visit nodes during preprocessing before the flag is set via function pre-processing.