### PR TITLE
Fix activeresource:parts

### DIFF
--- a/doc/source/structures/vessels/stage.rst
+++ b/doc/source/structures/vessels/stage.rst
@@ -96,11 +96,11 @@ Stage Structure
         * - :attr:`RESOURCES`
           - :struct:`List`
           - Get only
-          - the :struct:`List` of :struct:`Resource` in the current stage
+          - the :struct:`List` of :struct:`AggregateResource` in the current stage
         * - :attr:`RESOURCESLEX`
           - :struct:`Lexicon`
           - Get only
-          - the :struct:`Lexicon` of name :struct:`String` keyed :struct:`Resource` values in the current stage
+          - the :struct:`Lexicon` of name :struct:`String` keyed :struct:`AggregateResource` values in the current stage
 
 .. attribute:: Stage:READY
 
@@ -121,7 +121,7 @@ Stage Structure
     :access: Get
     :type: :struct:`List`
 
-    This is a collection of the available :struct:`Resource` for the current stage.
+    This is a collection of the available :struct:`AggregateResource` for the current stage.
 
 .. attribute:: Stage:Resourceslex
 
@@ -130,6 +130,6 @@ Stage Structure
 
     This is a dictionary style collection of the available :struct:`Resource`
     for the current stage.  The :struct:`String` key in the lexicon will match
-    the name suffix on the :struct:`Resource`.  This suffix walks the parts
+    the name suffix on the :struct:`AggregateResource`.  This suffix walks the parts
     list entirely on every call, so it is recommended that you cache the value
     if it will be reference repeatedly.

--- a/src/kOS/Binding/FlightStats.cs
+++ b/src/kOS/Binding/FlightStats.cs
@@ -14,6 +14,8 @@ namespace kOS.Binding
     [Binding("ksp")]
     public class FlightStats : Binding
     {
+        private StageValues stageValue;
+
         public override void AddTo(SharedObjects shared)
         {
             shared.BindingMgr.AddGetter("ALT", () => new VesselAlt(shared));
@@ -26,7 +28,7 @@ namespace kOS.Binding
             shared.BindingMgr.AddGetter("SHIP", () => new VesselTarget(shared));
             shared.BindingMgr.AddGetter("ACTIVESHIP", () => new VesselTarget(FlightGlobals.ActiveVessel, shared));
             shared.BindingMgr.AddGetter("STATUS", () => shared.Vessel.situation.ToString());
-            shared.BindingMgr.AddGetter("STAGE", () => new StageValues(shared));
+            shared.BindingMgr.AddGetter("STAGE", () => stageValue ?? (stageValue = new StageValues(shared)));
 
             shared.BindingMgr.AddSetter("SHIPNAME", value => shared.Vessel.vesselName = value.ToString());
 

--- a/src/kOS/Suffixed/AggregateResourceValue.cs
+++ b/src/kOS/Suffixed/AggregateResourceValue.cs
@@ -10,7 +10,7 @@ namespace kOS.Suffixed
     public class AggregateResourceValue : Structure
     {
         private readonly string name;
-        private readonly SharedObjects shared;
+        protected readonly SharedObjects shared;
         private readonly float density;
         private readonly List<PartResource> resources;
 
@@ -25,25 +25,34 @@ namespace kOS.Suffixed
 
         private void InitializeAggregateResourceSuffixes()
         {
-            AddSuffix("NAME", new Suffix<StringValue>(() => name, "The name of the resource (eg LiguidFuel, ElectricCharge)"));
-            AddSuffix("DENSITY", new Suffix<ScalarValue>(() => density, "The density of the resource"));
+            AddSuffix("NAME", new Suffix<StringValue>(GetName, "The name of the resource (eg LiguidFuel, ElectricCharge)"));
+            AddSuffix("DENSITY", new Suffix<ScalarValue>(GetDensity, "The density of the resource"));
             AddSuffix("AMOUNT", new Suffix<ScalarValue>(GetAmount, "The resources currently available"));
             AddSuffix("CAPACITY", new Suffix<ScalarValue>(GetCapacity, "The total storage capacity currently available"));
-            AddSuffix("PARTS", new Suffix<ListValue<PartValue>>(GetParts, "The containers for this resource"));
+            AddSuffix("PARTS", new Suffix<ListValue>(GetParts, "The containers for this resource"));
         }
 
-        private ListValue<PartValue> GetParts()
+        public virtual StringValue GetName()
         {
-            var parts = PartValueFactory.Construct(resources.Select(r => r.part), shared);
-            return ListValue<PartValue>.CreateList(parts);
+            return name;
         }
 
-        private ScalarValue GetCapacity()
+        public ScalarValue GetDensity()
+        {
+            return density;
+        }
+
+        public virtual ListValue GetParts()
+        {
+            return PartValueFactory.Construct(resources.Select(r => r.part), shared);
+        }
+
+        public virtual ScalarValue GetCapacity()
         {
             return resources.Sum(r => r.maxAmount);
         }
 
-        private ScalarValue GetAmount()
+        public virtual ScalarValue GetAmount()
         {
             return resources.Sum(r => r.amount);
         }


### PR DESCRIPTION
Fixes #1835

ActiveResourcesValue.cs
* Update so that it inherits from AggregateResourceValue.
* Override the GetParts, GetAmount, and GetCapacity methods
* Tie in to StageValue hooks

AggregateResourceValue.cs
* Add virtual methods
* Switch to normal ListValue for return of PARTS

StageValue.cs
* Cache the resource list and lexicon
* Add timeout check for CreatePartSet

FlightStats.cs
* Cache the value of STAGE

stage.rst
* Update docs to refer to Aggregate resources when talking about stage
objects.

Should also fix #1840 
By making Active inherit from Aggregate, this should also fix #1633 