### PR TITLE
Fixes #1926 - wave init for voices 6 through 9.

### DIFF
--- a/src/kOS/Sound/SoundMaker.cs
+++ b/src/kOS/Sound/SoundMaker.cs
@@ -110,7 +110,7 @@ namespace kOS.Sound
         {
             if (! waveGenerators.ContainsKey(waveName))
                 return false;
-            if (num < 0 || num > waveGenerators.Count)
+            if (num < 0 || num >= voices.Length)
                 return false;
 
             voices[num].SetWave(waveGenerators[waveName]);


### PR DESCRIPTION
The problem was caused by SoundMaker.SetWave().

It contained a protection check to try to prevent us from using
it to set a voice index number that doesn't exist.  (i.e.
trying to call SetWave(11,"sine"), when there is no such thing
as voice 11).

The problem is that the check it was performing was comparing
the index to how many WAVEFORMS were defined, instead of
how many VOICES were.  So because there are 5 defined waveforms,
but 10 defined voices, it refused to operate on voices 6,7,8,9.