### PR TITLE
Fixed math in VECTORANGLE docs

### DIFF
--- a/doc/source/math/vector.rst
+++ b/doc/source/math/vector.rst
@@ -259,13 +259,13 @@ Method / Operator                                                         Return
             \frac{
                 \vec{v_1}\cdot\vec{v_2}
             }{
-                \left|\vec{v_1}\cdot\vec{v_2}\right|
+                \left|\vec{v_1}\right|\cdot\left|\vec{v_2}\right|
             }
         \right)
 
     or in **KerboScript**::
 
-        arccos( (VDOT(v1,v2) / VDOT(v1,v2):MAG ) )
+        arccos( (VDOT(v1,v2) / (v1:MAG * v2:MAG) ) )
 
 .. function:: VXCL(v1,v2)
 


### PR DESCRIPTION
The divisor in the equation should be the products of the vectors' magnitudes, not the magnitude of the dot product of the vectors (which is a meaningless statement anyways). The division is done to normalize the vectors.

I built the changes on my own machine using the instructions on [the Contribute page](http://ksp-kos.github.io/KOS_DOC/contribute.html#how-to-edit-this-documentation) and verified that they built properly and looked fine.