### PR TITLE
Enable ignoring locks for target set

### DIFF
--- a/src/kOS/Utilities/VesselUtils.cs
+++ b/src/kOS/Utilities/VesselUtils.cs
@@ -151,12 +151,12 @@ namespace kOS.Utilities
 
         public static void SetTarget(ITargetable val, Vessel currentVessel)
         {
-            if (val is Vessel && val == currentVessel)
-                throw new kOS.Safe.Exceptions.KOSInvalidTargetException("A ship cannot set TARGET to itself.");
-            else if (val is ITargetable && ((ITargetable)val).GetVessel() == currentVessel)
-                throw new kOS.Safe.Exceptions.KOSInvalidTargetException("A ship cannot set TARGET to a part of itself.");
-            
-            FlightGlobals.fetch.SetVesselTarget(val);
+            if (val is Vessel && (Vessel)val == currentVessel)
+                throw new Safe.Exceptions.KOSInvalidTargetException("A ship cannot set TARGET to itself.");
+            else if (val.GetVessel() == currentVessel)
+                throw new Safe.Exceptions.KOSInvalidTargetException("A ship cannot set TARGET to a part of itself.");
+
+            FlightGlobals.fetch.SetVesselTarget(val, true);
         }
 
         public static float AngleDelta(float a, float b)


### PR DESCRIPTION
Fixes #1931

VesselUtils.cs
* Update SetTarget method to use optional parameter to ignore locks
* Fixes setting the target from script if the window is not focused, or
if another control lock is active.