### PR TITLE
Remove some empty functions in VesselModule

### DIFF
--- a/src/kOS/Module/kOSVesselModule.cs
+++ b/src/kOS/Module/kOSVesselModule.cs
@@ -149,24 +149,24 @@ namespace kOS.Module
         /// <summary>
         /// Update is called once per UI tick.
         /// </summary>
-        public void Update()
-        {
-        }
+        //public void Update()
+        //{
+        //}
 
         /// <summary>
         /// LastUpdate is called at the end of the update frame.  Useful if something needs to be
         /// done after the physics and UI updates have been completed, but before scene or gui rendering.
         /// </summary>
-        public void LastUpdate()
-        {
-        }
+        //public void LastUpdate()
+        //{
+        //}
 
         /// <summary>
         /// OnGUI is where any vessel specific interface rendering should be done.
         /// </summary>
-        public void OnGUI()
-        {
-        }
+        //public void OnGUI()
+        //{
+        //}
         #endregion
 
         /// <summary>


### PR DESCRIPTION
This greatly reduces garbage creation, as even an empty OnGUI() is causing 384 kB of garbage every time it's called, and VesselModules are active for every vessel in the game (also those that are not loaded, see
http://forum.kerbalspaceprogram.com/index.php?/topic/156959-vessel-modules-seem-to-run-for-inactive-vessels-now/
With this simple change I got rid of about 50 kB garbage per frame in my current save game.