### PR TITLE
Choose ip addr

### DIFF
--- a/doc/source/general/telnet.rst
+++ b/doc/source/general/telnet.rst
@@ -76,8 +76,8 @@ Using it
 2. The very first time you do this, you will get a warning message, as per
    `SQUAD's rule number 5 about mods that run network services <http://forum.kerbalspaceprogram.com/threads/87843-Forum-Rules-Add-on-Posting-Rules-August-21st-2014>`_. 
    After accepting and clicking "yes", the server will be running on loopback 
-   127.0.0.1 (if you want to make it run on the non-loopback address, you will
-   get a secondary warning message about that too.
+   127.0.0.1 (if you want to make it run on a non-loopback address, you will
+   get a secondary warning message about that too.)
 
 3. Launch your telnet client (there is a list of telnet clients that are known
    to work listed below.
@@ -309,8 +309,8 @@ even implementing a name and password for connecting to the kOS telnet server.
 The purpose is to make it clear that if you want to open up your kOS telnet
 server, you need to be careful about how you do it.
 
-The default settings that kOS ships with restricts your kOS telnet server to
-only operating on the loopback address (127.0.0.1) so that you won't accidentally
+The default settings that kOS ships with sets your kOS telnet server to
+operate on the loopback address (127.0.0.1) so that you won't accidentally
 open anything up to the public without thinking about it and making a conscious
 decision to do so.  If you don't know what that means, it means this:
 Any server that runs on the magic special address 127.0.0.1, known as "loopback",
@@ -319,7 +319,7 @@ is incapable of taking connections from other computers besides itself.
 In order to allow your kOS telnet server to take connections from other 
 computers, you will typically need to do one of two things:
 
-Either turn off the CONFIG:LOOPBACK option in your kOS install and then
+Either set the CONFIG:IPADDRESS option to the address of your computer and then
 restart your telnet server (turn it off and on again using the button on the 
 control panel), or (much better), set up a remote ssh tunnel that will map
 from your current machine's loopback address on the port number of your server to
@@ -337,7 +337,7 @@ end up talking to your machine's port 5410 on its loopback address.
 
 **Port forwarding**
 
-If you opt to turn off the loopback-only mode on your kOS telnet server, then you
+If you opt to use a non-loopback address on your kOS telnet server, then you
 will probably also, if you have a typical home network setup, need to enable
 port forwarding on your router if you want people from outside your house to 
 connect to it.  (Again, think about the implications of doing so before you do it).

--- a/doc/source/structures/misc/config.rst
+++ b/doc/source/structures/misc/config.rst
@@ -92,10 +92,10 @@ Configuration of kOS
           - :struct:`Scalar` (integer)
           - 5410
           - set the port the telnet server will run on
-        * - :attr:`LOOPBACK`
-          - :struct:`Boolean`
-          - True
-          - Force the telnet server to use loopback (127.0.0.1) address
+        * - :attr:`IPADDRESS`
+          - :struct:`String`
+          - "127.0.0.1"
+          - The IP address the telnet server will try to use.
         * - :attr:`BRIGHTNESS`
           - :struct:`Scalar`
           - 0.7 (from range [0.0 .. 1.0])
@@ -258,21 +258,22 @@ Configuration of kOS
     To make the change take effect you may have to
     stop, then restart the telnet server, as described above.
 
-.. attribute:: Config:LOOPBACK
+.. attribute:: Config:IPADDRESS
 
     :access: Get/Set
-    :type: :struct:`Boolean`
+    :type: :struct:`String`
 
     **GLOBAL SETTING**
 
-    Configures the ``TelnetLoopback`` setting.
+    Configures the ``TelnetIPAddrString`` setting.
 
-    If true, then it tells the
-    `kOS telnet server in game <../../general/telnet.html>`__
-    to refuse to use the computer's actual IP address, and
-    instead use the loopback address (127.0.0.1).  This is
-    the default mode the kOS mod ships in, in order to
-    make it impossible get external access to your computer.
+    This is the IP address the telnet server will attempt to use when
+    it is enabled.  By default it will use the loopback address of
+    "127.0.0.1" unless you change this setting to the computer's
+    actual IP address.  Because most modern PC's have multiple IP
+    addresses, no attempt is made by kOS to guess which of them is "the"
+    right one.  You must tell kOS which one to use if you don't want it
+    to use the loopback address.
 
     To make the change take effect you may have to
     stop, then restart the telnet server, as described above.

--- a/src/kOS.Safe/Encapsulation/IConfig.cs
+++ b/src/kOS.Safe/Encapsulation/IConfig.cs
@@ -16,7 +16,7 @@ namespace kOS.Safe.Encapsulation
         bool EnableTelnet { get; set; }
         int TelnetPort { get; set; }
         bool AudibleExceptions { get; set; }
-        bool TelnetLoopback { get; set; }
+        string TelnetIPAddrString { get; set; }
         bool UseBlizzyToolbarOnly { get; set; }
         int TerminalFontDefaultSize {get; set; }
         string TerminalFontName {get; set; }

--- a/src/kOS/Screen/KOSToolbarWindow.cs
+++ b/src/kOS/Screen/KOSToolbarWindow.cs
@@ -560,9 +560,9 @@ namespace kOS.Screen
 
                     kOS.Screen.ListPickerDialog.CloseAction onClose = delegate() { ipAddrPicker = null; };
 
-                    ipAddrPicker.Summon(windowRect.x, windowRect.y + windowRect.height, 250,
-                        "Telnet address (restart telnet to take effect)\n",
-                        "current selection: ", key.Value.ToString(), TelnetMainServer.GetAllAddresses(), onChange, onClose
+                    ipAddrPicker.Summon(windowRect.x, windowRect.y + windowRect.height, 300,
+                        "Telnet address (restart telnet to take effect)\n", null, 
+                        "current: " + key.Value.ToString(), TelnetMainServer.GetAllAddresses(), onChange, onClose
                     );
                 }
                 else

--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -1031,6 +1031,7 @@ namespace kOS.Screen
         {
             server.DisconnectFromProcessor();
             telnets.Remove(server);
+            prevTelnetScreens.Remove(server);
         }
         
         public void DetachAllTelnets()

--- a/src/kOS/Suffixed/Config.cs
+++ b/src/kOS/Suffixed/Config.cs
@@ -26,7 +26,7 @@ namespace kOS.Suffixed
         public bool VerboseExceptions { get { return kOSCustomParameters.Instance.verboseExceptions; } set { kOSCustomParameters.Instance.verboseExceptions = value; } }
         public bool EnableTelnet { get { return GetPropValue<bool>(PropId.EnableTelnet); } set { SetPropValue(PropId.EnableTelnet, value); } }
         public int TelnetPort { get { return GetPropValue<int>(PropId.TelnetPort); } set { SetPropValue(PropId.TelnetPort, value); } }
-        public bool TelnetLoopback { get { return GetPropValue<bool>(PropId.TelnetLoopback); } set { SetPropValue(PropId.TelnetLoopback, value); } }        
+        public string TelnetIPAddrString { get { return GetPropValue<string>(PropId.TelnetIPAddrString); } set { SetPropValue(PropId.TelnetIPAddrString, value); } }        
         public int TerminalFontDefaultSize {get { return GetPropValue<int>(PropId.TerminalFontDefaultSize); } set { SetPropValue(PropId.TerminalFontDefaultSize, value); } }
         public string TerminalFontName {get { return GetPropValue<string>(PropId.TerminalFontName); } set { SetPropValue(PropId.TerminalFontName, value); } }
         public bool UseBlizzyToolbarOnly { get { return kOSCustomParameters.Instance.useBlizzyToolbarOnly; } set { kOSCustomParameters.Instance.useBlizzyToolbarOnly = value; } }
@@ -63,7 +63,7 @@ namespace kOS.Suffixed
         {
             AddConfigKey(PropId.EnableTelnet, new ConfigKey("EnableTelnet", "TELNET", "Enable Telnet server", false, false, true, typeof(bool)));
             AddConfigKey(PropId.TelnetPort, new ConfigKey("TelnetPort", "TPORT", "Telnet port number (must restart telnet to take effect)", 5410, 1024, 65535, typeof(int)));
-            AddConfigKey(PropId.TelnetLoopback, new ConfigKey("TelnetLoopback", "LOOPBACK", "Restricts telnet to 127.0.0.1 (must restart telnet to take effect)", true, false, true, typeof(bool)));
+            AddConfigKey(PropId.TelnetIPAddrString, new ConfigKey("TelnetIPAddrString", "IPADDRESS", "Telnet IP address string (must restart telnet to take effect)", "127.0.0.1", "n/a", "n/a", typeof(string)));
             AddConfigKey(PropId.TerminalFontDefaultSize, new ConfigKey("TerminalFontDefaultSize", "DEFAULTFONTSIZE", "Initial Terminal:CHARHEIGHT when a terminal is first opened", 12, 6, 20, typeof(int)));
             AddConfigKey(PropId.TerminalFontName, new ConfigKey("TerminalFontName", "FONTNAME", "Font Name for terminal window", "Courier New Bold", "n/a", "n/a", typeof(string)));
             AddConfigKey(PropId.TerminalBrightness, new ConfigKey("TerminalBrightness", "BRIGHTNESS", "Initial brightness setting for new terminals", 0.7f, 0f, 1f, typeof(float)));
@@ -215,7 +215,7 @@ namespace kOS.Suffixed
             VerboseExceptions = 9,
             EnableTelnet = 10,
             TelnetPort = 11,
-            TelnetLoopback = 12,
+            TelnetIPAddrString = 12,
             UseBlizzyToolbarOnly = 13,
             DebugEachOpcode = 14,
             TerminalFontDefaultSize = 15,

--- a/src/kOS/UserIO/TelnetSingletonServer.cs
+++ b/src/kOS/UserIO/TelnetSingletonServer.cs
@@ -170,13 +170,24 @@ namespace kOS.UserIO
             rawStream = client.GetStream();
             lock (keepAliveAccess)
                 gotSomeRecentTraffic = true;
-            inThread = new Thread(DoInThread);
-            outThread = new Thread(DoOutThread);
             outQueue = new Queue<char>();
             inQueue = new Queue<char>();
+            SpawnWelcomeMenu();
+            inThread = new Thread(DoInThread);
+            outThread = new Thread(DoOutThread);
             ClientWidth = 80; // common default for a lot of terminal progs.  Will allow resize via RFC1073.
             ClientHeight = 24; // common default for a lot of terminal progs.  Will allow resize via RFC1073.
             ClientTerminalType = "INITIAL_UNSET"; // will be set by telnet client as described by RFC 1091
+        }
+
+        ~TelnetSingletonServer()
+        {
+            if (welcomeMenu != null)
+            {
+                welcomeMenu.Detach();
+                GameObject.Destroy(welcomeMenu);
+                welcomeMenu = null;
+            }
         }
 
         /// <summary>
@@ -206,6 +217,12 @@ namespace kOS.UserIO
                 // That can cause subsequent reconnections from the TelnetWelcomeMenu to end up connecting you to the now dead CPU, with confusing results:
                 ConnectedProcessor = null;
                 alreadyDisconnecting = false;
+
+                // Disconnecting the CPU from this, so connect the welcome menu instead
+                if (welcomeMenu != null)
+                {
+                    welcomeMenu.Attach(this);
+                }
             }
         }
 
@@ -539,6 +556,7 @@ namespace kOS.UserIO
                 ContinuousChecks();
 
                 sb.Remove(0,sb.Length); // clear the whole thing.
+                Console.WriteLine("outThread, before lock section");
                 lock(outQueueAccess) // all access to inQueue and outQueue needs to be atomic.
                 {
                     while (outQueue.Count > 0)
@@ -547,8 +565,10 @@ namespace kOS.UserIO
                         sb.Append(ch);
                     }
                 }
+                Console.WriteLine("outThread, after lock section");
                 if (sb.Length > 0)
                 {
+                    Console.WriteLine("outThread, saw some text.");
                     sleepTime = 0; // Saw at least one char, so reset the sleep-slowdown.
                     string content = sb.ToString(); // instead of calling ToString() over and over.
                     if (terminalMapper == null)
@@ -561,6 +581,7 @@ namespace kOS.UserIO
                 }
                 else
                 {
+                    Console.WriteLine("outThread, sleeping a bit.");
                     Thread.Sleep(sleepTime);
                     if (sleepTime < SLEEP_TIME_MAX)
                         sleepTime += SLEEP_TIME_INC;
@@ -577,25 +598,20 @@ namespace kOS.UserIO
                 StopListening();                    
             }
             
-            if (welcomeMenu == null)
+            if (! welcomeMenu.IsAttached)
             {
                 if (ConnectedProcessor == null)
-                    SpawnWelcomeMenu();
+                    welcomeMenu.Attach(this);
             }
             else if (ConnectedProcessor != null) // welcome menu is attached but we now have a processor picked, so detach it.
             {
-                welcomeMenu.enabled = false; // turn it off so it stops trying to read the input in its Update().
                 welcomeMenu.Detach();
-                welcomeMenu = null ; // let it get garbage collected.  Now it's the ConnectedProcessor's turn to do the work.
-                // If ConnectedProcessor gets disconnected again, a new welcomeMenu instance should get spawned by the check above.
             }
         }
         
         /// <summary>
         /// When the telnet client connects but is not associated with a particular kOSProcessor at the moment,
-        /// this will attach the welcome menu to it instead of having it attached to a kOSProcessor.  This should
-        /// occur BOTH when the telnet client first connects, and whenever it detaches from a kOSProcessor.
-        /// (It should go back to this menu, rather than get disconnected).
+        /// this will attach the welcome menu to it instead of having it attached to a kOSProcessor.
         /// <br/>
         /// The purpose of the welcome menu is to let the user pick which kOSProcessor to attach to.
         /// </summary>
@@ -604,7 +620,7 @@ namespace kOS.UserIO
             var gObj = new GameObject( "TelnetWelcomeMenu_" + MySpawnOrder, typeof(TelnetWelcomeMenu) );
             Object.DontDestroyOnLoad(gObj);
             welcomeMenu = (TelnetWelcomeMenu)gObj.GetComponent(typeof(TelnetWelcomeMenu));
-            welcomeMenu.Setup(this);
+            welcomeMenu.Attach(this);
         }
         
         

--- a/src/kOS/UserIO/TelnetSingletonServer.cs
+++ b/src/kOS/UserIO/TelnetSingletonServer.cs
@@ -556,7 +556,6 @@ namespace kOS.UserIO
                 ContinuousChecks();
 
                 sb.Remove(0,sb.Length); // clear the whole thing.
-                Console.WriteLine("outThread, before lock section");
                 lock(outQueueAccess) // all access to inQueue and outQueue needs to be atomic.
                 {
                     while (outQueue.Count > 0)
@@ -565,10 +564,8 @@ namespace kOS.UserIO
                         sb.Append(ch);
                     }
                 }
-                Console.WriteLine("outThread, after lock section");
                 if (sb.Length > 0)
                 {
-                    Console.WriteLine("outThread, saw some text.");
                     sleepTime = 0; // Saw at least one char, so reset the sleep-slowdown.
                     string content = sb.ToString(); // instead of calling ToString() over and over.
                     if (terminalMapper == null)
@@ -581,7 +578,6 @@ namespace kOS.UserIO
                 }
                 else
                 {
-                    Console.WriteLine("outThread, sleeping a bit.");
                     Thread.Sleep(sleepTime);
                     if (sleepTime < SLEEP_TIME_MAX)
                         sleepTime += SLEEP_TIME_INC;

--- a/src/kOS/UserIO/TelnetSingletonServer.cs
+++ b/src/kOS/UserIO/TelnetSingletonServer.cs
@@ -185,7 +185,7 @@ namespace kOS.UserIO
             if (welcomeMenu != null)
             {
                 welcomeMenu.Detach();
-                GameObject.Destroy(welcomeMenu);
+                Object.Destroy(welcomeMenu);
                 welcomeMenu = null;
             }
         }
@@ -383,6 +383,14 @@ namespace kOS.UserIO
             outThread = null; // dispose old thread.
             
             rawStream.Close();
+
+            // Get rid of the welcome menu too, which has a reference to this server and should prevent GC
+            if (welcomeMenu != null)
+            {
+                welcomeMenu.Detach();
+                Object.Destroy(welcomeMenu);
+                welcomeMenu = null;
+            }
         }
 
         public void StartListening()

--- a/src/kOS/UserIO/TelnetWelcomeMenu.cs
+++ b/src/kOS/UserIO/TelnetWelcomeMenu.cs
@@ -29,7 +29,7 @@ namespace kOS.UserIO
         public bool IsAttached { get { return telnetServer != null; } }
 
         // Because this will be created as a Unity Gameobject, it has to have a parameterless constructor.
-        // Actual setup args will be in the Setup() method below.
+        // Actual setup args will be in the Attach() method below.
         public TelnetWelcomeMenu()
         {
             firstTime = true;

--- a/src/kOS/Utilities/Utils.cs
+++ b/src/kOS/Utilities/Utils.cs
@@ -283,5 +283,25 @@ namespace kOS.Utilities
             foundId = 0;
             return false;
         }
+
+        /// <summary>
+        /// Displays a popup dialog box with the given title, message, and single "OK" button.
+        /// Use to provide simple information to the user that requires no direct input.
+        /// </summary>
+        /// <param name="title"></param>
+        /// <param name="message"></param>
+        public static void DisplayPopupAlert(string title, string message, params string[] formatArgs)
+        {
+            PopupDialog.SpawnPopupDialog(
+                new MultiOptionDialog(
+                    string.Format(message, formatArgs),
+                    title,
+                    HighLogic.UISkin,
+                    new DialogGUIButton("OK", null, true)
+                    ),
+                true,
+                HighLogic.UISkin
+                );
+        }
     }
 }


### PR DESCRIPTION
Fixes #1935 
Fixes #668

Now you will be allowed to choose which of the IP addresses on your computer is the one you want it to use for the telnet server.  This replaces the previous CONFIG:LOOPBACK boolean with a new CONFIG:IPADDRESS string that lets you pick the IP address (i.e. set it to "127.0.0.1" to get the old loopback behaviour.)

It also contains the changes to the ``KOSToolBarMenu` to show a pick list of the IP addresses of the local machine so you can pick from the list instead of typing it in.

### Do not merge until after PR #1948 !!!

Because this change depends on the existence of the `ListPickerDialog` introduced with PR #1948 , this should not be merged until after PR #1948 is.  Please note that the majority of the diffs you see in the "Files Changed" are there purely because PR #1948 isn't merged yet.  This change *actually* only changed 2 source files and some RST docs - the rest is carryover from #1948.


