### PR TITLE
Adds "uniques heap" for VesselTarget instances.  Fixes #1980 and #1982

### DIFF
--- a/src/kOS.Safe.Test/Opcode/FakeCpu.cs
+++ b/src/kOS.Safe.Test/Opcode/FakeCpu.cs
@@ -7,6 +7,7 @@ namespace kOS.Safe.Test.Opcode
     public class FakeCpu : ICpu
     {
         private readonly Stack<object> fakeStack;
+        public bool IsPoppingContext { get { return false; } }
 
         public FakeCpu()
         {

--- a/src/kOS.Safe/Execution/CPU.cs
+++ b/src/kOS.Safe/Execution/CPU.cs
@@ -61,6 +61,14 @@ namespace kOS.Safe.Execution
         
         public List<string> ProfileResult { get; private set; }
 
+        /// <summary>
+        /// It's quite bad to abort the PopContext activity partway through while the CPU is
+        /// trying to clean up from a program crash or break, so this advertises when that's the case
+        /// so other parts of the system can decide not to use exceptions when in this fragile state:
+        /// </summary>
+        /// <value><c>true</c> if this CPU is popping context; otherwise, <c>false</c>.</value>
+        public bool IsPoppingContext { get; private set; }
+
         public CPU(SafeSharedObjects shared)
         {
             this.shared = shared;
@@ -186,6 +194,7 @@ namespace kOS.Safe.Execution
         private void PopContext()
         {
             SafeHouse.Logger.Log("Popping context " + contexts.Count);
+            IsPoppingContext = true;
             if (contexts.Any())
             {
                 // remove the last context
@@ -211,6 +220,7 @@ namespace kOS.Safe.Execution
                     shared.Interpreter.SetInputLock(false);
                 }
             }
+            IsPoppingContext = false;
         }
 
         /// <summary>

--- a/src/kOS.Safe/Execution/ICpu.cs
+++ b/src/kOS.Safe/Execution/ICpu.cs
@@ -59,5 +59,7 @@ namespace kOS.Safe.Execution
 
         List<string> GetCodeFragment(int contextLines);
         void RunProgram(List<Opcode> program);
+
+        bool IsPoppingContext { get; }
     }
 }

--- a/src/kOS.Safe/Module/IProcessor.cs
+++ b/src/kOS.Safe/Module/IProcessor.cs
@@ -13,6 +13,10 @@ namespace kOS.Safe.Module
 
         bool CheckCanBoot();
         string Tag { get; }
+
+        /// <summary>Can be used as a unique ID of which processor this is, but unlike Guid,
+        /// it doesn't remain unique across runs so you shouldn't use it for serialization.</summary>
+        int KOSCoreId { get; }
     }
     public enum ProcessorModes { READY, STARVED, OFF };
 }

--- a/src/kOS/AddOns/InfernalRobotics/IRControlGroup.cs
+++ b/src/kOS/AddOns/InfernalRobotics/IRControlGroup.cs
@@ -60,10 +60,10 @@ namespace kOS.AddOns.InfernalRobotics
             {
                 //IF IR version is 0.21.4 or below IR API may return null, but it also means that IR API only returns groups for ActiveVessel
                 //so returning the ActiveVessel should work
-                return cg.Vessel != null ? new VesselTarget (cg.Vessel, shared) : new VesselTarget(FlightGlobals.ActiveVessel, shared);
+                return cg.Vessel != null ? VesselTarget.CreateOrGetExisting(cg.Vessel, shared) : VesselTarget.CreateOrGetExisting(FlightGlobals.ActiveVessel, shared);
             } 
             else
-                return new VesselTarget(shared.Vessel, shared); //user should not be able to get here anyway, but to avoid null will return shared.Vessel
+                return VesselTarget.CreateOrGetExisting(shared.Vessel, shared); //user should not be able to get here anyway, but to avoid null will return shared.Vessel
         }
 
         public void ThrowIfNotCPUVessel()

--- a/src/kOS/AddOns/RemoteTech/RemoteTechAntennaModuleFields.cs
+++ b/src/kOS/AddOns/RemoteTech/RemoteTechAntennaModuleFields.cs
@@ -106,7 +106,7 @@ namespace kOS.AddOns.RemoteTech
                 {
                     if (vessel.id.Equals(guid))
                     {
-                        return new VesselTarget(vessel, shared);
+                        return VesselTarget.CreateOrGetExisting(vessel, shared);
                     }
                 }
 

--- a/src/kOS/Binding/FlightStats.cs
+++ b/src/kOS/Binding/FlightStats.cs
@@ -25,7 +25,7 @@ namespace kOS.Binding
             shared.BindingMgr.AddGetter("MISSIONTIME", () => shared.Vessel.missionTime);
             shared.BindingMgr.AddGetter(new [] { "OBT" , "ORBIT"}, () => new OrbitInfo(shared.Vessel.orbit,shared));
             shared.BindingMgr.AddGetter("TIME", () => new TimeSpan(Planetarium.GetUniversalTime()));
-            shared.BindingMgr.AddGetter("ACTIVESHIP", () => new VesselTarget(FlightGlobals.ActiveVessel, shared));
+            shared.BindingMgr.AddGetter("ACTIVESHIP", () => VesselTarget.CreateOrGetExisting(FlightGlobals.ActiveVessel, shared));
             shared.BindingMgr.AddGetter("STATUS", () => shared.Vessel.situation.ToString());
             shared.BindingMgr.AddGetter("STAGE", () => stageValue ?? (stageValue = new StageValues(shared)));
 

--- a/src/kOS/Binding/MissionSettings.cs
+++ b/src/kOS/Binding/MissionSettings.cs
@@ -18,7 +18,7 @@ namespace kOS.Binding
             sharedObj = shared;
 
             shared.BindingMgr.AddGetter("CORE", () => new Core((kOSProcessor)shared.Processor, shared));
-            shared.BindingMgr.AddGetter("SHIP", () => ship ?? (ship = new VesselTarget(shared)));
+            shared.BindingMgr.AddGetter("SHIP", () => ship ?? (ship = VesselTarget.CreateOrGetExisting(shared)));
             // These are now considered shortcuts to SHIP:suffix
             foreach (var scName in VesselTarget.ShortCuttableShipSuffixes)
             {
@@ -69,7 +69,7 @@ namespace kOS.Binding
                 var vessel = currentTarget as Vessel;
                 if (vessel != null)
                 {
-                    return new VesselTarget(vessel, shared);
+                    return VesselTarget.CreateOrGetExisting(vessel, shared);
                 }
                 var body = currentTarget as CelestialBody;
                 if (body != null)
@@ -107,19 +107,19 @@ namespace kOS.Binding
             base.Update();
             if (ship == null)
             {
-                ship = new VesselTarget(sharedObj);
+                ship = VesselTarget.CreateOrGetExisting(sharedObj);
                 ship.LinkCount++;
             }
             else if (ship.Vessel == null)
             {
                 ship.LinkCount--;
-                ship = new VesselTarget(sharedObj);
+                ship = VesselTarget.CreateOrGetExisting(sharedObj);
                 ship.LinkCount++;
             }
             else if (!ship.Vessel.id.Equals(sharedObj.Vessel.id))
             {
                 ship.LinkCount--;
-                ship = new VesselTarget(sharedObj);
+                ship = VesselTarget.CreateOrGetExisting(sharedObj);
                 ship.LinkCount++;
             }
         }

--- a/src/kOS/Communication/MessageQueueStructure.cs
+++ b/src/kOS/Communication/MessageQueueStructure.cs
@@ -49,7 +49,7 @@ namespace kOS.Communication
             } else
             {
                 double sentAt = Planetarium.GetUniversalTime();
-                messageQueue.Push(Message.Create(content, sentAt, sentAt, new VesselTarget(sharedObjects.Vessel, sharedObjects),
+                messageQueue.Push(Message.Create(content, sentAt, sentAt, VesselTarget.CreateOrGetExisting(sharedObjects.Vessel, sharedObjects),
                     sharedObjects.Processor.Tag));
             }
         }

--- a/src/kOS/Communication/MessageStructure.cs
+++ b/src/kOS/Communication/MessageStructure.cs
@@ -61,7 +61,7 @@ namespace kOS.Communication
                 return new BooleanValue(false);
             }
 
-            return new VesselTarget(vessel, shared);
+            return VesselTarget.CreateOrGetExisting(vessel, shared);
         }
         
         public BooleanValue GetVesselExists()

--- a/src/kOS/Communication/VesselConnection.cs
+++ b/src/kOS/Communication/VesselConnection.cs
@@ -55,14 +55,14 @@ namespace kOS.Communication
 
             double sentAt = Planetarium.GetUniversalTime();
             double receivedAt = sentAt + Delay;
-            queue.Push(Message.Create(content, sentAt, receivedAt, new VesselTarget(shared), shared.Processor.Tag));
+            queue.Push(Message.Create(content, sentAt, receivedAt, VesselTarget.CreateOrGetExisting(shared), shared.Processor.Tag));
 
             return true;
         }
 
         protected override Structure Destination()
         {
-            return new VesselTarget(vessel, shared);
+            return VesselTarget.CreateOrGetExisting(vessel, shared);
         }
     }
 }

--- a/src/kOS/Control/SteeringManager.cs
+++ b/src/kOS/Control/SteeringManager.cs
@@ -382,7 +382,12 @@ namespace kOS.Control
         public void DisableControl(SharedObjects sharedObj)
         {
             if (enabled && partId != sharedObj.KSPPart.flightID)
-                throw new Safe.Exceptions.KOSException("Cannot unbind Steering Manager on this ship in use by another processor.");
+            {
+                if (sharedObj.Cpu.IsPoppingContext)
+                    return; // popping context calls DisableControl but at a time when we mustn't throw exceptions.
+                else
+                    throw new Safe.Exceptions.KOSException ("Cannot unbind Steering Manager on this ship in use by another processor.");
+            }
             partId = 0;
             Enabled = false;
         }

--- a/src/kOS/Core.cs
+++ b/src/kOS/Core.cs
@@ -31,7 +31,7 @@ namespace kOS
         private void InitializeSuffixes()
         {
             AddSuffix("VERSION", new Suffix<VersionInfo>(() => VersionInfo));
-            AddSuffix("VESSEL", new Suffix<VesselTarget>(() => new VesselTarget(shared.KSPPart.vessel, shared)));
+            AddSuffix("VESSEL", new Suffix<VesselTarget>(() => VesselTarget.CreateOrGetExisting(shared.KSPPart.vessel, shared)));
             AddSuffix("ELEMENT", new Suffix<ElementValue>(GetEelement));
             AddSuffix("CURRENTVOLUME", new Suffix<Volume>(GetCurrentVolume, "The currently selected volume"));
             AddSuffix("MESSAGES", new NoArgsSuffix<MessageQueueStructure>(() => new MessageQueueStructure(processor.Messages, shared),

--- a/src/kOS/Function/BuildList.cs
+++ b/src/kOS/Function/BuildList.cs
@@ -28,7 +28,7 @@ namespace kOS.Function
                     foreach (var vessel in FlightGlobals.Vessels)
                     {
                         if (vessel == shared.Vessel) continue;
-                        list.Add(new VesselTarget(vessel, shared));
+                        list.Add(VesselTarget.CreateOrGetExisting(vessel, shared));
                     }
                     break;
                 case "resources":

--- a/src/kOS/Function/PrintList.cs
+++ b/src/kOS/Function/PrintList.cs
@@ -170,7 +170,7 @@ namespace kOS.Function
             {
                 if (vessel == shared.Vessel) continue;
 
-                var vT = new VesselTarget(vessel, shared);
+                var vT = VesselTarget.CreateOrGetExisting(vessel, shared);
                 list.AddItem(vT.Vessel.vesselName, vT.GetDistance());
             }
 

--- a/src/kOS/Function/Suffixed.cs
+++ b/src/kOS/Function/Suffixed.cs
@@ -139,7 +139,7 @@ namespace kOS.Function
         {
             string vesselName = PopValueAssert(shared).ToString();
             AssertArgBottomAndConsume(shared);
-            var result = new VesselTarget(VesselUtils.GetVesselByName(vesselName, shared.Vessel), shared);
+            var result = VesselTarget.CreateOrGetExisting(VesselUtils.GetVesselByName(vesselName, shared.Vessel), shared);
             ReturnValue = result;
         }
     }

--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -48,6 +48,14 @@ namespace kOS.Module
         private bool firstUpdate = true;
         private bool objectsInitialized = false;
 
+        /// How many times have instances of this class been constructed during this process run?
+        private static int constructorCount;
+
+        private int kOSCoreId;
+        /// <summary>Can be used as a unique ID of which processor this is, but unlike Guid,
+        /// it doesn't remain unique across runs so you shouldn't use it for serialization.</summary>
+        public int KOSCoreId { get { return kOSCoreId; } }
+
         private MovingAverage averagePower = new MovingAverage();
 
         // This is the "constant" byte count used when calculating the EC
@@ -110,6 +118,7 @@ namespace kOS.Module
         public kOSProcessor()
         {
             ProcessorMode = ProcessorModes.READY;
+            kOSCoreId = ++constructorCount;
         }
 
         public VolumePath BootFilePath {
@@ -909,7 +918,7 @@ namespace kOS.Module
         public void Send(Structure content)
         {
             double sentAt = Planetarium.GetUniversalTime();
-            Messages.Push(Message.Create(content, sentAt, sentAt, new VesselTarget(shared), Tag));
+            Messages.Push(Message.Create(content, sentAt, sentAt, VesselTarget.CreateOrGetExisting(shared), Tag));
         }
     }
 }

--- a/src/kOS/Sound/SawtoothSoundWave.cs
+++ b/src/kOS/Sound/SawtoothSoundWave.cs
@@ -14,9 +14,6 @@ namespace kOS.Sound
                 
         public override float SampleFunction(float t)
         {
-            // if (t >= 0.5f)   //eraseme
-            //    t -= 0.5f;    //eraseme
-            // return 2*t - 1;  //eraseme
             return 1 - 2*t;
         }
 

--- a/src/kOS/Suffixed/BodyTarget.cs
+++ b/src/kOS/Suffixed/BodyTarget.cs
@@ -50,7 +50,7 @@ namespace kOS.Suffixed
                 if (soiBody.orbit != null)
                     futureOrbitalVel = soiBody.orbit.GetFrameVelAtUT(timeStamp.ToUnixStyleTime());
                 else
-                    futureOrbitalVel = -1 * new VesselTarget(Shared.Vessel, Shared).GetVelocitiesAtUT(timeStamp).Orbital.ToVector3D();
+                    futureOrbitalVel = -1 * VesselTarget.CreateOrGetExisting(Shared.Vessel, Shared).GetVelocitiesAtUT(timeStamp).Orbital.ToVector3D();
                 Vector swappedVel = new Vector(futureOrbitalVel.x, futureOrbitalVel.z, futureOrbitalVel.y); // swap Y and Z because KSP API is weird.
                  // Also invert directions because the above gives vel of my body rel to sun, and I want vel of sun rel to my body:
                 return new OrbitableVelocity( -swappedVel, -swappedVel);

--- a/src/kOS/Suffixed/ElementValue.cs
+++ b/src/kOS/Suffixed/ElementValue.cs
@@ -33,7 +33,7 @@ namespace kOS.Suffixed
         {
             AddSuffix("NAME", new SetSuffix<StringValue>(() => dockedVesselInfo.name, SetName ));
             AddSuffix("UID", new Suffix<StringValue>(() => dockedVesselInfo.rootPartUId.ToString()));
-            AddSuffix("VESSEL", new Suffix<VesselTarget>(() => new VesselTarget(parts[0].vessel, shared)));
+            AddSuffix("VESSEL", new Suffix<VesselTarget>(() => VesselTarget.CreateOrGetExisting(parts[0].vessel, shared)));
             AddSuffix("PARTS", new Suffix<ListValue>(() => PartValueFactory.Construct(parts, shared)));
             AddSuffix("DOCKINGPORTS", new Suffix<ListValue>(() => DockingPortValue.PartsToList(parts, shared)));
             AddSuffix("RESOURCES", new Suffix<ListValue>(GetResourceManifest));

--- a/src/kOS/Suffixed/KUniverseValue.cs
+++ b/src/kOS/Suffixed/KUniverseValue.cs
@@ -37,7 +37,7 @@ namespace kOS.Suffixed
             AddSuffix("QUICKSAVELIST", new Suffix<ListValue>(GetQuicksaveList));
             AddSuffix("ORIGINEDITOR", new Suffix<StringValue>(OriginatingEditor));
             AddSuffix("DEFAULTLOADDISTANCE", new Suffix<LoadDistanceValue>(() => new LoadDistanceValue(PhysicsGlobals.Instance.VesselRangesDefault)));
-            AddSuffix("ACTIVEVESSEL", new SetSuffix<VesselTarget>(() => new VesselTarget(FlightGlobals.ActiveVessel, shared), SetActiveVessel));
+            AddSuffix("ACTIVEVESSEL", new SetSuffix<VesselTarget>(() => VesselTarget.CreateOrGetExisting(FlightGlobals.ActiveVessel, shared), SetActiveVessel));
             AddSuffix(new string[] { "FORCESETACTIVEVESSEL", "FORCEACTIVE" }, new OneArgsSuffix<VesselTarget>(ForceSetActiveVessel));
             AddSuffix("HOURSPERDAY", new Suffix<ScalarValue>(GetHoursPerDay));
             AddSuffix("DEBUGLOG", new OneArgsSuffix<StringValue>(DebugLog));

--- a/src/kOS/Suffixed/Part/PartValue.cs
+++ b/src/kOS/Suffixed/Part/PartValue.cs
@@ -42,7 +42,7 @@ namespace kOS.Suffixed.Part
             AddSuffix("FACING", new Suffix<Direction>(() => GetFacing(Part)));
             AddSuffix("RESOURCES", new Suffix<ListValue>(() => GatherResources(Part)));
             AddSuffix("TARGETABLE", new Suffix<BooleanValue>(() => Part.Modules.OfType<ITargetable>().Any()));
-            AddSuffix("SHIP", new Suffix<VesselTarget>(() => new VesselTarget(Part.vessel, Shared)));
+            AddSuffix("SHIP", new Suffix<VesselTarget>(() => VesselTarget.CreateOrGetExisting(Part.vessel, Shared)));
             AddSuffix("HASMODULE", new OneArgsSuffix<BooleanValue, StringValue>(HasModule));
             AddSuffix("GETMODULE", new OneArgsSuffix<PartModuleFields, StringValue>(GetModule));
             AddSuffix("GETMODULEBYINDEX", new OneArgsSuffix<PartModuleFields, ScalarValue>(GetModuleIndex));


### PR DESCRIPTION
Fixes #1980 and #1982.

Problem #1982 was simpler so I'll explain it first:

When the SteeringManager complains about the CPU controlling
an already-controlled craft, it throws an exception which
makes the CPU try to abort execution.  But as part of trying to
abort that execution it calls PopContext(), which in turn
calls the SteeringManager to ask it to unbind the steering,
where the SteeringManager again throws an exception because
of the dual CPU control.  This second exception makes the CPU
abort partway through finishing the work of breaking the
execution, so it never quite fully terminates the program, which
is why it keeps trying to run after some of the running context
information has been wiped away (thus the null refs in
ExecuteInstruction).

The fix:  The CPU now advertises when it's in a PopContext,
so the SteeringManager can choose not to throw that second
exception in that case.

Problem #1980 required a slight refactor:

This problem was caused by the fact that VesselTarget now
inserts callback hooks into GameEvents, which it didn't do
before, and those callback hooks prevent it from getting
garbage collected.   As long as GameEvents has a
reference to a delegate that needs the VesselTarget object
to keep existing as part of its closure, the VesselTarget
can't ever get orphaned.  It was depending on being a
KOSScopeObserver to discover when kOS orphans it, so it
can remove its hooks from GameEvents, but KOSScopeObserver
can't really reliably catch all cases like that, and relies
on a C# destructor ( ~Variable ) to call ScopeLost().  But
the C# destructor never happens if the thing never orphans,
so it's a catch-22.  The orphaning event that tells
VesselTarget to unhook itself won't happen because VesselTarget
hasn't unhooked itself.

Thus the freeze at docking was caused by the fact that
every time the docking script had referred to the target vessel
during its main loop, it was creating a new instance of the
VesselTarget wrapper around it, and the old instances
never truly orphaned away like they should.  By the time
the docking happened there were thousands of thse extra
instances in memory, and upon docking ALL their callback
hooks got fired off at once.

The Fix:

Since VesselTarget is just a wrapper around a KSP Vessel,
and all the information contained therein is meant to
just inherit the info from the Vessel, and all the
Setter Suffixes are meant to pass the change on to the
KSP Vessel itself, there is no practical difference between
a kerboscript having two different VesselTarget instances
wrapping the same Vessel versus having just one VesselTarget
instance for it and then just having two references to it.

Threfore we track whether or not a VesselTarget wrapper
around a Vessel already exists, and if it does then we just
hand out a reference to the existing one instead of constructing
a new one.  That prevents us from having thousands of copies
of the same VesselTarget in memory when they don't orphan.

It should also have the nice side effect of reducing
execution burden by not re-running the Parts query of
the vessel each time it's referrenced in the script, as
it had to do before when each mention of TARGET made a
brand new VesselTarget.

The reason so many files got touched is because all instances
of calling the VesselTarget constructor had to be edited
to use a factory method instead, that does what the
above paragraphs describe.