### PR TITLE
Fixes #1971: Boolean meaning 0.00001 = true, 0.00000 = false

### DIFF
--- a/src/kOS.Safe/Encapsulation/ScalarDoubleValue.cs
+++ b/src/kOS.Safe/Encapsulation/ScalarDoubleValue.cs
@@ -15,6 +15,11 @@
             get { return false; }
         }
 
+        public override bool BooleanMeaning
+        {
+            get { return (double)Value != 0d; }
+        }
+
         public ScalarDoubleValue(double value)
         {
             Value = value;

--- a/src/kOS.Safe/Encapsulation/ScalarIntValue.cs
+++ b/src/kOS.Safe/Encapsulation/ScalarIntValue.cs
@@ -18,6 +18,11 @@
             get { return true; }
         }
 
+        public override bool BooleanMeaning
+        {
+            get { return (int)Value != 0; }
+        }
+
         public ScalarIntValue(int value)
         {
             Value = value;

--- a/src/kOS.Safe/Encapsulation/ScalarValue.cs
+++ b/src/kOS.Safe/Encapsulation/ScalarValue.cs
@@ -19,6 +19,8 @@ namespace kOS.Safe.Encapsulation
 
         abstract public bool IsDouble { get; }
 
+        abstract public bool BooleanMeaning { get; }
+
         public bool IsValid
         {
             get
@@ -356,8 +358,7 @@ namespace kOS.Safe.Encapsulation
 
         bool IConvertible.ToBoolean(IFormatProvider provider)
         {
-            if (GetIntValue() == 0) return false;
-            return true;
+            return BooleanMeaning;
         }
 
         byte IConvertible.ToByte(IFormatProvider provider)


### PR DESCRIPTION
Fixes #1971 

I moved the code out of abstract class ScalarValue
into the classes that override it, because I wanted
to use a simple cast operator and to do that I need
to know the type of Value at compile-time.

I could have just used C#'s own knowledge of how you're
meant to "convert" numbers to Booleans by doing
Convert.ToBoolean(Value) in ScalarValue.  It would have
given the same result, but I think this way is a bit faster
because it casts instead of using Convert methods.