### PR TITLE
Fixes #1985   stock :deploy Reflection removed

### DIFF
--- a/src/kOS/Suffixed/PartModuleField/StockScienceExperimentFields.cs
+++ b/src/kOS/Suffixed/PartModuleField/StockScienceExperimentFields.cs
@@ -42,19 +42,15 @@ namespace kOS.Suffixed.PartModuleField
         protected virtual void Deploy()
         {
             ThrowIfNotCPUVessel();
-
-            var gatherDataMethod = module.GetType().GetMethod("gatherData",
-                BindingFlags.NonPublic | BindingFlags.Instance);
-
-            object result = gatherDataMethod.Invoke(module, new object[] { false });
-
-            IEnumerator e = result as IEnumerator;
-
-            module.StartCoroutine(e);
+            module.DeployExperiment();
         }
             
         public override bool Inoperable()
         {
+            BaseEvent deployAction = module.Events["DeployExperiment"];
+            if (deployAction == null || ! deployAction.active)
+                return true;
+
             return module.Inoperable;
         }
 


### PR DESCRIPTION
Reflection was being used to bypass access
permissions in a naughty way.  (We were calling
a non-public method).  By not using the public
method instead, the code bypassed some of the
checks that KSP normally performs for seeing if
an experiment is allowed.

I added some better checks to avoid calling it
in cases where we shouldn't, but also replaced
that use of reflection with a call to the proper
public-facing method as well so that if we don't
catch everything, at least we're not bypassing
KSP's checking.  (The reason I didn't just rely
on KSP's checking alone is that it sometimes fails
silently when it doesn't like what you're doing,
and I wanted to let the user see a message.)

The same sort of naughty private-access
reflection is used in DMScienceExperiment too,
but there I didn't change it because that
had to use reflection to avoid the code blowing
up when DMagic science is missing.  Also, I didn't
write that code and don't use DMagic science so it
would have been hard to test it if I tried to
fix that part.