### PR TITLE
Fixes #1970 and adds altitudesealevel.

### DIFF
--- a/doc/source/structures/celestial_bodies/atmosphere.rst
+++ b/doc/source/structures/celestial_bodies/atmosphere.rst
@@ -68,8 +68,27 @@ A Structure closely tied to :struct:`Body` A variable of type :struct:`Atmospher
     :type: :ref:`scalar <scalar>` (atm)
     :access: Get only
 
-    Number of Atm's at planet's sea level 1.0 Atm's = same as Kerbin.
+    Pressure at the body's sea level.
+
+    Result is returned in Atmospheres.  1.0 Atmosphere = same as Kerbin or Earth.
+    If you prefer to see the answer in KiloPascals, multiply the answer by
+    :ref:`Constant:AtmToKPa <Constant:AtmToKPa>`.
     
+.. method:: Atmosphere:ALTITUDEPRESSURE(altitude)
+
+    :parameter altitude: The altitude above sea level (in meters) you want to know the pressure for.
+    :type: :ref:`scalar <scalar>` (atm)
+
+    Number of Atm's of atmospheric pressure at the given altitude.
+    If you pass in zero, you should get the sea level pressure.
+    If you pass in 10000, you get the pressure at altitude=10,000m.
+    This will return zero if the body has no atmosphere, or if the altitude you
+    pass in is above the max atmosphere altitude for the body.
+
+    Result is returned in Atmospheres.  1.0 Atmosphere = same as Kerbin or Earth.
+    If you prefer to see the answer in KiloPascals, multiply the answer by
+    :ref:`Constant:AtmToKPa <Constant:AtmToKPa>`.
+
 .. attribute:: Atmosphere:HEIGHT
 
     :type: :ref:`scalar <scalar>` (m)

--- a/src/kOS/Suffixed/BodyAtmosphere.cs
+++ b/src/kOS/Suffixed/BodyAtmosphere.cs
@@ -16,8 +16,9 @@ namespace kOS.Suffixed
             AddSuffix("BODY", new Suffix<StringValue>(()=> celestialBody.bodyName));
             AddSuffix("EXISTS", new Suffix<BooleanValue>(()=> celestialBody.atmosphere));
             AddSuffix("OXYGEN", new Suffix<BooleanValue>(()=> celestialBody.atmosphere && celestialBody.atmosphereContainsOxygen));
-            AddSuffix("SEALEVELPRESSURE", new Suffix<ScalarValue>(()=> celestialBody.atmosphere ? celestialBody.atmospherePressureSeaLevel : 0));
+            AddSuffix("SEALEVELPRESSURE", new Suffix<ScalarValue>(()=> celestialBody.atmosphere ? celestialBody.atmospherePressureSeaLevel * ConstantValue.KpaToAtm : 0));
             AddSuffix("HEIGHT", new Suffix<ScalarValue>(()=> celestialBody.atmosphere ? celestialBody.atmosphereDepth : 0));
+            AddSuffix("ALTITUDEPRESSURE", new OneArgsSuffix<ScalarValue, ScalarValue>((alt)=> celestialBody.GetPressure(alt) * ConstantValue.KpaToAtm));
 
             AddSuffix("SCALE", new Suffix<ScalarValue>(() => { throw new KOSAtmosphereObsoletionException("0.17.2","SCALE","<None>",string.Empty); }));
         }


### PR DESCRIPTION
In addition to changing the sealevelpressure to ATM's, I also noticed the pressure at a given altitude was missing from the atmosphere structure so I added that too.