### PR TITLE
Fixes #1947 adding geoposition suffix to body.

### DIFF
--- a/doc/source/math/geocoordinates.rst
+++ b/doc/source/math/geocoordinates.rst
@@ -18,7 +18,17 @@ Creation
     :parameter lng: (deg) Longitude
     :return: :struct:`GeoCoordinates`
 
-    This function creates a :struct:`GeoCoordinates` object with the given latitude and longitude. Once created it can't be changed. The :attr:`GeoCoordinates:LAT` and :attr:`GeoCoordinates:LNG` suffixes are get-only and cannot be set. To switch to a new location, make a new call to :func:`LATLNG()`.
+    This function creates a :struct:`GeoCoordinates` object with the given
+    latitude and longitude, assuming the current SHIP's Body is the body
+    to make it for.
+    
+    Once created it can't be changed. The :attr:`GeoCoordinates:LAT` and
+    :attr:`GeoCoordinates:LNG` suffixes are get-only (they cannot be
+    set.) To switch to a new location, make a new call to :func:`LATLNG()`.
+
+    If you wish to create a :struct:`GeoCoordinates` object for a latitude
+    and longitude around a *different* body than the ship's current sphere
+    of influence body, see :method:`Body:Geoposition` for a means to do that.
 
     It is also possible to obtain a :struct:`GeoCoordinates` from some suffixes of some other structures. For example::
 

--- a/doc/source/structures/celestial_bodies/body.rst
+++ b/doc/source/structures/celestial_bodies/body.rst
@@ -73,7 +73,8 @@ All of the main celestial bodies in the game are reserved variable names. The fo
     :attr:`MU`                       :ref:`scalar <scalar>` (:math:`m^3 s^{−2}`)
     :attr:`ATM`                      :struct:`Atmosphere`
     :attr:`ANGULARVEL`               :struct:`Vector` in :ref:`SHIP-RAW <ship-raw>`
-    :attr:`GEOPOSITIONOF`            :struct:`GeoCoordinates` in :ref:`SHIP-RAW <ship-raw>`
+    :attr:`GEOPOSITIONOF`            :struct:`GeoCoordinates` given :ref:`SHIP-RAW <ship-raw>` position vector
+    :method:`GEOPOSITION`            :struct:`GeoCoordinates` given latitude and longitude values
     :attr:`ALTITUDEOF`               :ref:`scalar <scalar>` (m)
     :attr:`SOIRADIUS`                :ref:`scalar <scalar>` (m)
     :attr:`ROTATIONANGLE`            :ref:`scalar <scalar>` (deg)
@@ -140,6 +141,15 @@ All of the main celestial bodies in the game are reserved variable names. The fo
 .. attribute:: Body:GEOPOSITIONOF
 
     The geoposition underneath the given vector position.  SHIP:BODY:GEOPOSITIONOF(SHIP:POSITION) should, in principle, give the same thing as SHIP:GEOPOSITION, while SHIP:BODY:GEOPOSITIONOF(SHIP:POSITION + 1000*SHIP:NORTH) would give you the lat/lng of the position 1 kilometer north of you.  Be careful not to confuse this with :GEOPOSITION (no "OF" in the name), which is also a suffix of Body by virtue of the fact that Body is an Orbitable, but it doesn't mean the same thing.
+
+.. method:: Body:GEOPOSITIONOF(latitude, longitude)
+
+    :parameter latitude: :struct:`Scalar` input latitude
+    :parameter longitude: :struct:`Scalar` input longitude
+    :type: :struct:`GeoCoordinates`
+
+    Given a latitude and longitude, this returns a :struct:`GeoCoordinates` structure
+    for that position on this body.
 
 .. attribute:: Body:ALTITUDEOF
 

--- a/doc/source/structures/celestial_bodies/body.rst
+++ b/doc/source/structures/celestial_bodies/body.rst
@@ -73,7 +73,7 @@ All of the main celestial bodies in the game are reserved variable names. The fo
     :attr:`MU`                       :ref:`scalar <scalar>` (:math:`m^3 s^{−2}`)
     :attr:`ATM`                      :struct:`Atmosphere`
     :attr:`ANGULARVEL`               :struct:`Vector` in :ref:`SHIP-RAW <ship-raw>`
-    :attr:`GEOPOSITIONOF`            :struct:`GeoCoordinates` given :ref:`SHIP-RAW <ship-raw>` position vector
+    :method:`GEOPOSITIONOF`          :struct:`GeoCoordinates` given :ref:`SHIP-RAW <ship-raw>` position vector
     :method:`GEOPOSITION`            :struct:`GeoCoordinates` given latitude and longitude values
     :attr:`ALTITUDEOF`               :ref:`scalar <scalar>` (m)
     :attr:`SOIRADIUS`                :ref:`scalar <scalar>` (m)
@@ -138,11 +138,17 @@ All of the main celestial bodies in the game are reserved variable names. The fo
     congruent with how VESSEL:ANGULARMOMENTUM is expressed, and for
     backward compatibility with older kOS scripts.
 
-.. attribute:: Body:GEOPOSITIONOF
+.. method:: Body:GEOPOSITIONOF(vectorPos)
+
+    :parameter vectorPos: :struct:`Vector` input position in XYZ space.
 
     The geoposition underneath the given vector position.  SHIP:BODY:GEOPOSITIONOF(SHIP:POSITION) should, in principle, give the same thing as SHIP:GEOPOSITION, while SHIP:BODY:GEOPOSITIONOF(SHIP:POSITION + 1000*SHIP:NORTH) would give you the lat/lng of the position 1 kilometer north of you.  Be careful not to confuse this with :GEOPOSITION (no "OF" in the name), which is also a suffix of Body by virtue of the fact that Body is an Orbitable, but it doesn't mean the same thing.
 
-.. method:: Body:GEOPOSITIONOF(latitude, longitude)
+    (Not to be confused with the :attr:`Orbitable:GEOPOSITION` suffix, which ``Body`` inherits
+    from :struct:`Orbitable`, and which gives the position that this body is directly above
+    on the surface *of its parent body*.)
+
+.. method:: Body:GEOPOSITIONLATLNG(latitude, longitude)
 
     :parameter latitude: :struct:`Scalar` input latitude
     :parameter longitude: :struct:`Scalar` input longitude
@@ -150,6 +156,10 @@ All of the main celestial bodies in the game are reserved variable names. The fo
 
     Given a latitude and longitude, this returns a :struct:`GeoCoordinates` structure
     for that position on this body.
+
+    (Not to be confused with the :attr:`Orbitable:GEOPOSITION` suffix, which ``Body`` inherits
+    from :struct:`Orbitable`, and which gives the position that this body is directly above
+    on the surface *of its parent body*.)
 
 .. attribute:: Body:ALTITUDEOF
 

--- a/src/kOS/Suffixed/BodyTarget.cs
+++ b/src/kOS/Suffixed/BodyTarget.cs
@@ -122,6 +122,10 @@ namespace kOS.Suffixed
                       new OneArgsSuffix<ScalarValue, Vector>(
                               AltitudeFromPosition,
                               "Interpret the vector given as a 3D position, and return its altitude above 'sea level' of this body."));
+            AddSuffix("GEOPOSITION",
+                      new TwoArgsSuffix<GeoCoordinates, ScalarValue, ScalarValue>(
+                              GeoCoordinatesFromLatLng,
+                              "Given latitude and longitude, return the geoposition on this body corresponding to it."));
         }
 
         /// <summary>
@@ -135,6 +139,15 @@ namespace kOS.Suffixed
             double lat = Body.GetLatitude(unityWorldPosition);
             double lng = Body.GetLongitude(unityWorldPosition);
             return new GeoCoordinates(Body, Shared, lat, lng);
+        }
+
+        /// <summary>
+        /// Return a Geocoordinates on this body, given the latitude and longitude
+        /// </summary>
+        /// <returns>The LATLNG (GeoCoordinates) structure.</returns>
+        public GeoCoordinates GeoCoordinatesFromLatLng(ScalarValue latitude, ScalarValue longitude)
+        {
+            return new GeoCoordinates(Body, Shared, latitude, longitude);
         }
 
         /// <summary>

--- a/src/kOS/Suffixed/BodyTarget.cs
+++ b/src/kOS/Suffixed/BodyTarget.cs
@@ -122,7 +122,7 @@ namespace kOS.Suffixed
                       new OneArgsSuffix<ScalarValue, Vector>(
                               AltitudeFromPosition,
                               "Interpret the vector given as a 3D position, and return its altitude above 'sea level' of this body."));
-            AddSuffix("GEOPOSITION",
+            AddSuffix("GEOPOSITIONLATLNG",
                       new TwoArgsSuffix<GeoCoordinates, ScalarValue, ScalarValue>(
                               GeoCoordinatesFromLatLng,
                               "Given latitude and longitude, return the geoposition on this body corresponding to it."));

--- a/src/kOS/Suffixed/GeoCoordinates.cs
+++ b/src/kOS/Suffixed/GeoCoordinates.cs
@@ -281,7 +281,7 @@ namespace kOS.Suffixed
 
         public override string ToString()
         {
-            return "LATLNG(" + Latitude + ", " + Longitude + ")";
+            return string.Format("{0}:GEOPOSITIONLATLNG({1},{2})", Body.GetName(), Latitude, Longitude);
         }
 
         public void SetSharedObjects(SharedObjects sharedObjects)


### PR DESCRIPTION
In addition to changing the sealevelpressure to ATM's, I also noticed the pressure at a given altitude was missing from the atmosphere structure so I added that too.