### PR TITLE
Fixes #1956 and changes font search order.

### DIFF
--- a/src/kOS/Module/AssetManager.cs
+++ b/src/kOS/Module/AssetManager.cs
@@ -86,7 +86,7 @@ namespace kOS.Module
                 if (!FontNames.Contains(fontName))
                 {
                     // Only add those fonts which pass the monospace test:
-                    if (GetSystemFontByNameAndSize(fontName, 13, true, false) != null)
+                    if (GetSystemFontByNameAndSize(fontName, 13, true, false, false) != null)
                         FontNames.Add(fontName);
                 }
                 namesThatNoLongerExist.Remove(fontName);
@@ -120,7 +120,11 @@ namespace kOS.Module
         /// if it's not monospaced.</param>
         /// <param name="doErrorMessage">If true, then if the checkMono check (see above) fails, a message will
         /// appear on screen complaining about this as it returns a null, else it will return null silently.</param>
-        public Font GetSystemFontByNameAndSize(string name, int size, bool checkMono, bool doErrorMessage = true)
+        /// <param name="doDetectedCheck">If true, then protect against trying to use un-detected font names.
+        /// By default, if the font name you use was not discovered when walking the list of all OS font names, this
+        /// method will force a null return.  But if this is being called before that walk is finished, you have to
+        /// bypass that check to make it work at all.</param> 
+        public Font GetSystemFontByNameAndSize(string name, int size, bool checkMono, bool doErrorMessage = true, bool doDetectedCheck = true)
         {
             // Now that a font is asked for, now we'll lazy-load it.
 
@@ -128,6 +132,17 @@ namespace kOS.Module
             string key = MakeKey(name, size);
             if ( (!Fonts.ContainsKey(key)) || Fonts[key] == null)
             {
+                // Font.CreateDynamicFontFromOSFont will never return null just because you
+                // gave it a bogus font name that doesn't exist.  Instead Unity chooses
+                // to return the default Arial font instead when it can't find the font name.
+                // Because our logic requires that we try calling this method again and again
+                // walking through a list of fonts until we find one that works, we need this
+                // to return null when there's no such font.
+                // (Else when the first font in the list of fonts to try fails, we get a
+                // "success" at using Arial, instead of trying the next font.)
+                if (doDetectedCheck && !FontNames.Contains(name))
+                    return null;
+                
                 Fonts[key] = Font.CreateDynamicFontFromOSFont(name, size);
             }
 

--- a/src/kOS/Module/Bootstrapper.cs
+++ b/src/kOS/Module/Bootstrapper.cs
@@ -25,6 +25,22 @@ namespace kOS.Module
                                                     "attempt to migrate your existing scripts?  See the warning regarding the boot " +
                                                     "directory at http://kos.github.io/KOS_DOC/general/volumes.html#special-handling-of-files-in-the-boot-directory " +
                                                     "for more details.";
+        private const string UNPICKED_FONT_DESC =
+            "<b><size=18>Terminal Font</size></b>\n" +
+            "\n" +
+            "By default, kOS will choose a font from a list of guesses, but this is less than ideal. " +
+            "You should pick a font choice yourself once you can during play.\n " +
+            "<b><color=#FFFFFF>You can choose a font using the kOS toolbar panel " +
+            "that appears during play <i>when you are in flight view</color></i></b>.\n" +
+            "\n" +
+            "<b><size=16>If you liked the old look:</size></b>\n" +
+            "\n" +
+            "If you liked the old look of kOS's terminal, with its very wide boxy characters, " +
+            "you can have that again by downloading and installing a Commodore(tm) 64 font onto your " +
+            "computer and re-launching KSP.  The old bitmap images were designed to mimic the " +
+            "character set of the old Commodore 64 computer.  (We (kOS developers) considered " +
+            "including a Commodore 64 font in the download of kOS, but licensing terms precluded " +
+            "redistributing any of the fonts we found.)\n";
 
         private bool backup = true;
         
@@ -36,6 +52,8 @@ namespace kOS.Module
             BuildLogger();
 
             CheckForLegacyArchive();
+
+            CheckForUnpickedFont();
             
             var assemblies = AssemblyLoader.loadedAssemblies.Where(a => a.dllName.StartsWith("kOS.") || a.dllName.Equals("kOS") || a.dependencies.Where(d => d.name.Equals("kOS")).Any()).Select(a => a.assembly).ToArray();
             AssemblyWalkAttribute.Walk(assemblies);
@@ -114,6 +132,28 @@ namespace kOS.Module
                 true,
                 HighLogic.UISkin
                 );
+        }
+
+        private void CheckForUnpickedFont()
+        {
+            if (SafeHouse.Config.TerminalFontName.Equals("_not_chosen_yet_"))
+            {
+                PopupDialog.SpawnPopupDialog(
+                    new MultiOptionDialog(
+                        UNPICKED_FONT_DESC,
+                        "kOS",
+                        HighLogic.UISkin,
+                        new DialogGUIButton("Okay, got it!", () => {}, true)
+                    ),
+                    true,
+                    HighLogic.UISkin
+                );
+                // Still leave the user's chosen font name as a bogus value, but
+                // change it to one that looks more pleasing on the button in the
+                // toolbar dialog.  (This will also prevent this dialog box from
+                // ever firing off again once this value gets saved in config.xml).
+                SafeHouse.Config.TerminalFontName = "Choose Font";
+            }
         }
 
         private void MigrateScripts()

--- a/src/kOS/Screen/KOSTextEditPopup.cs
+++ b/src/kOS/Screen/KOSTextEditPopup.cs
@@ -24,7 +24,10 @@ namespace kOS.Screen
         private Font font;
         // A list of fonts including the user's choice plus a few fallback options if the user's choice isn't working:
         private string[] tryFontNames =
-            new string[] { "_User's choice_", "Courier New Bold", "Courier Bold", "Courier New", "Courier", "Monaco", "Consolas", "Liberation Mono", "Arial" };
+            new string[] {
+               "_User's choice_",
+               "Consolas Bold", "Consolas", "Monaco Bold", "Monaco", "Liberation Mono Bold", "Liberation Mono",
+               "Courier New Bold", "Courier Bold", "Courier New", "Courier", "Arial" };
         private string prevConfigFontName = "";
         private int prevConfigFontSize = 12;
         private Rect innerCoords;

--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -38,9 +38,6 @@ namespace kOS.Screen
         
         private bool collapseFastBeepsToOneBeep = false; // This is a setting we might want to fiddle with depending on opinion.
 
-        private KeyBinding rememberThrottleCutoffKey;
-        private KeyBinding rememberThrottleFullKey;
-
         private bool allTexturesFound = true;
         private float cursorBlinkTime;
 
@@ -48,13 +45,16 @@ namespace kOS.Screen
         private int fontSize;
         private string[] tryFontNames = {
             "User pick Goes Here", // overwrite this first one with the user selection - the rest are a fallback just in case
-            "Courier New Bold",
+            "Consolas Bold",          // typical Windows good programming font
+            "Consolas",
+            "Monaco Bold",            // typical Mac good programming font
+            "Monaco",
+            "Liberation Mono Bold",   // typical Linux good programming font
+            "Liberation Mono",
+            "Courier New Bold",  // The Courier ones are ugly fallbacks just in case.
             "Courier Bold",
             "Courier New",
             "Courier",
-            "Monaco",
-            "Consolas",
-            "Liberation Mono",
             "Arial" // very bad, proportional, but guaranteed to exist in Unity no matter what.
         };
         private GUISkin terminalLetterSkin;

--- a/src/kOS/Suffixed/Config.cs
+++ b/src/kOS/Suffixed/Config.cs
@@ -69,7 +69,7 @@ namespace kOS.Suffixed
             AddConfigKey(PropId.TelnetPort, new ConfigKey("TelnetPort", "TPORT", "Telnet port number (must restart telnet to take effect)", 5410, 1024, 65535, typeof(int)));
             AddConfigKey(PropId.TelnetIPAddrString, new ConfigKey("TelnetIPAddrString", "IPADDRESS", "Telnet IP address string (must restart telnet to take effect)", "127.0.0.1", "n/a", "n/a", typeof(string)));
             AddConfigKey(PropId.TerminalFontDefaultSize, new ConfigKey("TerminalFontDefaultSize", "DEFAULTFONTSIZE", "Initial Terminal:CHARHEIGHT when a terminal is first opened", 12, 6, 20, typeof(int)));
-            AddConfigKey(PropId.TerminalFontName, new ConfigKey("TerminalFontName", "FONTNAME", "Font Name for terminal window", "Courier New Bold", "n/a", "n/a", typeof(string)));
+            AddConfigKey(PropId.TerminalFontName, new ConfigKey("TerminalFontName", "FONTNAME", "Font Name for terminal window", "_not_chosen_yet_", "n/a", "n/a", typeof(string)));
             AddConfigKey(PropId.TerminalBrightness, new ConfigKey("TerminalBrightness", "BRIGHTNESS", "Initial brightness setting for new terminals", 0.7d, 0d, 1d, typeof(double)));
         }
 


### PR DESCRIPTION
Fixes #1956 

Note, because the only places I could find to download the C64 fonts from were sites with possibly invasive banner ads I didn't feel comfortable linking to in a URL, I decided to just mention the existence of the fonts out there, and let the user search for them, instead of including a direct URL.

---

When making the font dialog, I discovered
that the font search list didn't actually
work properly when the first font in the
list was a bogus font name like "_not_picked_".

Instead of trying the next font in the list, it was
just rendering everything in Arial.

There are some code changes to fix that problem too
in here.