### PR TITLE
Version 1.1.0 closeout fixes

### DIFF
--- a/src/kOS.Safe/UpdateHandler.cs
+++ b/src/kOS.Safe/UpdateHandler.cs
@@ -61,7 +61,31 @@ namespace kOS.Safe
                 observer.KOSFixedUpdate(deltaTime);
             }
         }
-        
+
+        public void ClearAllObservers()
+        {
+            var snapshot = new HashSet<IUpdateObserver>(observers);
+            foreach (var observer in snapshot)
+            {
+                IDisposable disp = observer as IDisposable;
+                if (disp != null)
+                {
+                    disp.Dispose();
+                }
+            }
+            var snapshotFixed = new HashSet<IFixedUpdateObserver>(fixedObservers);
+            foreach (var observer in snapshotFixed)
+            {
+                IDisposable disp = observer as IDisposable;
+                if (disp != null)
+                {
+                    disp.Dispose();
+                }
+            }
+            observers.Clear();
+            fixedObservers.Clear();
+        }
+
         /// <summary>
         /// Return all the registered fixed update handlers of a particular type
         /// </summary>

--- a/src/kOS/Communication/CommNetConnectivityManager.cs
+++ b/src/kOS/Communication/CommNetConnectivityManager.cs
@@ -105,7 +105,7 @@ namespace kOS.Communication
                 return true;
 
             // We next need to query the network to find a connection between the two vessels.
-            // I found no exposed method for accessing chached paths directly, other than the
+            // I found no exposed method for accessing cached paths directly, other than the
             // control path.
 
             // WARNING: In stock this will only work for vessels with a relay antenna installed.
@@ -113,7 +113,7 @@ namespace kOS.Communication
             // there isn't a very good way around it.
             var net = CommNetNetwork.Instance.CommNet;
             tempPath = new CommPath();
-            return net.FindPath(vessel1.Connection.Comm, tempPath, vessel2.Connection.Comm) || net.FindPath(vessel2.Connection.Comm, tempPath, vessel1.Connection.Comm);
+            return vessel1 == vessel2 || net.FindPath(vessel1.Connection.Comm, tempPath, vessel2.Connection.Comm) || net.FindPath(vessel2.Connection.Comm, tempPath, vessel1.Connection.Comm);
         }
 
         public void AddAutopilotHook(Vessel vessel, FlightInputCallback hook)

--- a/src/kOS/Communication/CommNetConnectivityManager.cs
+++ b/src/kOS/Communication/CommNetConnectivityManager.cs
@@ -113,7 +113,7 @@ namespace kOS.Communication
             // there isn't a very good way around it.
             var net = CommNetNetwork.Instance.CommNet;
             tempPath = new CommPath();
-            return vessel1 == vessel2 || net.FindPath(vessel1.Connection.Comm, tempPath, vessel2.Connection.Comm) || net.FindPath(vessel2.Connection.Comm, tempPath, vessel1.Connection.Comm);
+            return vessel1.id == vessel2.id || net.FindPath(vessel1.Connection.Comm, tempPath, vessel2.Connection.Comm) || net.FindPath(vessel2.Connection.Comm, tempPath, vessel1.Connection.Comm);
         }
 
         public void AddAutopilotHook(Vessel vessel, FlightInputCallback hook)

--- a/src/kOS/Function/HighlightStructure.cs
+++ b/src/kOS/Function/HighlightStructure.cs
@@ -35,6 +35,8 @@ namespace kOS.Function
             stale = true;
             enabled = true;
             updateHandler.AddObserver(this);
+            GameEvents.onStageSeparation.Add(OnHighlightStaleEvent);
+            GameEvents.onVesselPartCountChanged.Add(OnHighlightStaleEvent);
         }
 
         private void InitializeSuffixes()
@@ -111,9 +113,21 @@ namespace kOS.Function
             part.SetHighlight(enabled, false);
         }
 
+        private void OnHighlightStaleEvent(EventReport evt)
+        {
+            stale = true;
+        }
+
+        private void OnHighlightStaleEvent(Vessel ves)
+        {
+            stale = true;
+        }
+
         public void Dispose()
         {
             updateHandler.RemoveObserver(this);
+            GameEvents.onStageSeparation.Remove(OnHighlightStaleEvent);
+            GameEvents.onVesselPartCountChanged.Remove(OnHighlightStaleEvent);
         }
 
         public override string ToString()

--- a/src/kOS/SharedObjects.cs
+++ b/src/kOS/SharedObjects.cs
@@ -38,6 +38,7 @@ namespace kOS
             if (BindingMgr != null) { BindingMgr.Dispose(); }
             if (Window != null) { UnityEngine.Object.Destroy(Window); }
             if (SoundMaker != null) { SoundMaker.StopAllVoices(); }
+            if (UpdateHandler != null) { UpdateHandler.ClearAllObservers(); }
             var props = typeof(SharedObjects).GetProperties();
             foreach (var prop in props)
             {

--- a/src/kOS/SharedObjects.cs
+++ b/src/kOS/SharedObjects.cs
@@ -42,7 +42,7 @@ namespace kOS
             var props = typeof(SharedObjects).GetProperties();
             foreach (var prop in props)
             {
-                if (!prop.PropertyType.IsValueType)
+                if (!prop.PropertyType.IsValueType && prop.GetSetMethod() != null)
                 {
                     prop.SetValue(this, null, null);
                 }


### PR DESCRIPTION
UpdateHandler.cs
* Add a new method ClearAllObservers which will clear all observers and
Dispose of any observer that implements IDisposable

SharedObjects.cs
* Call the new ClearAllObservers method in SharedObjects.DestroyObjects
* Check to see if there is a Set method before setting a value to null

HighlightStructure.cs
* Add event subscription to monitor ship status
* Unsubscribe from events inside of Dispose

CommNetConnectivityManager.cs
* Update HasConnection to return true no matter what if checking
connection to the same cpu vessel
* Also fix a comment typo

Fixes #1977
Fixes #1911
Fixes #1783