### PR TITLE
Irrelevant whitespace change to force travis build.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ to the KSP API to make it work with KSP 1.3.
 Also updated the included ModuleManager to version 2.8, which
 is a necessity for compatibility with KSP 1.3.
 
+
 # v1.1.0 (for KSP 1.2.2) Ewww, everything's GUI.
 
 ### BREAKING CHANGES

--- a/src/kOS.Safe/Encapsulation/ListValue.cs
+++ b/src/kOS.Safe/Encapsulation/ListValue.cs
@@ -157,3 +157,6 @@ namespace kOS.Safe.Encapsulation
         }
     }
 }
+
+
+

--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -929,3 +929,6 @@ namespace kOS.Module
         }
     }
 }
+
+
+


### PR DESCRIPTION
This commit of pure whitespace-only changes is just so I can push a "code change" and see if travis's build will work with the new KSP 1.3 stub DLLs.