### PR TITLE
Fixes #2061 unicode mangle

### DIFF
--- a/src/kOS/Persistence/PersistenceExtensions.cs
+++ b/src/kOS/Persistence/PersistenceExtensions.cs
@@ -128,7 +128,7 @@ namespace kOS.Persistence
             {
                 if (SafeHouse.Config.UseCompressedPersistence)
                 {
-                    node.AddValue("binary", EncodeBase64(content.String));
+                    node.AddValue("binary", PersistenceUtilities.EncodeBase64(content.Bytes));
                 }
                 else
                 {
@@ -151,9 +151,5 @@ namespace kOS.Persistence
             }
         }
 
-        private static string EncodeBase64(string input)
-        {
-            return PersistenceUtilities.EncodeBase64(Encoding.ASCII.GetBytes(input));
-        }
     }
 }

--- a/src/kOS/Screen/KOSToolbarWindow.cs
+++ b/src/kOS/Screen/KOSToolbarWindow.cs
@@ -112,6 +112,7 @@ namespace kOS.Screen
             GameEvents.onGUIApplicationLauncherUnreadifying.Add(RemoveButton);
             GameEvents.onHideUI.Add(OnHideUI);
             GameEvents.onShowUI.Add(OnShowUI);
+            GameEvents.onGameStateSave.Add(OnGameStateSave);
             GameObject.DontDestroyOnLoad(this);
 
             fontPicker = null;
@@ -254,6 +255,7 @@ namespace kOS.Screen
 
             GameEvents.onHideUI.Remove(OnHideUI);
             GameEvents.onShowUI.Remove(OnShowUI);
+            GameEvents.onGameStateSave.Remove(OnGameStateSave);
 
             GoAway();
             SafeHouse.Logger.SuperVerbose("[kOSToolBarWindow] OnDestroy successful");
@@ -404,6 +406,18 @@ namespace kOS.Screen
         void OnShowUI()
         {
             uiGloballyHidden = false;
+        }
+
+        // As long as the user can get this toolbar menu dialog to show up, that means
+        // they can change a setting in it.  Those changes should be persisted even when
+        // there's no KOSProcessor modules loaded in the scene.  (Thus why the config
+        // save is done here as well as in KOSProcessor.)
+        void OnGameStateSave(ConfigNode node) // ConfigNode ignored.
+        {
+            if (SafeHouse.Config != null)
+            {
+                SafeHouse.Config.SaveConfig();
+            }
         }
 
         public void OnGUI()

--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -444,10 +444,14 @@ namespace kOS.Screen
             Event e = Event.current;
             if (e.type == EventType.KeyDown)
             {
-                // Unity handles some keys in a particular way
-                // e.g. Keypad7 is mapped to 0xffb7 instead of 0x37
-                var c = (char)(e.character & 0x007f);
-
+                // This ugly hack is here to solve a bug with Unity mapping
+                // Keycodes to Unicode chars incorrectly on its Linux version:
+                char c;
+                if ((e.character & 0xff00) == 0xff00) // Only trigger on Unicode values 0xff00 through 0xffff, to avoid issue #2061
+                    c = (char)(e.character & 0x007f); // When doing this to solve issue #206
+                else
+                    c = e.character;
+                
                 // command sequences
                 if (e.keyCode == KeyCode.C && e.control) // Ctrl+C
                 {


### PR DESCRIPTION
Fixes #2061 

Two places where unicode support for characters with codes > 127 didn't quite work right.  See in-line comments in the PR for details.
