### PR TITLE
Fix compile from interpreter context

### DIFF
--- a/src/kOS.Safe/Execution/YieldFinishedCompile.cs
+++ b/src/kOS.Safe/Execution/YieldFinishedCompile.cs
@@ -40,7 +40,8 @@ namespace kOS.Safe.Execution
 
         public override void ThreadInitialize(SafeSharedObjects shared)
         {
-            programContext = shared.Cpu.SwitchToProgramContext();
+            if (compileMode != CompileMode.FILE)
+                programContext = shared.Cpu.SwitchToProgramContext(); // only switch the context if executing
             codeParts = new List<CodePart>();
         }
 


### PR DESCRIPTION
Fixes #2069

YieldFinishedCompile.cs
* Previously we switched to the program context every time a program
compiled, which cause an issue with an empty program context if called
from the interpreter.
* Added a check for FILE CompileMode before switching contexts