### PR TITLE
Fixes #2067 - Deprecated suffixes in Docs

### DIFF
--- a/doc/source/structures/celestial_bodies/atmosphere.rst
+++ b/doc/source/structures/celestial_bodies/atmosphere.rst
@@ -111,7 +111,7 @@ Deprecated Suffix
 
         .. deprecated:: 0.17.2
 
-            To get the same functionality, you must use :attr:`Vessel:PATCHES`  which is a suffix of the :struct:`Vessel` itself.
+            Removed to account for significant changes to planetary atmosphere mechanics introduced in KSP 1.0
 
 
 Atmospheric Math

--- a/doc/source/structures/celestial_bodies/atmosphere.rst
+++ b/doc/source/structures/celestial_bodies/atmosphere.rst
@@ -59,13 +59,6 @@ A Structure closely tied to :struct:`Body` A variable of type :struct:`Atmospher
 
     True if the air has oxygen and could therefore be used by a jet engine's intake.
 
-.. attribute:: Atmosphere:SCALE
-
-    :type: :ref:`scalar <scalar>`
-    :access: Get only
-
-    A math constant plugged into a formula to find atmosphere density.
-
 .. attribute:: Atmosphere:SEALEVELPRESSURE
 
     :type: :ref:`scalar <scalar>` (atm)
@@ -103,6 +96,23 @@ A Structure closely tied to :struct:`Body` A variable of type :struct:`Atmospher
     :access: Get only
 
     The altitude at which the atmosphere is "officially" advertised as ending. (actual ending value differs, see below).
+
+Deprecated Suffix
+-----------------
+
+.. attribute:: Atmosphere:SCALE
+
+    :type: :ref:`scalar <scalar>`
+    :access: Get only
+
+    A math constant plugged into a formula to find atmosphere density.
+
+    .. note::
+
+        .. deprecated:: 0.17.2
+
+            To get the same functionality, you must use :attr:`Vessel:PATCHES`  which is a suffix of the :struct:`Vessel` itself.
+
 
 Atmospheric Math
 ----------------

--- a/doc/source/structures/celestial_bodies/atmosphere.rst
+++ b/doc/source/structures/celestial_bodies/atmosphere.rst
@@ -24,7 +24,7 @@ A Structure closely tied to :struct:`Body` A variable of type :struct:`Atmospher
         * - :attr:`OXYGEN`
           - :ref:`boolean <boolean>`
           - True if oxygen is present
-        * - :attr:`SCALE`
+        * - :attr:`SCALE` (DEPRECATED)
           - :ref:`scalar <scalar>`
           - Used to find atmospheric density
         * - :attr:`SEALEVELPRESSURE`

--- a/doc/source/structures/vessels/vessel.rst
+++ b/doc/source/structures/vessels/vessel.rst
@@ -215,13 +215,6 @@ All vessels share a structure. To get a variable referring to any vessel you can
 
     How fast the ship is moving relative to the air. KSP models atmosphere as simply a solid block of air "glued" to the planet surface (the weather on Kerbin is boring and there's no wind). Therefore airspeed is generally the same thing as as the magnitude of the surface velocity.
 
-.. attribute:: Vessel:TERMVELOCITY
-
-    :type: :ref:`scalar <scalar>` (m/s)
-    :access: Get only
-
-    terminal velocity of the vessel in freefall through atmosphere, based on the vessel's current altitude above sea level, and its drag properties. Warning, can cause values of Infinity if used in a vacuum, and kOS sometimes does not let you store Infinity in a variable.
-
 .. attribute:: Vessel:SHIPNAME
 
     :type: :ref:`string <string>`

--- a/doc/source/structures/vessels/vessel.rst
+++ b/doc/source/structures/vessels/vessel.rst
@@ -518,4 +518,4 @@ Deprecated Suffix
 
         .. deprecated:: 0.17.2
 
-            Removed to account for the numerous changes to the planetary atmosphere introduced in KSP 1.0
+            Removed to account for significant changes to planetary atmosphere mechanics introduced in KSP 1.0

--- a/doc/source/structures/vessels/vessel.rst
+++ b/doc/source/structures/vessels/vessel.rst
@@ -46,7 +46,6 @@ All vessels share a structure. To get a variable referring to any vessel you can
     :attr:`VERTICALSPEED`                    :struct:`scalar` (m/s)          How fast the ship is moving "up"
     :attr:`GROUNDSPEED`                      :struct:`scalar` (m/s)          How fast the ship is moving "horizontally"
     :attr:`AIRSPEED`                         :struct:`scalar` (m/s)          How fast the ship is moving relative to the air
-    :attr:`TERMVELOCITY`                     :struct:`scalar` (m/s)          terminal velocity of the vessel
     :attr:`SHIPNAME`                         :struct:`string`                The name of the vessel
     :attr:`NAME`                             :struct:`string`                Synonym for SHIPNAME
     :attr:`STATUS`                           :struct:`string`                Current ship status
@@ -510,3 +509,19 @@ All vessels share a structure. To get a variable referring to any vessel you can
     :return: :struct:`MessageQueue`
 
     Returns this vessel's message queue. You can only access this attribute for your current vessel (using for example `SHIP:MESSAGES`).
+
+Deprecated Suffix
+-----------------
+
+.. attribute:: Vessel:TERMVELOCITY
+
+    :type: :ref:`scalar <scalar>` (m/s)
+    :access: Get only
+
+    terminal velocity of the vessel in freefall through atmosphere, based on the vessel's current altitude above sea level, and its drag properties. Warning, can cause values of Infinity if used in a vacuum, and kOS sometimes does not let you store Infinity in a variable.
+
+    .. note::
+
+        .. deprecated:: 0.17.2
+
+            Removed to account for the numerous changes to the planetary atmosphere introduced in KSP 1.0

--- a/doc/source/structures/vessels/vessel.rst
+++ b/doc/source/structures/vessels/vessel.rst
@@ -46,6 +46,7 @@ All vessels share a structure. To get a variable referring to any vessel you can
     :attr:`VERTICALSPEED`                    :struct:`scalar` (m/s)          How fast the ship is moving "up"
     :attr:`GROUNDSPEED`                      :struct:`scalar` (m/s)          How fast the ship is moving "horizontally"
     :attr:`AIRSPEED`                         :struct:`scalar` (m/s)          How fast the ship is moving relative to the air
+    :attr:`TERMVELOCITY`(DEPRECATED)         :struct:`scalar` (m/s)          terminal velocity of the vessel
     :attr:`SHIPNAME`                         :struct:`string`                The name of the vessel
     :attr:`NAME`                             :struct:`string`                Synonym for SHIPNAME
     :attr:`STATUS`                           :struct:`string`                Current ship status

--- a/doc/source/tutorials/pidloops.rst
+++ b/doc/source/tutorials/pidloops.rst
@@ -309,7 +309,7 @@ The script we'll use to tune the highly overpowered rocket shown will launch the
 
     // feedback based on atmospheric efficiency
     LOCK surfspeed TO SHIP:VELOCITY:SURFACE:MAG.
-    LOCK atmoeff TO surfspeed / SHIP:TERMVELOCITY.
+    LOCK atmoeff TO surfspeed / SHIP:TERMVELOCITY.  //Using deprecated TERMVELOCITY syntax
     LOCK P TO 1.0 - atmoeff.
 
     SET t0 TO TIME:SECONDS.


### PR DESCRIPTION
Fixes #2067 

Changed the following:
  - `Vessel:TERMVELOCITY` definition on `/vessel` page and `Atmosphere:SCALE` definition on `/atmosphere` page were moved to "Deprecated Suffix" sections on their respective pages .  Deprecated suffix reference in summary list at top of pages annotated as (DEPRECATED) as well. 
-  Commented code lines in examples using `TERMVELOCITY` to indicate line is using deprecated syntax

I performed searches through both the online docs and the `.rst` files, but I couldn't find any references to `TERMINALVELOCITY`

