### PR TITLE
Fixes #1860 - progress bar terminal resize

### DIFF
--- a/src/kOS.Safe/Screen/IScreenBuffer.cs
+++ b/src/kOS.Safe/Screen/IScreenBuffer.cs
@@ -30,6 +30,7 @@ namespace kOS.Safe.Screen
         List<IScreenBufferLine> GetBuffer();
         void AddResizeNotifier(ScreenBuffer.ResizeNotifier notifier);
         void RemoveResizeNotifier(ScreenBuffer.ResizeNotifier notifier);
+        void RemoveAllResizeNotifiers();
         string DebugDump();
     }
 }

--- a/src/kOS.Safe/Screen/ScreenBuffer.cs
+++ b/src/kOS.Safe/Screen/ScreenBuffer.cs
@@ -85,6 +85,11 @@ namespace kOS.Safe.Screen
             Notifyees.Remove(notifier);
         }
 
+        public void RemoveAllResizeNotifiers()
+        {
+            Notifyees.Clear();
+        }
+
         public void SetSize(int rows, int columns)
         {
             RowCount = rows;

--- a/src/kOS.Safe/Screen/SubBuffer.cs
+++ b/src/kOS.Safe/Screen/SubBuffer.cs
@@ -21,9 +21,9 @@ namespace kOS.Safe.Screen
         /// if the new size is too small to hold the contents, and WillTruncate is false,
         /// then it will refuse to make it that small, and will use more rows than you
         /// requested as needed to preserve contents.
-        /// You can override this by setting this SubBuffer's WillTrungate property to true.
+        /// You can override this by setting this SubBuffer's WillTruncate property to true.
         /// </summary>
-        /// <param name="rowCount">Requested new number of rows (only guaranteed to be obeyed if truncateOkay is true)</param>
+        /// <param name="rowCount">Requested new number of rows (only guaranteed to be obeyed if WillTruncate is true)</param>
         /// <param name="columnCount">Desired new number of columns (this will be adhered to faithfully).</param>
         public void SetSize(int rowCount, int columnCount)
         {

--- a/src/kOS.Safe/Screen/SubBuffer.cs
+++ b/src/kOS.Safe/Screen/SubBuffer.cs
@@ -62,7 +62,7 @@ namespace kOS.Safe.Screen
         /// Replaces Buffer with one of the new current size, copying old contents
         /// over.
         /// </summary>
-        /// <returns>The buffer.</returns>
+        /// <returns>(Not implemented, hardcoded to zero) The new row to scroll to if need be.</returns>
         protected virtual int ResizeBuffer()
         {
             // This method also is being left open for potential overriding in subclasses

--- a/src/kOS.Safe/Screen/SubBuffer.cs
+++ b/src/kOS.Safe/Screen/SubBuffer.cs
@@ -13,17 +13,17 @@ namespace kOS.Safe.Screen
         public int PositionRow { get; set; }
         public int PositionColumn { get; set; }
         public bool Enabled { get; set; }
+        public bool WillTruncate { get; set; }
 
         /// <summary>
         /// Stretch/shrink the subbuffer to a new size, trying as best as possible to
-        /// preserve existing contents.  Note that if the new size is too small to hold
-        /// the contents,  then it WILL refuse to make it that small, and will add rows to your
-        /// intended size as needed to preserve contents.
-        /// <br/><br/>
-        /// Example: contents are "xxxxxxxxxx\nxxxxx" and you try to make it size 1,5.  You'll
-        /// end up with it being size 3,5 instead so it could store all 15 characters in it.
+        /// preserve existing contents, including wrapping lines if needed.  Note that
+        /// if the new size is too small to hold the contents, and WillTruncate is false,
+        /// then it will refuse to make it that small, and will use more rows than you
+        /// requested as needed to preserve contents.
+        /// You can override this by setting this SubBuffer's WillTrungate property to true.
         /// </summary>
-        /// <param name="rowCount">Desired new number of rows (this may end up larger than you requested if necessary to hold contents)</param>
+        /// <param name="rowCount">Requested new number of rows (only guaranteed to be obeyed if truncateOkay is true)</param>
         /// <param name="columnCount">Desired new number of columns (this will be adhered to faithfully).</param>
         public void SetSize(int rowCount, int columnCount)
         {
@@ -58,6 +58,11 @@ namespace kOS.Safe.Screen
             return ResizeBuffer();
         }
 
+        /// <summary>
+        /// Replaces Buffer with one of the new current size, copying old contents
+        /// over.
+        /// </summary>
+        /// <returns>The buffer.</returns>
         protected virtual int ResizeBuffer()
         {
             // This method also is being left open for potential overriding in subclasses
@@ -71,20 +76,29 @@ namespace kOS.Safe.Screen
             int newRow = 0;
             int oldRow = 0;
             int newCol = 0;
-            
+            bool isFull = false;
+
             // First, copy everything from old to new, and perhaps enlarge the new if the old won't fit.
-            while (oldRow < Buffer.Count)
+            while (oldRow < Buffer.Count && !isFull)
             {
                 int oldCol = 0;
-                while (oldCol < Buffer[oldRow].Length)
+                while (oldCol < Buffer[oldRow].Length && !isFull)
                 {
                     if (newCol >= ColumnCount) // wrap to new line when cur line is full.
                     {
                         ++newRow;
                         newCol = 0;
                     }
-                    if (newRow >= newBuffer.Count) // grow to required size.
-                        newBuffer.Add(new ScreenBufferLine(ColumnCount));
+                    if (newRow >= newBuffer.Count) // grow to required size, or quit if we aren't supposed to grow
+                    {
+                        if (WillTruncate)
+                        {
+                            isFull = true;
+                            break;
+                        }
+                        else
+                            newBuffer.Add(new ScreenBufferLine(ColumnCount));
+                    }
                     newBuffer[newRow][newCol] = Buffer[oldRow][oldCol];
                     ++newCol;
                     ++oldCol;

--- a/src/kOS/Screen/ConnectivityInterpreter.cs
+++ b/src/kOS/Screen/ConnectivityInterpreter.cs
@@ -27,11 +27,6 @@ namespace kOS.Screen
             AddResizeNotifier(CreateProgressBarSubBuffer);
         }
 
-        ~ConnectivityInterpreter()
-        {
-            RemoveResizeNotifier(CreateProgressBarSubBuffer);
-        }
-
         /// <summary>Whenever the terminal resizes, resize the progress bar,</summary>
         /// <param name="sb">The method operates on self (this), and the parameter sb would
         /// be unnecessary if it wasn't required by AddResizeNotifyer().</parm>

--- a/src/kOS/Screen/ConnectivityInterpreter.cs
+++ b/src/kOS/Screen/ConnectivityInterpreter.cs
@@ -27,6 +27,18 @@ namespace kOS.Screen
             AddResizeNotifier(CreateProgressBarSubBuffer);
         }
 
+        ~ConnectivityInterpreter()
+        {
+            // Normally this design pattern would fail because the notifier hooks
+            // would be references that prevent orphaning and thus we can't remove
+            // them in the destructor.
+            // 
+            // But in this case it probably can work, because this reference is
+            // circularly from the object to *itself* (these hooks are inside this
+            // instance itself), and thus probably don't prevent orphaning:
+            RemoveAllResizeNotifiers();
+        }
+
         /// <summary>Whenever the terminal resizes, resize the progress bar,</summary>
         /// <param name="sb">The method operates on self (this), and the parameter sb would
         /// be unnecessary if it wasn't required by AddResizeNotifyer().</parm>

--- a/src/kOS/Screen/ConnectivityInterpreter.cs
+++ b/src/kOS/Screen/ConnectivityInterpreter.cs
@@ -93,10 +93,6 @@ namespace kOS.Screen
 
         private void StartDeployment()
         {
-            // Make a new progress bar each time, orphaning the old.
-            // Then it matches the current terminal size when the command was entered:
-            CreateProgressBarSubBuffer(this);
-
             deploymentInProgress = true;
             progressBarSubBuffer.Enabled = (waitTotal > 0.5);
             deploymentMessage = deployingBatch ? "Deploying batch." : "Deploying command.";

--- a/src/kOS/SharedObjects.cs
+++ b/src/kOS/SharedObjects.cs
@@ -46,6 +46,7 @@ namespace kOS
             if (SoundMaker != null) { SoundMaker.StopAllVoices(); }
             if (UpdateHandler != null) { UpdateHandler.ClearAllObservers(); }
             if (GameEventDispatchManager != null) { GameEventDispatchManager.Clear(); }
+            if (Interpreter != null) { Interpreter.RemoveAllResizeNotifiers(); }
             var props = typeof(SharedObjects).GetProperties();
             IDisposable tempDisp;
             foreach (var prop in props)


### PR DESCRIPTION
Fixes #1860 

To test:

  - Be sure RemoteTech is installed.
  - Start new sandbox game.  Choose RemoteTechConnectivityManager.
  - Use Alt-F12 'set orbit' cheat to put a comsat into Kerbin orbit
  that can act as a relay to Duna.
  - Use Alt-F12 'set orbit' cheat to put a kOS-capable probe around Duna that
  relays through the satellite you made above.
  - Keep trying ``print "hello".`` in the probe's kOS Terminal,
  after resizing the terminal to different amounts.  Notice it will
  react to changes to the terminal made during the progres bar's
  wait time too, re-drawing the bar to fit the new size at the same
  ratio of completion it had before.