### PR TITLE
Fixes #2079

### DIFF
--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -1568,12 +1568,21 @@ namespace kOS.Safe.Compilation.KS
 
             if (trailerNode.Nodes[1].Token.Type == TokenType.arglist)
             {
-                bool remember = identifierIsSuffix;
+                // Some of the flags remembering the context of
+                // what we were inside of in the parse tree aren't
+                // appropriate to be using while evaluating the function's
+                // argument terms in the list:
+                bool rememberIsSuffix = identifierIsSuffix;
                 identifierIsSuffix = false;
+                bool rememberCompilingSetDestination = compilingSetDestination;
+                compilingSetDestination = false;
 
+                // Now compile the arguments in the list:
                 VisitNode(trailerNode.Nodes[1]);
 
-                identifierIsSuffix = remember;
+                // And then return the flags to their original condition:
+                compilingSetDestination = rememberCompilingSetDestination;
+                identifierIsSuffix = rememberIsSuffix;
             }
 
             if (isDirect)
@@ -1587,6 +1596,7 @@ namespace kOS.Safe.Compilation.KS
                 var op = new OpcodeCall(string.Empty) { Direct = false };
                 AddOpcode(op);
             }
+
         }
 
         private void VisitArgList(ParseNode node)


### PR DESCRIPTION
The actual problem was a kerboscript compiler bug caused by any script code of the following format:
```
set f(collection[some_index]):suffix to value.
```

There is a special flag in the compiler called ``compilingSetDestination``
that exists to work around the following problem:

The indexing for ``set thing[index] to val.`` requires
a different set of Opcodes than when getting the value at thing[index].
(You can't do OpcodeGetIndex, then set the result, and expect
to end up affecing the actual member of the collection.  If you do that
you only end up affecting the copy that was on the stack.  So the
Opcodes are slightly different when you expect to set the value AT that
index, rather than merely get that value).

So to manage this difference, the flag ``compilingSetDestination`` is
turned on while the compiler walks through the ``foo`` part of the
parse tree in any statement of the form ``set foo to value.`` or
``local foo is value.``.  This is a flag that essentially means,
"activate special exception code to handle the fact that this
expression is a lefthand-side expression that's going to get set,
not just read."

The problem is that one of the limited allowed things in such a lefthand-side
expression is a function call (see kRisc.tpg, ``varidentifier``, which is the
list of limited things you're allowed inside a set destination).
This caused that flag to remain on when parsing the function's arg list in
cases like so: `` set foo(arg1, arg2):suffix to value.``

So it was treating anything it found iside those args as if THEY
were the thing that would be assigned into.  This activated the
special exception code described above for indexes, when it shouldn't
have.

The fix is that when evaluating the args of a function call, that
flag should be temporarily suppressed so the args don't count as
set destinations just because they're being used to find the
eventual thing that will become the set destination at the outermost
level of that expression.