### PR TITLE
Fixes #2082 by allowing NoDelegate w/out Shared

### DIFF
--- a/src/kOS.Safe/Encapsulation/KOSDelegate.cs
+++ b/src/kOS.Safe/Encapsulation/KOSDelegate.cs
@@ -49,6 +49,8 @@ namespace kOS.Safe.Encapsulation
 
         public Structure CallPassingArgs(params Structure[] args)
         {
+            if (Cpu == null)
+                throw new KOSCannotCallException();
             PushUnderArgs();
             Cpu.PushStack(new KOSArgMarkerType());
             foreach (Structure arg in PreBoundArgs)
@@ -78,6 +80,8 @@ namespace kOS.Safe.Encapsulation
         /// </summary>
         public void InsertPreBoundArgs()
         {
+            if (Cpu == null)
+                throw new KOSCannotCallException();
             Stack<object> aboveArgs = new Stack<object>();
             object arg = ""; // doesn't matter what it is as long as it's non-null for the while check below.
             while (arg != null && !(arg is KOSArgMarkerType))

--- a/src/kOS.Safe/Encapsulation/NoDelegate.cs
+++ b/src/kOS.Safe/Encapsulation/NoDelegate.cs
@@ -18,7 +18,7 @@ namespace kOS.Safe.Encapsulation
         static private int sameHashForAllInstances =
             ("All EmptyDelegate Instances are Equal 0987654321.123456789").GetHashCode();
 
-        public NoDelegate(ICpu cpu) : base(cpu, cpu.GetCurrentContext(), -1, false)
+        public NoDelegate(ICpu cpu) : base(cpu, (cpu == null ? null : cpu.GetCurrentContext()), -1, false)
         {
         }
 

--- a/src/kOS.Safe/Encapsulation/UserDelegate.cs
+++ b/src/kOS.Safe/Encapsulation/UserDelegate.cs
@@ -56,6 +56,8 @@ namespace kOS.Safe.Encapsulation
         {
             return (weakProgContext != null) && // If this is still null then we got called during the constructor and this doesn't count yet.
                 (
+                    (Cpu == null) ||
+                    (ProgContext == null) ||
                     (!weakProgContext.IsAlive) ||
                     (weakProgContext.Target == null) ||
                     (((IProgramContext)weakProgContext.Target).ContextId != Cpu.GetCurrentContext().ContextId)
@@ -139,9 +141,8 @@ namespace kOS.Safe.Encapsulation
             EntryPoint = entryPoint;
             if (useClosure)
                 CaptureClosure();
-            else
-                Closure = new List<VariableScope>(); // make sure it exists as an empty list so we don't have to have 'if null' checks everwywhere.
-            Cpu.AddPopContextNotifyee(this);
+            if (Cpu != null)
+                Cpu.AddPopContextNotifyee(this);
         }
 
         public UserDelegate(UserDelegate oldCopy) : base(oldCopy)
@@ -149,7 +150,8 @@ namespace kOS.Safe.Encapsulation
             ProgContext = oldCopy.ProgContext;
             EntryPoint = oldCopy.EntryPoint;
             Closure = oldCopy.Closure;
-            Cpu.AddPopContextNotifyee(this);
+            if (Cpu != null)
+                Cpu.AddPopContextNotifyee(this);
         }
         
         public override KOSDelegate Clone()
@@ -159,13 +161,16 @@ namespace kOS.Safe.Encapsulation
 
         private void CaptureClosure()
         {
-            Closure = Cpu.GetCurrentClosure();
+            if (Cpu != null)
+                Closure = Cpu.GetCurrentClosure();
+            else
+                Closure = new List<VariableScope>(); // make sure it exists as an empty list so we don't have to have 'if null' checks everwywhere.
         }
         
         public override string ToString()
         {
             return string.Format("UserDelegate(cpu={0}, entryPoint={1}, Closure={2},\n   {3})",
-                                 Cpu, EntryPoint, Closure, base.ToString());
+                (Cpu == null ? "(No CPU)" : Cpu.ToString()), EntryPoint, Closure, base.ToString());
         }
         
         public override bool Equals(object obj)
@@ -191,6 +196,8 @@ namespace kOS.Safe.Encapsulation
 
         public override void PushUnderArgs()
         {
+            if (Cpu == null)
+                throw new KOSCannotCallException();
             CheckForDead(true);
             // Going to do an indirect call of myself, and indirect calls need
             // to have the delegate underneath the args.  That's how
@@ -200,6 +207,8 @@ namespace kOS.Safe.Encapsulation
 
         public override Structure CallWithArgsPushedAlready()
         {
+            if (Cpu == null)
+                throw new KOSCannotCallException();
             CheckForDead(true);
             int absoluteJumpTo = OpcodeCall.StaticExecute(Cpu, false, "", true);
             if (absoluteJumpTo >= 0)


### PR DESCRIPTION
Fixes #2082.

The problem was that the GUI code was trying to make use of
a feature of the ``NoDelegate`` type which it turns out
never really worked right, ``NoDelegate.Instance``.

NoDelegate.Instance can't refer to which Cpu it's part of (to
do so it would have to have one copy per ``SharedObjects``,
rather than one gobally static instance.)  So it tries to
construct a ``NoDelegate`` with a null ``Cpu``, under the
premise that you don't need a real ``Cpu`` defined if it
can never be called.  But it turned out
that never really worked because the NoDelegate constructor,
when making the very first ``instance``, still tries to call
``Cpu.GetCurrentContext()`` (on the null ``Cpu``) as part
of passing off to the ``UserDelegate`` base constructor, here:

```
        public NoDelegate(ICpu cpu) : base(cpu, cpu.GetCurrentContext(), -1, false)
        {
        }
```

Fixing this meant making it so that NoDelegate is actually able
to tolerate being constructed with a null ``Cpu``, and that meant
having to insert a few extra safety checks here and there.