### PR TITLE
Altered VersionInfo so it can hold 4 values

### DIFF
--- a/doc/source/bindings.rst
+++ b/doc/source/bindings.rst
@@ -379,10 +379,11 @@ something entirely outside the in-character experience.
 
 ::
 
-    PRINT VERSION.            // Returns operating system version number. e.g. 0.8.6
-    PRINT VERSION:MAJOR.      // Returns major version number. e.g. 0
-    PRINT VERSION:MINOR.      // Returns minor version number. e.g. 8
-    PRINT VERSION:BUILD.      // Returns build version number. e.g. 6
+    PRINT VERSION.            // Returns operating system version number. e.g. 0.1.2.3
+    PRINT VERSION:MAJOR.      // Returns major version number. e.g. 0 if version is 0.1.2.3
+    PRINT VERSION:MINOR.      // Returns minor version number. e.g. 1 if version is 0.1.2.3
+    PRINT VERSION:PATCH.      // Returns patch version number. e.g. 2 if version is 0.1.2.3
+    PRINT VERSION:BUILD.      // Returns build version number. e.g. 3 if version is 0.1.2.3
     PRINT SESSIONTIME.        // Returns amount of time, in seconds, from vessel load.
 
 NOTE the following important difference:

--- a/src/kOS.Safe/Encapsulation/VersionInfo.cs
+++ b/src/kOS.Safe/Encapsulation/VersionInfo.cs
@@ -7,12 +7,14 @@ namespace kOS.Safe.Encapsulation
     {
         private readonly int major;
         private readonly int minor;
+        private readonly int patch;
         private readonly int build;
 
-        public VersionInfo(int major, int minor, int build)
+        public VersionInfo(int major, int minor, int patch, int build)
         {
             this.major = major;
             this.minor = minor;
+            this.patch = patch;
             this.build = build;
             VersionInitializeSuffixes();
         }
@@ -21,12 +23,13 @@ namespace kOS.Safe.Encapsulation
         {
             AddSuffix("MAJOR", new StaticSuffix<ScalarValue>(() => major));
             AddSuffix("MINOR", new StaticSuffix<ScalarValue>(() => minor));
+            AddSuffix("PATCH", new StaticSuffix<ScalarValue>(() => patch));
             AddSuffix("BUILD", new StaticSuffix<ScalarValue>(() => build));
         }
 
         public override string ToString()
         {
-            return string.Format("{0}.{1}.{2}", major, minor, build);
+            return string.Format("{0}.{1}.{2}.{3}", major, minor, patch, build);
         }
     }
 }

--- a/src/kOS/Core.cs
+++ b/src/kOS/Core.cs
@@ -20,7 +20,13 @@ namespace kOS
         static Core()
         {
             var ver = typeof(Core).Assembly.GetName().Version;
-            VersionInfo = new VersionInfo(ver.Major, ver.Minor, ver.Build);
+            // NOTICE: there is a clash of nomenclature here.  C# calls the
+            // 3rd number "BUILD" and the 4th number "Revision" while the AVC mod
+            // (and presumably CKAN) calls the 3rd number "PATCH" and the 4th number "BUILD".
+            // We'll be using the AVC terminology in kerboscript, thus why this next line
+            // passes in "ver.Revision" where the VersionInfo's "BUILD" goes, and the
+            // "ver.Build" where VersionInfo's "PATCH" goes:
+            VersionInfo = new VersionInfo(ver.Major, ver.Minor, ver.Build, ver.Revision);
         }
 
         public Core(kOSProcessor processor, SharedObjects shared):base(processor, shared)


### PR DESCRIPTION
Small change to allow it to hold 4 numbers in the version and show them on the terminal bootup screen.