### PR TITLE
Update kOS.netkan

### DIFF
--- a/kOS.netkan
+++ b/kOS.netkan
@@ -3,6 +3,7 @@
     "identifier"     : "kOS",
     "$kref"          : "#/ckan/github/KSP-KOS/KOS",
     "$vref"          : "#/ckan/ksp-avc",
+    "x_netkan_epoch" : 1,
     "name"           : "kOS: Scriptable Autopilot System",
     "abstract"       : "kOS is a scriptable autopilot Mod for Kerbal Space Program. It allows you write small programs that automate specific tasks.",
     "author"         : "many KSP-KOS contributers, currently dunbaratu and hvacengi",
@@ -33,6 +34,14 @@
         {
             "file"   : "GameData/kOS",
             "install_to" : "GameData"
+        }
+    ],
+    "x_netkan_override": [
+        {
+            "version": "1:1.1.3.1",
+            "override": {
+                "ksp_version_min" : "1.2.0"
+            }
         }
     ]
 }


### PR DESCRIPTION
"x_netkan_epoch" gives us a numbering restart allowing us to jump over the 1.3.3.1 release. The epoch is hidden by default in the CKAN client.
"x_netkan_override" forces the min ksp version for the 1.1.3.1 release, which is still "1.0.0" in the download

I'll duplicate the 1.1.3.0 .ckan to 1:1.1.3.0 in the CKAN repo and change any others with the 1.0.0 ksp_min version.