### PR TITLE
Update for release for KSP 1.3.1 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
 
 env:
   global:
-  - KSP_VERSION="1.3.0"
+  - KSP_VERSION="1.3.1"
 
 # Pre-shared token for pushing notifications to slack chat
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 kOS Mod Changelog
 =================
+# v1.1.3.2 (for KSP 1.3.1) New KSP version HOTFIX
+This version is functionally identical to v1.1.3.0, however the binaries are
+compiled against KSP 1.3.1 to allow it to properly load with the updated version
+of KSP
+### BREAKING CHANGES:
+- This build will not work on previous versions of KSP.
+### NEW FEATURES:
+(None)
+### BUG FIXES:
+(None)
 # v1.1.3.1 (for KSP 1.2.2) Backward compatibility version of v1.1.3.0
 
 ### Only use if you are stuck on KSP 1.2.2.

--- a/Resources/GameData/kOS/kOS.version
+++ b/Resources/GameData/kOS/kOS.version
@@ -12,17 +12,17 @@
     "MAJOR": 1,
     "MINOR": 1,
     "PATCH": 3,
-    "BUILD": 0
+    "BUILD": 2
   },
   "KSP_VERSION": {
     "MAJOR": 1,
     "MINOR": 3,
-    "PATCH": 0
+    "PATCH": 1
   },
   "KSP_VERSION_MIN": {
     "MAJOR": 1,
     "MINOR": 3,
-    "PATCH": 0
+    "PATCH": 1
   },
   "KSP_VERSION_MAX": {
     "MAJOR": 1,

--- a/src/kOS/Properties/AssemblyInfo.cs
+++ b/src/kOS/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.1.3.0")]
-[assembly: AssemblyVersion("1.1.3.0")]
-[assembly: KSPAssembly("kOS", 1, 1)]
+[assembly: AssemblyFileVersion("1.1.3.2")]
+[assembly: AssemblyVersion("1.1.3.2")]
+[assembly: KSPAssembly("kOS", 1, 3)]


### PR DESCRIPTION
Fixes 2129
Fixes 2131

.travis.yml
* Point to updated KSP tar file
CHANGELOG.md
* Update changelog
kOS.version
* Update KSP version requirements
AssemblyInfo.cs
* Update assembly version number and KSPAssembly version

Once this is merged we can publish the corresponding release zip.