### PR TITLE
Fix scanner hang on very large numbers

### DIFF
--- a/src/kOS.Safe.Test/KS/ParserTest.cs
+++ b/src/kOS.Safe.Test/KS/ParserTest.cs
@@ -17,15 +17,15 @@ namespace kOS.Safe.Test.KS
         [SetUp]
         public void Setup()
         {
-          scanner = new Scanner();
-          parser = new Parser(scanner);
+            scanner = new Scanner();
+            parser = new Parser(scanner);
         }
 
         [Test, Timeout(2000)]
         public void ParsesLargeNumbers()
         {
-          parser.Parse("012345678901234567890123456789");
-          parser.Parse("// 012345678901234567890123456789");
+            parser.Parse("012345678901234567890123456789");
+            parser.Parse("// 012345678901234567890123456789");
         }
     }
 }

--- a/src/kOS.Safe.Test/KS/ParserTest.cs
+++ b/src/kOS.Safe.Test/KS/ParserTest.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using kOS.Safe.Compilation.KS;
+using NUnit.Framework;
+
+namespace kOS.Safe.Test.KS
+{
+    [TestFixture]
+    public class ParserTest
+    {
+        Scanner scanner;
+        Parser parser;
+
+        [SetUp]
+        public void Setup()
+        {
+          scanner = new Scanner();
+          parser = new Parser(scanner);
+        }
+
+        [Test, Timeout(2000)]
+        public void ParsesLargeNumbers()
+        {
+          parser.Parse("012345678901234567890123456789");
+          parser.Parse("// 012345678901234567890123456789");
+        }
+    }
+}

--- a/src/kOS.Safe.Test/kOS.Safe.Test.csproj
+++ b/src/kOS.Safe.Test/kOS.Safe.Test.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Persistence\HarddiskToHarddiskCopyAndMoveTest.cs" />
     <Compile Include="Persistence\ArchiveAndHarddiskCopyAndMoveTest.cs" />
     <Compile Include="Persistence\ArchiveToHarddiskCopyAndMoveTest.cs" />
+    <Compile Include="KS\ParserTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\kOS.Safe\kOS.Safe.csproj">
@@ -93,7 +94,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/kOS.Safe/Compilation/KS/Scanner.cs
+++ b/src/kOS.Safe/Compilation/KS/Scanner.cs
@@ -336,7 +336,7 @@ namespace kOS.Safe.Compilation.KS
             Patterns.Add(TokenType.INTEGER, regex);
             Tokens.Add(TokenType.INTEGER);
 
-            regex = new Regex(@"(\d[_\d]*)*\.\d[_\d]*");
+            regex = new Regex(@"(\d+(?:_\d*)*)\.\d+(?:_\d*)*");
             Patterns.Add(TokenType.DOUBLE, regex);
             Tokens.Add(TokenType.DOUBLE);
 

--- a/src/kOS.Safe/Compilation/KS/Scanner.cs
+++ b/src/kOS.Safe/Compilation/KS/Scanner.cs
@@ -336,7 +336,7 @@ namespace kOS.Safe.Compilation.KS
             Patterns.Add(TokenType.INTEGER, regex);
             Tokens.Add(TokenType.INTEGER);
 
-            regex = new Regex(@"(\d+(?:_\d*)*)\.\d+(?:_\d*)*");
+            regex = new Regex(@"(\d+(?:_\d*)*)?\.\d+(?:_\d*)*");
             Patterns.Add(TokenType.DOUBLE, regex);
             Tokens.Add(TokenType.DOUBLE);
 

--- a/src/kOS.Safe/Compilation/KS/kRISC.tpg
+++ b/src/kOS.Safe/Compilation/KS/kRISC.tpg
@@ -81,7 +81,7 @@ ALL          -> @"\ball\b";
 IDENTIFIER   -> @"[_\p{L}]\w*";
 FILEIDENT    -> @"[_\p{L}]\w*(\.[_\p{L}]\w*)*";
 INTEGER      -> @"\d[_\d]*";
-DOUBLE       -> @"(\d[_\d]*)*\.\d[_\d]*";
+DOUBLE       -> @"(\d+(?:_\d*)*)\.\d+(?:_\d*)*";
 STRING       -> @"@?\""(\""\""|[^\""])*\""";
 EOI          -> @"\.";
 //Compiler Directives

--- a/src/kOS.Safe/Compilation/KS/kRISC.tpg
+++ b/src/kOS.Safe/Compilation/KS/kRISC.tpg
@@ -81,7 +81,7 @@ ALL          -> @"\ball\b";
 IDENTIFIER   -> @"[_\p{L}]\w*";
 FILEIDENT    -> @"[_\p{L}]\w*(\.[_\p{L}]\w*)*";
 INTEGER      -> @"\d[_\d]*";
-DOUBLE       -> @"(\d+(?:_\d*)*)\.\d+(?:_\d*)*";
+DOUBLE       -> @"(\d+(?:_\d*)*)?\.\d+(?:_\d*)*";
 STRING       -> @"@?\""(\""\""|[^\""])*\""";
 EOI          -> @"\.";
 //Compiler Directives


### PR DESCRIPTION
Fixes #2080 

The regex used for parsing doubles had an extremely high branching factor, resulting in an out-of-memory error when parsing longer strings. This replaces it with a lower branching regex of:

- 0 or 1
  - 1 or more digit
  - 0 or more
    - `_`
    - 0 or more digits
- `.`
- 1 or more digit
- 0 or more
  - `_`
  - 0 or more digits

This maintains the behavior of allowing weird numbers like `0_.0_`