### PR TITLE
Don't re-initialize suffixes on every GetSuffix

### DIFF
--- a/src/kOS.Safe/Encapsulation/Structure.cs
+++ b/src/kOS.Safe/Encapsulation/Structure.cs
@@ -48,6 +48,7 @@ namespace kOS.Safe.Encapsulation
                 {
                     callback.Invoke();
                 }
+                needToInitializeSuffixes = false;
             }
         }
         


### PR DESCRIPTION
This dropped the runtime of my perf script (sorting 200 random items in a `list`) from 26 seconds to 18 seconds.