### PR TITLE
Rewrite Stack to be double stack

### DIFF
--- a/src/kOS.Safe.Test/Opcode/FakeCpu.cs
+++ b/src/kOS.Safe.Test/Opcode/FakeCpu.cs
@@ -35,11 +35,6 @@ namespace kOS.Safe.Test.Opcode
             return fakeStack.Pop();
         }
 
-        public void MoveStackPointer(int delta)
-        {
-            throw new NotImplementedException();
-        }
-
         public void PushAboveStack(object thing)
         {
             throw new NotImplementedException();

--- a/src/kOS.Safe.Test/Opcode/FakeCpu.cs
+++ b/src/kOS.Safe.Test/Opcode/FakeCpu.cs
@@ -35,12 +35,12 @@ namespace kOS.Safe.Test.Opcode
             return fakeStack.Pop();
         }
 
-        public void PushAboveStack(object thing)
+        public void PushScopeStack(object thing)
         {
             throw new NotImplementedException();
         }
 
-        public object PopAboveStack(int howMany)
+        public object PopScopeStack(int howMany)
         {
             throw new NotImplementedException();
         }

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -1466,13 +1466,13 @@ namespace kOS.Safe.Compilation
                 var contextRecord = new SubroutineContext(cpu.InstructionPointer+1);
                 newIP = Convert.ToInt32(functionPointer);
                 
-                cpu.PushAboveStack(contextRecord);
+                cpu.PushScopeStack(contextRecord);
                 if (userDelegate != null)
                 {
                     cpu.AssertValidDelegateCall(userDelegate);
                     // Reverse-push the closure's scope record, just after the function return context got put on the stack.
                     for (int i = userDelegate.Closure.Count - 1 ; i >= 0 ; --i)
-                        cpu.PushAboveStack(userDelegate.Closure[i]);
+                        cpu.PushScopeStack(userDelegate.Closure[i]);
                 }
             }
             else if (functionPointer is string)
@@ -1632,10 +1632,10 @@ namespace kOS.Safe.Compilation
             VariableScope peeked = cpu.PeekRaw(-1, out okay) as VariableScope;
             while (okay && peeked != null && peeked.IsClosure)
             {
-                cpu.PopAboveStack(1);
+                cpu.PopScopeStack(1);
                 peeked = cpu.PeekRaw(-1, out okay) as VariableScope;
             }
-            object shouldBeContextRecord = cpu.PopAboveStack(1);
+            object shouldBeContextRecord = cpu.PopScopeStack(1);
             if ( !(shouldBeContextRecord is SubroutineContext) )
             {
                 // This should never happen with any user code:
@@ -1964,7 +1964,7 @@ namespace kOS.Safe.Compilation
         
         public override void Execute(ICpu cpu)
         {
-            cpu.PushAboveStack(new VariableScope(ScopeId,ParentScopeId));
+            cpu.PushScopeStack(new VariableScope(ScopeId,ParentScopeId));
         }
 
         public override string ToString()
@@ -2025,7 +2025,7 @@ namespace kOS.Safe.Compilation
         /// <param name="levels">number of levels to popscope.</param>
         public static void DoPopScope(ICpu cpuObj, Int16 levels)
         {
-            cpuObj.PopAboveStack(levels);
+            cpuObj.PopScopeStack(levels);
         }
 
         public override string ToString()

--- a/src/kOS.Safe/Execution/CPU.cs
+++ b/src/kOS.Safe/Execution/CPU.cs
@@ -285,24 +285,24 @@ namespace kOS.Safe.Execution
         }
 
         /// <summary>
-        /// Push a single thing onto the secret "over" stack.
+        /// Push a single thing onto the scope stack.
         /// </summary>
-        public void PushAboveStack(object thing)
+        public void PushScopeStack(object thing)
         {
-            stack.PushAbove(thing);
+            stack.PushScope(thing);
         }
 
         /// <summary>
-        /// Pop one or more things from the secret "over" stack, only returning the
+        /// Pop one or more things from the scope stack, only returning the
         /// finalmost thing popped.  (i.e if you pop 3 things then you get:
         /// pop once and throw away, pop again and throw away, pop again and return the popped thing.)
         /// </summary>
-        public object PopAboveStack(int howMany)
+        public object PopScopeStack(int howMany)
         {
             object returnVal = new int(); // bogus return val if given a bogus "pop zero things" request.
             while (howMany > 0)
             {
-                returnVal = stack.PopAbove();
+                returnVal = stack.PopScope();
                 --howMany;
             }
 
@@ -1409,12 +1409,12 @@ namespace kOS.Safe.Execution
                         // first line of the trigger, like OpcodeCall would do.
                         SubroutineContext contextRecord =
                             new SubroutineContext(currentInstructionPointer, trigger);
-                        PushAboveStack(contextRecord);
+                        PushScopeStack(contextRecord);
 
                         // Reverse-push the closure's scope record, if there is one, just after the function return context got put on the stack.
                         if (trigger.Closure != null)
                             for (int i = trigger.Closure.Count - 1 ; i >= 0 ; --i)
-                                PushAboveStack(trigger.Closure[i]);
+                                PushScopeStack(trigger.Closure[i]);
 
                         PushStack(new KOSArgMarkerType());
 

--- a/src/kOS.Safe/Execution/CPU.cs
+++ b/src/kOS.Safe/Execution/CPU.cs
@@ -289,8 +289,7 @@ namespace kOS.Safe.Execution
         /// </summary>
         public void PushAboveStack(object thing)
         {
-            PushStack(thing);
-            MoveStackPointer(-1);
+            stack.PushAbove(thing);
         }
 
         /// <summary>
@@ -303,8 +302,7 @@ namespace kOS.Safe.Execution
             object returnVal = new int(); // bogus return val if given a bogus "pop zero things" request.
             while (howMany > 0)
             {
-                MoveStackPointer(1);
-                returnVal = PopStack();
+                returnVal = stack.PopAbove();
                 --howMany;
             }
 
@@ -556,11 +554,6 @@ namespace kOS.Safe.Execution
         public object PopStack()
         {
             return stack.Pop();
-        }
-
-        public void MoveStackPointer(int delta)
-        {
-            stack.MoveStackPointer(delta);
         }
 
         /// <summary>Throw exception if the user delegate is not one the CPU can call right now.</summary>

--- a/src/kOS.Safe/Execution/ICpu.cs
+++ b/src/kOS.Safe/Execution/ICpu.cs
@@ -8,8 +8,8 @@ namespace kOS.Safe.Execution
     {
         void PushStack(object item);
         object PopStack();
-        void PushAboveStack(object thing);
-        object PopAboveStack(int howMany);
+        void PushScopeStack(object thing);
+        object PopScopeStack(int howMany);
         List<VariableScope> GetCurrentClosure();
         IUserDelegate MakeUserDelegate(int entryPoint, bool withClosure);
         void AssertValidDelegateCall(IUserDelegate userDelegate);

--- a/src/kOS.Safe/Execution/ICpu.cs
+++ b/src/kOS.Safe/Execution/ICpu.cs
@@ -8,7 +8,6 @@ namespace kOS.Safe.Execution
     {
         void PushStack(object item);
         object PopStack();
-        void MoveStackPointer(int delta);
         void PushAboveStack(object thing);
         object PopAboveStack(int howMany);
         List<VariableScope> GetCurrentClosure();

--- a/src/kOS.Safe/Execution/IStack.cs
+++ b/src/kOS.Safe/Execution/IStack.cs
@@ -6,10 +6,11 @@ namespace kOS.Safe.Execution
     {
         void Push(object item);
         object Pop();
+        void PushAbove(object item);
+        object PopAbove();
         object Peek(int digDepth);
         bool PeekCheck(int digDepth, out object item);
         int GetLogicalSize();
-        void MoveStackPointer(int delta);
         void Clear();
         string Dump();
         List<int> GetCallTrace();

--- a/src/kOS.Safe/Execution/IStack.cs
+++ b/src/kOS.Safe/Execution/IStack.cs
@@ -6,10 +6,10 @@ namespace kOS.Safe.Execution
     {
         void Push(object item);
         object Pop();
-        void PushAbove(object item);
-        object PopAbove();
         object Peek(int digDepth);
         bool PeekCheck(int digDepth, out object item);
+        void PushScope(object item);
+        object PopScope();
         int GetLogicalSize();
         void Clear();
         string Dump();

--- a/src/kOS.Safe/Execution/Stack.cs
+++ b/src/kOS.Safe/Execution/Stack.cs
@@ -6,7 +6,7 @@ using kOS.Safe.Encapsulation;
 
 namespace kOS.Safe.Execution
 {
-    public class Stack
+    public class Stack : IStack
     {
         private const int MAX_STACK_SIZE = 3000;
         private readonly object[] stack = new object[MAX_STACK_SIZE];


### PR DESCRIPTION
Stack operations had to shift everything in the above stack up and down on every push and pop. The above stack is usually small since it is just the context chain, but the extra shuffling adds up. This switches it to be two separate stacks (implemented as fixed-size arrays to avoid re-allocating), changing the `MoveStackPointer` into `PushAbove` and `PopAbove`, as it was never used for transferring between the stacks, just for accessing the above stack.

This reduces the runtime of my sort script from ~16 seconds to ~14.5 seconds.