### PR TITLE
Use generalized call delegate instead of DynamicInvoke

### DIFF
--- a/src/kOS.Safe/Encapsulation/Suffixes/NoArgsSuffix.cs
+++ b/src/kOS.Safe/Encapsulation/Suffixes/NoArgsSuffix.cs
@@ -13,7 +13,12 @@ namespace kOS.Safe.Encapsulation.Suffixes
 
         public override ISuffixResult Get()
         {
-            return new DelegateSuffixResult(del);
+            return new DelegateSuffixResult(del, call);
+        }
+
+        private object call(object[] args)
+        {
+            return (TReturn)del();
         }
     }
 

--- a/src/kOS.Safe/Encapsulation/Suffixes/NoArgsVoidSuffix.cs
+++ b/src/kOS.Safe/Encapsulation/Suffixes/NoArgsVoidSuffix.cs
@@ -19,7 +19,13 @@ namespace kOS.Safe.Encapsulation.Suffixes
 
         public override ISuffixResult Get()
         {
-            return new DelegateSuffixResult(del);
+            return new DelegateSuffixResult(del, call);
+        }
+
+        private object call(object[] args)
+        {
+            del();
+            return null;
         }
     }
 }

--- a/src/kOS.Safe/Encapsulation/Suffixes/OneArgsSuffix.cs
+++ b/src/kOS.Safe/Encapsulation/Suffixes/OneArgsSuffix.cs
@@ -13,7 +13,12 @@ namespace kOS.Safe.Encapsulation.Suffixes
 
         public override ISuffixResult Get()
         {
-            return new DelegateSuffixResult(del);
+            return new DelegateSuffixResult(del, call);
+        }
+
+        private object call(object[] args)
+        {
+            return (TReturn)del((TParam)args[0]);
         }
     }
 }

--- a/src/kOS.Safe/Encapsulation/Suffixes/OneArgsVoidSuffix.cs
+++ b/src/kOS.Safe/Encapsulation/Suffixes/OneArgsVoidSuffix.cs
@@ -13,7 +13,13 @@ namespace kOS.Safe.Encapsulation.Suffixes
 
         public override ISuffixResult Get()
         {
-            return new DelegateSuffixResult(del);
+            return new DelegateSuffixResult(del, call);
+        }
+
+        private object call(object[] args)
+        {
+            del((TParam)args[0]);
+            return null;
         }
     }
 }

--- a/src/kOS.Safe/Encapsulation/Suffixes/ThreeArgsSuffix.cs
+++ b/src/kOS.Safe/Encapsulation/Suffixes/ThreeArgsSuffix.cs
@@ -15,7 +15,12 @@ namespace kOS.Safe.Encapsulation.Suffixes
 
         public override ISuffixResult Get()
         {
-            return new DelegateSuffixResult(del);
+            return new DelegateSuffixResult(del, call);
+        }
+
+        private object call(object[] args)
+        {
+            return (TReturn)del((TParam)args[0], (TParam2)args[1], (TParam3)args[2]);
         }
     }
 
@@ -33,7 +38,13 @@ namespace kOS.Safe.Encapsulation.Suffixes
 
         public override ISuffixResult Get()
         {
-            return new DelegateSuffixResult(del);
+            return new DelegateSuffixResult(del, call);
+        }
+
+        private object call(object[] args)
+        {
+            del((TParam)args[0], (TParam2)args[1], (TParam3)args[2]);
+            return null;
         }
     }
 }

--- a/src/kOS.Safe/Encapsulation/Suffixes/TwoArgsSuffix.cs
+++ b/src/kOS.Safe/Encapsulation/Suffixes/TwoArgsSuffix.cs
@@ -14,7 +14,12 @@ namespace kOS.Safe.Encapsulation.Suffixes
 
         public override ISuffixResult Get()
         {
-            return new DelegateSuffixResult(del);
+            return new DelegateSuffixResult(del, call);
+        }
+
+        private object call(object[] args)
+        {
+            return (TReturn)del((TParam)args[0], (TParam2)args[1]);
         }
     }
 
@@ -32,7 +37,13 @@ namespace kOS.Safe.Encapsulation.Suffixes
 
         public override ISuffixResult Get()
         {
-            return new DelegateSuffixResult(del);
+            return new DelegateSuffixResult(del, call);
+        }
+
+        private object call(object[] args)
+        {
+            del((TParam)args[0], (TParam2)args[1]);
+            return null;
         }
     }
 }

--- a/src/kOS.Safe/Encapsulation/Suffixes/VarArgsSuffix.cs
+++ b/src/kOS.Safe/Encapsulation/Suffixes/VarArgsSuffix.cs
@@ -13,7 +13,12 @@ namespace kOS.Safe.Encapsulation.Suffixes
 
         public override ISuffixResult Get()
         {
-            return new DelegateSuffixResult(del);
+            return new DelegateSuffixResult(del, call);
+        }
+
+        private object call(object[] args)
+        {
+            return (TReturn)del((TParam[])args[0]);
         }
     }
 }


### PR DESCRIPTION
The `DynamicInvoke` calls were taking a disproportionately large amount of time to resolve the generic parameters on invoke (which we already do ahead of time in constructing the arguments). This replaces it with an explicit call delegate that will call the function from an argument array.

Initial tests show a speedup of ~20% (from 9s down to 7s on sorting a list of 1000 numbers).