### PR TITLE
Skip interface cast to allow inlining InstructionPointer access

### DIFF
--- a/src/kOS.Safe/Execution/CPU.cs
+++ b/src/kOS.Safe/Execution/CPU.cs
@@ -1498,8 +1498,8 @@ namespace kOS.Safe.Execution
                 SafeHouse.Logger.Log(executeLog.ToString());
         }
 
-        private bool ExecuteInstruction(IProgramContext context, bool doProfiling)
-        {            
+        private bool ExecuteInstruction(ProgramContext context, bool doProfiling)
+        {
             Opcode opcode = context.Program[context.InstructionPointer];
             
             if (SafeHouse.Config.DebugEachOpcode)


### PR DESCRIPTION
This function is the vast majority of accesses to the InstructionPointer, but since it was being passed an interface type (where the only call site passes in a concrete type), the compiler couldn't inline the property access.

This is accessed so frequently that allowing it to inline here gives it a 5% speedup.