### PR TITLE
Switch VariableScope to link directly to its parent

### DIFF
--- a/src/kOS.Safe.Test/Opcode/FakeCpu.cs
+++ b/src/kOS.Safe.Test/Opcode/FakeCpu.cs
@@ -45,6 +45,11 @@ namespace kOS.Safe.Test.Opcode
             throw new NotImplementedException();
         }
 
+        public void PushNewScope(Int16 scopeId, Int16 parentScopeId)
+        {
+            throw new NotImplementedException();
+        }
+
         public List<VariableScope> GetCurrentClosure()
         {
             throw new NotImplementedException();

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -1964,7 +1964,7 @@ namespace kOS.Safe.Compilation
         
         public override void Execute(ICpu cpu)
         {
-            cpu.PushScopeStack(new VariableScope(ScopeId,ParentScopeId));
+            cpu.PushNewScope(ScopeId,ParentScopeId);
         }
 
         public override string ToString()

--- a/src/kOS.Safe/Execution/ICpu.cs
+++ b/src/kOS.Safe/Execution/ICpu.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using kOS.Safe.Compilation;
 using kOS.Safe.Encapsulation;
@@ -8,6 +9,7 @@ namespace kOS.Safe.Execution
     {
         void PushArgumentStack(object item);
         object PopArgumentStack();
+        void PushNewScope(Int16 scopeId, Int16 parentScopeId);
         void PushScopeStack(object thing);
         object PopScopeStack(int howMany);
         List<VariableScope> GetCurrentClosure();

--- a/src/kOS.Safe/Execution/IStack.cs
+++ b/src/kOS.Safe/Execution/IStack.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace kOS.Safe.Execution
 {
@@ -17,5 +18,7 @@ namespace kOS.Safe.Execution
         string Dump();
         List<int> GetCallTrace();
         bool HasTriggerContexts();
+        VariableScope FindScope(Int16 scopeId);
+        VariableScope GetCurrentScope();
     }
 }

--- a/src/kOS.Safe/Execution/Stack.cs
+++ b/src/kOS.Safe/Execution/Stack.cs
@@ -333,17 +333,48 @@ namespace kOS.Safe.Execution
             VariableScope dict = item as VariableScope;
             if (dict != null)
             {
-                builder.AppendFormat("          ScopeId={0}, ParentScopeId={1}, ParentSkipLevels={2} IsClosure={3}",
-                                             dict.ScopeId, dict.ParentScopeId, dict.ParentSkipLevels, dict.IsClosure);
+                Int16 parentScopeId = -1;
+                if (dict.ParentScope != null)
+                {
+                    parentScopeId = dict.ParentScope.ScopeId;
+                }
+
+                builder.AppendFormat("          ScopeId={0}, ParentScopeId={1}, IsClosure={2}",
+                                             dict.ScopeId, parentScopeId, dict.IsClosure);
                 builder.AppendLine();
                 // Dump the local variable context stored here on the stack:
-                foreach (string varName in dict.Variables.Keys)
+                foreach (var entry in dict.Locals)
                 {
-                    var value = dict.Variables[varName].Value;
-                    builder.AppendFormat("            local var {0} is {1} with value = {2}", varName, KOSNomenclature.GetKOSName(value.GetType()), dict.Variables[varName].Value);
+                    builder.AppendFormat("            local var {0} is {1} with value = {2}", entry.Key, KOSNomenclature.GetKOSName(entry.Value.GetType()), entry.Value);
                     builder.AppendLine();
                 }
             }
+        }
+
+        public VariableScope FindScope(Int16 ScopeId)
+        {
+            for (int index = scopeCount - 1; index >= 0; --index)
+            {
+                var scope = scopeStack[index] as VariableScope;
+                if (scope != null && scope.ScopeId == ScopeId)
+                {
+                    return scope;
+                }
+            }
+            return null;
+        }
+
+        public VariableScope GetCurrentScope()
+        {
+            for (int index = scopeCount - 1; index >= 0; --index)
+            {
+                var scope = scopeStack[index] as VariableScope;
+                if (scope != null)
+                {
+                    return scope;
+                }
+            }
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
This avoids bouncing back and forth through the stack to find the parent scopes by just linking them directly on creation.

This was meant as a prerequisite to start caching variable lookups, but actually on its own resulted in a ~8% speedup.