### PR TITLE
Avoid string StartsWith and EndsWith

### DIFF
--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -1420,14 +1420,14 @@ namespace kOS.Safe.Compilation
             if (functionPointer is string || functionPointer is StringValue)
             {
                 string functionName = functionPointer.ToString();
-                if (functionName.EndsWith("()"))
+                if (StringUtil.EndsWith(functionName, "()"))
                     functionName = functionName.Substring(0, functionName.Length - 2);
                 if (!(cpu.BuiltInExists(functionName)))
                 {
                     // It is not a built-in, so instead get its value as a user function pointer variable, despite
                     // the fact that it's being called AS IF it was direct.
-                    if (!functionName.EndsWith("*")) functionName = functionName + "*";
-                    if (!functionName.StartsWith("$")) functionName = "$" + functionName;
+                    if (!StringUtil.EndsWith(functionName, "*")) functionName = functionName + "*";
+                    if (!StringUtil.StartsWith(functionName, "$")) functionName = "$" + functionName;
                     functionPointer = cpu.GetValue(functionName);
                 }
             }
@@ -1482,7 +1482,7 @@ namespace kOS.Safe.Compilation
                 // might want to change that.
                 var name = functionPointer as string;
                 string functionName = name;
-                if (functionName.EndsWith("()"))
+                if (StringUtil.EndsWith(functionName, "()"))
                     functionName = functionName.Substring(0, functionName.Length - 2);
                 cpu.CallBuiltinFunction(functionName);
 

--- a/src/kOS.Safe/Execution/CPU.cs
+++ b/src/kOS.Safe/Execution/CPU.cs
@@ -404,7 +404,7 @@ namespace kOS.Safe.Execution
             //   IP jump location for subprograms.
             //   IP jump location for functions.
             savedPointers = new VariableScope(0, null);
-            var pointers = new List<KeyValuePair<string, Variable>>(globalVariables.Locals.Where(entry => entry.Key.Contains('*')));
+            var pointers = new List<KeyValuePair<string, Variable>>(globalVariables.Locals.Where(entry => StringUtil.EndsWith(entry.Key, "*")));
 
             foreach (var entry in pointers)
             {
@@ -720,7 +720,7 @@ namespace kOS.Safe.Execution
             // In the case where we were looking for a function pointer but didn't find one, and would
             // have failed with exception, then it's still acceptable to find a hit that isn't a function
             // pointer (has no trailing asterisk '*') but only if it's a delegate of some sort:
-            if (identifier[identifier.Length - 1] == '*')
+            if (StringUtil.EndsWith(identifier, "*"))
             {
                 string trimmedTail = identifier.TrimEnd('*');
                 Variable retryVal = GetVariable(trimmedTail, barewordOkay, failOkay);
@@ -744,7 +744,7 @@ namespace kOS.Safe.Execution
         /// <param name="overwrite">true if it's okay to overwrite an existing variable</param>
         public void AddVariable(Variable variable, string identifier, bool local, bool overwrite = false)
         {
-            if (identifier[0] != '$')
+            if (!StringUtil.StartsWith(identifier, "$"))
             {
                 identifier = "$" + identifier;
             }

--- a/src/kOS.Safe/Utilities/StringUtil.cs
+++ b/src/kOS.Safe/Utilities/StringUtil.cs
@@ -1,0 +1,51 @@
+﻿using System;
+namespace kOS.Safe
+{
+    /// <summary>
+    /// String utility functions that avoid the culture-aware overhead of the builtin string functions.
+    /// </summary>
+    public static class StringUtil
+    {
+        public static bool EndsWith(string str, string suffix)
+        {
+            int strLen = str.Length;
+            int suffixLen = suffix.Length;
+
+            if (strLen < suffixLen)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < suffixLen; i++)
+            {
+                if (str[strLen - i - 1] != suffix[suffixLen - i - 1])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public static bool StartsWith(string str, string prefix)
+        {
+            int strLen = str.Length;
+            int prefixLen = prefix.Length;
+
+            if (strLen < prefixLen)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < prefixLen; i++)
+            {
+                if (str[i] != prefix[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -283,6 +283,7 @@
     <Compile Include="Function\Persistence.cs" />
     <Compile Include="Function\Suffixed.cs" />
     <Compile Include="Function\Trigonometry.cs" />
+    <Compile Include="Utilities\StringUtil.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Compilation\CompiledObject-doc.md" />


### PR DESCRIPTION
String functions in mono are extremely slow. This avoids calling `StartsWith` and `EndsWith` for cases where we could just check the characters directly.

This had a varying effect from almost no speedup to an 8% speedup in my test cases depending on how call heavy the script was (the `EndsWith("()")` check is the most expensive).