### PR TITLE
Cache type lookups on Suffix delegates

### DIFF
--- a/src/kOS.Safe.Test/Collections/CollectionValueTest.cs
+++ b/src/kOS.Safe.Test/Collections/CollectionValueTest.cs
@@ -1,20 +1,38 @@
 ﻿using System;
 using kOS.Safe.Encapsulation;
+using kOS.Safe.Execution;
 using NUnit.Framework;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Serialization;
+using kOS.Safe.Test.Opcode;
 
 namespace kOS.Safe.Test
 {
     public abstract class CollectionValueTest
     {
+        private ICpu cpu;
+
+        [SetUp]
+        public void Setup()
+        {
+            cpu = new FakeCpu();
+        }
 
         protected object InvokeDelegate(SerializableStructure stack, string suffixName, params object[] parameters)
         {
             var lengthObj = stack.GetSuffix(suffixName) as DelegateSuffixResult;
             Assert.IsNotNull(lengthObj);
-            Assert.IsNotNull(lengthObj.Del);
-            return lengthObj.Del.DynamicInvoke(parameters);
+
+            cpu.PushArgumentStack(null); // fake delegate info
+            cpu.PushArgumentStack(new KOSArgMarkerType());
+            foreach (object param in parameters)
+            {
+                cpu.PushArgumentStack(param);
+            }
+
+            lengthObj.Invoke(cpu);
+
+            return lengthObj.Value;
         }
     }
 }

--- a/src/kOS.Safe.Test/Collections/LexiconTest.cs
+++ b/src/kOS.Safe.Test/Collections/LexiconTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
+using kOS.Safe.Execution;
 using kOS.Safe.Exceptions;
 using kOS.Safe.Test.Opcode;
 using NUnit.Framework;
@@ -13,10 +14,12 @@ namespace kOS.Safe.Test.Collections
     [TestFixture]
     public class LexiconTest
     {
+        private ICpu cpu;
+
         [SetUp]
         public void Setup()
         {
-
+            cpu = new FakeCpu();
         }
 
         [Test]
@@ -310,9 +313,16 @@ namespace kOS.Safe.Test.Collections
                 var delegateResult = lengthResult as DelegateSuffixResult;
                 if (delegateResult != null)
                 {
-                    var temp = delegateResult.Del.DynamicInvoke(parameters);
+                    cpu.PushArgumentStack(null); // fake delegate info
+                    cpu.PushArgumentStack(new KOSArgMarkerType());
+                    foreach (var param in parameters)
+                    {
+                        cpu.PushArgumentStack(param);
+                    }
+
+                    delegateResult.Invoke(cpu);
                     
-                    return temp as Encapsulation.Structure;
+                    return delegateResult.Value;
                 }
             }
 

--- a/src/kOS.Safe.Test/Structure/TwoArgsVoidSuffixTest.cs
+++ b/src/kOS.Safe.Test/Structure/TwoArgsVoidSuffixTest.cs
@@ -1,4 +1,7 @@
 ﻿using kOS.Safe.Encapsulation.Suffixes;
+using kOS.Safe.Encapsulation;
+using kOS.Safe.Execution;
+using kOS.Safe.Test.Opcode;
 using NSubstitute;
 using NUnit.Framework;
 using System;
@@ -8,6 +11,14 @@ namespace kOS.Safe.Test.Structure
     [TestFixture]
     public class TwoArgsVoidSuffixTest
     {
+        private ICpu cpu;
+
+        [SetUp]
+        public void Setup()
+        {
+            cpu = new FakeCpu();
+        }
+
         [Test]
         public void CanCreate()
         {
@@ -15,27 +26,25 @@ namespace kOS.Safe.Test.Structure
             Assert.IsNotNull(suffix.Get());
         }
 
-        [Test]
-        public void CanGetDelegate()
-        {
-            var suffix = new TwoArgsSuffix<kOS.Safe.Encapsulation.Structure, kOS.Safe.Encapsulation.Structure>((one, two) => { });
-            var del = suffix.Get() as DelegateSuffixResult;
-            Assert.IsNotNull(del);
-            var delegateAsDelegate = del.Del;
-            Assert.IsNotNull(delegateAsDelegate);
-        }
+        private delegate void TwoArgs(kOS.Safe.Encapsulation.Structure a1,kOS.Safe.Encapsulation.Structure a2);
 
         [Test]
         public void CanExecuteDelegate()
         {
-            var mockDel = Substitute.For<TwoArgsSuffix<kOS.Safe.Encapsulation.Structure, kOS.Safe.Encapsulation.Structure>.Del<object, object>>();
+            var mockDel = Substitute.For<TwoArgsSuffix<kOS.Safe.Encapsulation.Structure, kOS.Safe.Encapsulation.Structure>.Del<kOS.Safe.Encapsulation.Structure, kOS.Safe.Encapsulation.Structure>>();
 
-            var suffix = new TwoArgsSuffix<kOS.Safe.Encapsulation.Structure, kOS.Safe.Encapsulation.Structure>(mockDel);
+            // Wrap it in a lambda to avoid the weird third closure arg
+            var suffix = new TwoArgsSuffix<kOS.Safe.Encapsulation.Structure, kOS.Safe.Encapsulation.Structure>((one, two) => mockDel(one, two));
             var del = suffix.Get() as DelegateSuffixResult;
             Assert.IsNotNull(del);
-            var delegateAsDelegate = del.Del;
-            Assert.IsNotNull(delegateAsDelegate);
-            delegateAsDelegate.DynamicInvoke(new object(), new object());
+
+            // Add fake arguments to the stack for the call
+            cpu.PushArgumentStack(null);
+            cpu.PushArgumentStack(new KOSArgMarkerType());
+            cpu.PushArgumentStack(ScalarIntValue.Zero);
+            cpu.PushArgumentStack(ScalarIntValue.Zero);
+
+            del.Invoke(cpu);
 
             mockDel.ReceivedWithAnyArgs(1);
         }

--- a/src/kOS.Safe/Encapsulation/Suffixes/GlobalSuffix.cs
+++ b/src/kOS.Safe/Encapsulation/Suffixes/GlobalSuffix.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace kOS.Safe.Encapsulation.Suffixes
 {
 
@@ -13,6 +15,21 @@ namespace kOS.Safe.Encapsulation.Suffixes
         public override ISuffixResult Get()
         {
             return new SuffixResult(getter.Invoke());
+        }
+
+        protected override object Call (object [] args)
+        {
+            // We are overriding Get so no need to implement this
+            throw new NotImplementedException ();
+        }
+
+        protected override Delegate Delegate
+        {
+            get
+            {
+                // We are override Get so no need to implement
+                throw new NotImplementedException ();
+            }
         }
     }
 }

--- a/src/kOS.Safe/Encapsulation/Suffixes/NoArgsSuffix.cs
+++ b/src/kOS.Safe/Encapsulation/Suffixes/NoArgsSuffix.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace kOS.Safe.Encapsulation.Suffixes
 {
     public class NoArgsSuffix<TReturn> : SuffixBase where TReturn : Structure
@@ -11,14 +13,17 @@ namespace kOS.Safe.Encapsulation.Suffixes
             this.del = del;
         }
 
-        public override ISuffixResult Get()
-        {
-            return new DelegateSuffixResult(del, call);
-        }
-
-        private object call(object[] args)
+        protected override object Call(object[] args)
         {
             return (TReturn)del();
+        }
+
+        protected override Delegate Delegate
+        {
+            get
+            {
+                return del;
+            }
         }
     }
 

--- a/src/kOS.Safe/Encapsulation/Suffixes/NoArgsVoidSuffix.cs
+++ b/src/kOS.Safe/Encapsulation/Suffixes/NoArgsVoidSuffix.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace kOS.Safe.Encapsulation.Suffixes
 {
     /// <summary>
@@ -17,15 +19,18 @@ namespace kOS.Safe.Encapsulation.Suffixes
             this.del = del;
         }
 
-        public override ISuffixResult Get()
-        {
-            return new DelegateSuffixResult(del, call);
-        }
-
-        private object call(object[] args)
+        protected override object Call(object[] args)
         {
             del();
             return null;
+        }
+
+        protected override Delegate Delegate
+        {
+            get
+            {
+                return del;
+            }
         }
     }
 }

--- a/src/kOS.Safe/Encapsulation/Suffixes/OneArgsSuffix.cs
+++ b/src/kOS.Safe/Encapsulation/Suffixes/OneArgsSuffix.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace kOS.Safe.Encapsulation.Suffixes
 {
     public class OneArgsSuffix<TReturn,TParam> : SuffixBase where TReturn : Structure where TParam : Structure
@@ -11,14 +13,17 @@ namespace kOS.Safe.Encapsulation.Suffixes
             this.del = del;
         }
 
-        public override ISuffixResult Get()
-        {
-            return new DelegateSuffixResult(del, call);
-        }
-
-        private object call(object[] args)
+        protected override object Call(object[] args)
         {
             return (TReturn)del((TParam)args[0]);
+        }
+
+        protected override Delegate Delegate
+        {
+            get
+            {
+                return del;
+            }
         }
     }
 }

--- a/src/kOS.Safe/Encapsulation/Suffixes/OneArgsVoidSuffix.cs
+++ b/src/kOS.Safe/Encapsulation/Suffixes/OneArgsVoidSuffix.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace kOS.Safe.Encapsulation.Suffixes
 {
     public class OneArgsSuffix<TParam> : SuffixBase where TParam : Structure
@@ -11,15 +13,18 @@ namespace kOS.Safe.Encapsulation.Suffixes
             this.del = del;
         }
 
-        public override ISuffixResult Get()
-        {
-            return new DelegateSuffixResult(del, call);
-        }
-
-        private object call(object[] args)
+        protected override object Call(object[] args)
         {
             del((TParam)args[0]);
             return null;
+        }
+
+        protected override Delegate Delegate
+        {
+            get
+            {
+                return del;
+            }
         }
     }
 }

--- a/src/kOS.Safe/Encapsulation/Suffixes/Suffix.cs
+++ b/src/kOS.Safe/Encapsulation/Suffixes/Suffix.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace kOS.Safe.Encapsulation.Suffixes
 {
     public class Suffix<TReturn> : SuffixBase where TReturn : Structure
@@ -12,6 +14,21 @@ namespace kOS.Safe.Encapsulation.Suffixes
         public override ISuffixResult Get()
         {
             return new SuffixResult(getter.Invoke());
+        }
+
+        protected override object Call (object [] args)
+        {
+            // We are overriding Get so no need to implement this
+            throw new NotImplementedException ();
+        }
+
+        protected override Delegate Delegate
+        {
+            get
+            {
+                // We are override Get so no need to implement
+                throw new NotImplementedException ();
+            }
         }
     }
 }

--- a/src/kOS.Safe/Encapsulation/Suffixes/SuffixBase.cs
+++ b/src/kOS.Safe/Encapsulation/Suffixes/SuffixBase.cs
@@ -1,4 +1,7 @@
-﻿namespace kOS.Safe.Encapsulation.Suffixes
+﻿using System;
+using System.Reflection;
+
+namespace kOS.Safe.Encapsulation.Suffixes
 {
     public abstract class SuffixBase : ISuffix
     {
@@ -6,8 +9,57 @@
         {
             Description = description;
         }
-        public abstract ISuffixResult Get();
+
+        public virtual ISuffixResult Get()
+        {
+            return new DelegateSuffixResult(DelegateInfo(), Call);
+        }
+
+        private DelegateInfo delegateInfo;
+
+        private DelegateInfo DelegateInfo()
+        {
+            if (delegateInfo != null)
+            {
+                return delegateInfo;
+            }
+
+            Delegate del = Delegate;
+
+            MethodInfo methInfo = del.Method;
+            ParameterInfo[] paramInfos = methInfo.GetParameters();
+
+            DelegateParameter[] delParams = new DelegateParameter[paramInfos.Length];
+            for (int i = 0; i < paramInfos.Length; i++)
+            {
+                delParams[i] = new DelegateParameter() {
+                    ParameterType = paramInfos[i].ParameterType,
+                    IsParams = (i == paramInfos.Length - 1) ? Attribute.IsDefined(paramInfos[i], typeof(ParamArrayAttribute)) : false
+                };
+            }
+
+            delegateInfo = new DelegateInfo() { Name = methInfo.Name, ReturnType = methInfo.ReturnType, Parameters = delParams };
+
+            return delegateInfo;
+        }
+
+        protected abstract Delegate Delegate { get; }
+
+        protected abstract object Call(object[] args);
 
         public string Description { get; private set; }
+    }
+
+    public class DelegateInfo
+    {
+        public String Name { get; set; }
+        public Type ReturnType { get; set; }
+        public DelegateParameter[] Parameters { get; set; }
+    }
+
+    public class DelegateParameter
+    {
+        public Type ParameterType { get; set; }
+        public bool IsParams { get; set; }
     }
 }

--- a/src/kOS.Safe/Encapsulation/Suffixes/ThreeArgsSuffix.cs
+++ b/src/kOS.Safe/Encapsulation/Suffixes/ThreeArgsSuffix.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace kOS.Safe.Encapsulation.Suffixes
 {
     public class ThreeArgsSuffix<TReturn, TParam, TParam2, TParam3> : SuffixBase
@@ -13,14 +15,17 @@ namespace kOS.Safe.Encapsulation.Suffixes
             this.del = del;
         }
 
-        public override ISuffixResult Get()
-        {
-            return new DelegateSuffixResult(del, call);
-        }
-
-        private object call(object[] args)
+        protected override object Call(object[] args)
         {
             return (TReturn)del((TParam)args[0], (TParam2)args[1], (TParam3)args[2]);
+        }
+
+        protected override Delegate Delegate
+        {
+            get
+            {
+                return del;
+            }
         }
     }
 
@@ -36,15 +41,18 @@ namespace kOS.Safe.Encapsulation.Suffixes
             this.del = del;
         }
 
-        public override ISuffixResult Get()
-        {
-            return new DelegateSuffixResult(del, call);
-        }
-
-        private object call(object[] args)
+        protected override object Call(object[] args)
         {
             del((TParam)args[0], (TParam2)args[1], (TParam3)args[2]);
             return null;
+        }
+
+        protected override Delegate Delegate
+        {
+            get
+            {
+                return del;
+            }
         }
     }
 }

--- a/src/kOS.Safe/Encapsulation/Suffixes/TwoArgsSuffix.cs
+++ b/src/kOS.Safe/Encapsulation/Suffixes/TwoArgsSuffix.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace kOS.Safe.Encapsulation.Suffixes
 {
     public class TwoArgsSuffix<TReturn, TParam, TParam2> : SuffixBase where TReturn : Structure where TParam : Structure where TParam2 : Structure
@@ -12,14 +14,17 @@ namespace kOS.Safe.Encapsulation.Suffixes
             this.del = del;
         }
 
-        public override ISuffixResult Get()
-        {
-            return new DelegateSuffixResult(del, call);
-        }
-
-        private object call(object[] args)
+        protected override object Call(object[] args)
         {
             return (TReturn)del((TParam)args[0], (TParam2)args[1]);
+        }
+
+        protected override Delegate Delegate
+        {
+            get
+            {
+                return del;
+            }
         }
     }
 
@@ -35,15 +40,18 @@ namespace kOS.Safe.Encapsulation.Suffixes
             this.del = del;
         }
 
-        public override ISuffixResult Get()
-        {
-            return new DelegateSuffixResult(del, call);
-        }
-
-        private object call(object[] args)
+        protected override object Call(object[] args)
         {
             del((TParam)args[0], (TParam2)args[1]);
             return null;
+        }
+
+        protected override Delegate Delegate
+        {
+            get
+            {
+                return del;
+            }
         }
     }
 }

--- a/src/kOS.Safe/Encapsulation/Suffixes/VarArgsSuffix.cs
+++ b/src/kOS.Safe/Encapsulation/Suffixes/VarArgsSuffix.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace kOS.Safe.Encapsulation.Suffixes
 {
     public class VarArgsSuffix<TReturn, TParam> : SuffixBase where TReturn : Structure where TParam : Structure
@@ -11,14 +13,17 @@ namespace kOS.Safe.Encapsulation.Suffixes
             this.del = del;
         }
 
-        public override ISuffixResult Get()
-        {
-            return new DelegateSuffixResult(del, call);
-        }
-
-        private object call(object[] args)
+        protected override object Call(object[] args)
         {
             return (TReturn)del((TParam[])args[0]);
+        }
+
+        protected override Delegate Delegate
+        {
+            get
+            {
+                return del;
+            }
         }
     }
 }


### PR DESCRIPTION
Includes changes from #2139 

The type lookups (the largest of which by a huge margin was the check for varargs) were taking a decent amount of time. During profiling this only looked like it was going to result in a speedup of a few percent, but on running tests with profiling off, it resulted in a 10-25% speedup (depending on how suffix heavy the workload was).