### PR TITLE
Properly unlock identifiers when setting them

### DIFF
--- a/kerboscript_tests/integration/lock.ks
+++ b/kerboscript_tests/integration/lock.ks
@@ -8,3 +8,6 @@ print(c).
 
 set b to 3.
 print(c).
+
+set c to 5.
+print(c).

--- a/kerboscript_tests/integration/suffixes.ks
+++ b/kerboscript_tests/integration/suffixes.ks
@@ -1,0 +1,22 @@
+
+set a to lexicon().
+
+print(a:length).
+
+set a["a"] to 2.
+
+print(a:length).
+
+print(a["a"]).
+
+set a["b"] to list(1,2,3).
+
+print(a["b"]:length).
+
+set a:case to true.
+
+print(a:length).
+
+set a["a"] to 3.
+
+print(a:haskey("A")).

--- a/src/kOS.Safe.Test/Execution/SimpleTest.cs
+++ b/src/kOS.Safe.Test/Execution/SimpleTest.cs
@@ -99,5 +99,22 @@ namespace kOS.Safe.Test.Execution
                 "5"
             );
         }
+
+        [Test]
+        public void TestSuffixes()
+        {
+            // Test that various suffix and index combinations work for getting and setting
+            RunScript("integration/suffixes.ks");
+            RunSingleStep();
+            RunSingleStep();
+            AssertOutput(
+                "0",
+                "1",
+                "2",
+                "3",
+                "0",
+                "False"
+            );
+        }
     }
 }

--- a/src/kOS.Safe.Test/Execution/SimpleTest.cs
+++ b/src/kOS.Safe.Test/Execution/SimpleTest.cs
@@ -95,7 +95,8 @@ namespace kOS.Safe.Test.Execution
             RunSingleStep();
             AssertOutput(
                 "3",
-                "4"
+                "4",
+                "5"
             );
         }
     }

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -1909,14 +1909,13 @@ namespace kOS.Safe.Compilation.KS
                 if (compilingSetDestination)
                 {
                     UnlockIdentifier(userFuncObject);
-                    AddOpcode(new OpcodePush("$" + identifier));
                 }
                 else
                 {
                     AddOpcode(new OpcodeCall(userFuncObject.ScopelessPointerIdentifier));
                 }
             }
-            else
+            else if (!compilingSetDestination)
             {
                 AddOpcode(new OpcodePush(prefix + identifier));
             }
@@ -2089,14 +2088,15 @@ namespace kOS.Safe.Compilation.KS
         /// <param name="toThis">The righthand-side expression to set it to</param>
         private void ProcessSetOperation(ParseNode setThis, ParseNode toThis)
         {
+            // destination
+            compilingSetDestination = true;
+            VisitNode(setThis);
+            compilingSetDestination = false;
+
             bool isSuffix = VarIdentifierEndsWithSuffix(setThis);
             bool isIndex = VarIdentifierEndsWithIndex(setThis);
             if (isSuffix || isIndex)
             {
-                // destination
-                compilingSetDestination = true;
-                VisitNode(setThis);
-                compilingSetDestination = false;
                 // expression
                 VisitNode(toThis);
 


### PR DESCRIPTION
Fixes #2182 

The issue was that the changes in #2156 made it no longer visit the identifier node, which is where the auto-unlock code was.

Since this auto-unlock can only happen during a set, I moved the unlock code into `ProcessSetOperation` so it doesn't have to infer wether it needs to unlock based on the global state variables.