### PR TITLE
Fixes #2178 allowing aborting queued triggers.

### DIFF
--- a/src/kOS.Safe.Test/Opcode/FakeCpu.cs
+++ b/src/kOS.Safe.Test/Opcode/FakeCpu.cs
@@ -55,6 +55,11 @@ namespace kOS.Safe.Test.Opcode
             throw new NotImplementedException();
         }
 
+        public SubroutineContext GetCurrentSubroutineContext()
+        {
+            throw new NotImplementedException();
+        }
+
         public IUserDelegate MakeUserDelegate(int entryPoint, bool withClosure)
         {
             throw new NotImplementedException();
@@ -201,6 +206,16 @@ namespace kOS.Safe.Test.Opcode
         }
 
         public void RemoveTrigger(TriggerInfo trigger)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void CancelCalledTriggers(int triggerFunctionPointer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void CancelCalledTriggers(TriggerInfo trigger)
         {
             throw new NotImplementedException();
         }

--- a/src/kOS.Safe/Execution/CPU.cs
+++ b/src/kOS.Safe/Execution/CPU.cs
@@ -691,6 +691,22 @@ namespace kOS.Safe.Execution
             return currentScope;
         }
 
+        public SubroutineContext GetCurrentSubroutineContext()
+        {
+            return stack.GetCurrentSubroutineContext();
+        }
+
+        /// <summary>
+        /// Find any trigger call contexts that are on the callstack to be executed
+        /// that match the given trigger.
+        /// </summary>
+        /// <returns>List of matching trigger call contexts.  Zero length if none.</returns>
+        /// <param name="trigger">Trigger.</param>
+        public List<SubroutineContext> GetTriggerCallContexts(TriggerInfo trigger)
+        {
+            return stack.GetTriggerCallContexts(trigger);
+        }
+
         /// <summary>
         /// Get the variable's contents, performing a lookup through all nesting levels
         /// up to global.
@@ -1188,6 +1204,22 @@ namespace kOS.Safe.Execution
         public void RemoveTrigger(TriggerInfo trigger)
         {
             currentContext.RemoveTrigger(trigger);
+        }
+
+        public void CancelCalledTriggers(int triggerFunctionPointer)
+        {
+            CancelCalledTriggers(new TriggerInfo(currentContext, triggerFunctionPointer, null));
+        }
+
+        public void CancelCalledTriggers(TriggerInfo trigger)
+        {
+            // Inform any already existing calls to the trigger that they should cancel themselves
+            // if they support the cancellation logic (if they pay attention to OpcodeTestCancelled).
+            List<SubroutineContext> calls = GetTriggerCallContexts(trigger);
+            for (int i = 0; i < calls.Count; ++i)
+            {
+                calls[i].Cancel();
+            }
         }
 
         public void KOSFixedUpdate(double deltaTime)

--- a/src/kOS.Safe/Execution/ICpu.cs
+++ b/src/kOS.Safe/Execution/ICpu.cs
@@ -43,12 +43,15 @@ namespace kOS.Safe.Execution
         TriggerInfo AddTrigger(UserDelegate del, params Structure[] args);
         void RemoveTrigger(int triggerFunctionPointer);
         void RemoveTrigger(TriggerInfo trigger);
+        void CancelCalledTriggers(int triggerFunctionPointer);
+        void CancelCalledTriggers(TriggerInfo trigger);
         void CallBuiltinFunction(string functionName);
         bool BuiltInExists(string functionName);
         void BreakExecution(bool manual);
         void YieldProgram(YieldFinishedDetector yieldTracker);
         void AddVariable(Variable variable, string identifier, bool local, bool overwrite = false);
         IProgramContext GetCurrentContext();
+        SubroutineContext GetCurrentSubroutineContext();
         void AddPopContextNotifyee(IPopContextNotifyee notifyee);
         void RemovePopContextNotifyee(IPopContextNotifyee notifyee);
         Opcode GetCurrentOpcode();

--- a/src/kOS.Safe/Execution/IStack.cs
+++ b/src/kOS.Safe/Execution/IStack.cs
@@ -20,5 +20,7 @@ namespace kOS.Safe.Execution
         bool HasTriggerContexts();
         VariableScope FindScope(Int16 scopeId);
         VariableScope GetCurrentScope();
+        SubroutineContext GetCurrentSubroutineContext();
+        List<SubroutineContext> GetTriggerCallContexts(TriggerInfo trigger);
     }
 }

--- a/src/kOS.Safe/Execution/Stack.cs
+++ b/src/kOS.Safe/Execution/Stack.cs
@@ -384,6 +384,45 @@ namespace kOS.Safe.Execution
         }
 
         /// <summary>
+        /// Gets the subroutine context of the currently executing routine from the stack,
+        /// or returns null if we are not inside a subroutine.
+        /// </summary>
+        /// <returns>The current subroutine context.</returns>
+        public SubroutineContext GetCurrentSubroutineContext()
+        {
+            for (int index = scopeCount - 1; index >= 0; --index)
+            {
+                var context = scopeStack[index] as SubroutineContext;
+                if (context != null)
+                {
+                    return context;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the subroutine contexts of any calls matching the trigger given
+        /// which have already been pushed onto the call stack for execution.
+        /// </summary>
+        /// <returns>List of matches, zero length if no matches.</returns>
+        public List<SubroutineContext> GetTriggerCallContexts(TriggerInfo trigger)
+        {
+            List<SubroutineContext> returnList = new List<SubroutineContext>();
+            for (int index = scopeCount - 1; index >= 0; --index)
+            {
+                var context = scopeStack[index] as SubroutineContext;
+
+                // Note must use .Equals(), not == below:  For TriggerInfo, == still means
+                // reference-equals because there's places we need that.  For this case, we
+                // want to match all equivalent triggers (ones that execute the same subroutine):
+                if (context != null && context.IsTrigger && context.Trigger.Equals(trigger))
+                    returnList.Add(context);
+            }
+            return returnList;
+        }
+
+        /// <summary>
         /// Return the subroutine call trace of how the code got to where it is right now.
         /// </summary>
         /// <returns>The items in the list are the instruction pointers of the Opcodecall instructions


### PR DESCRIPTION
Fixes #2178 allowing aborting queued triggers.

### In a nutshell, the problem is this:

**This is how the interrupts like triggers, callbacks, and the
locked steering are implemented in the system:**

- At the start of a physics tick pass, for each pending trigger
or callback, the CPU pushes a record onto the stack to simulate
as if that routine had just been called from the current spot in
the mainline code.  If there's 3 such triggers, A, B, and C, then
the CPU arranges the stack as if your mainline code had just called
A, which as its first instruction had just called B, which as its first
instruction had just called C.  Thus when it goes to execute the
instructions, it will call the nested routines and pop back to the main
code once they're all done.

^^ The logic to perform the above stack trickery is in ``Cpu.ProcessTriggers()``.

- That system encounters a problem when you want to have one of those
interrupt routines (the GUI callback in this case) cancel one of
the others (the steering trigger) - the stack has already been arranged
to call both routines, then one routine says to cancel the other.
The call to steering is already baked in to the stack by the time the
callback says to cancel it.  Even if the callback removes the trigger,
the steering routine still gets one last call to happen from this one last
scheduled stack call that's already baked in to the stack.  And in the
case of steering, that causes it to re-enable the steeringmanager as
it assigns something in to ``$steering`` again in the routine.

**The fix:**

The fix implemented here is to make it so that when a trigger is removed
by code explicitly trying to remove it (as happens in unlock steering),
it will also search for all pending calls to that trigger that are already
baked into the stack and flag them as cancelled.  Then any trigger that
wishes to allow itself to be cancel-able in this way must execute code
at the start of itself that will skip its body if it sees it's already been
thusly cancelled.  The new OpcodeTestCancelled was added to make this possible.

Right now that's just the steering/throttle/wheelthrottle/wheelsteering locks
that do this.  But in the future we could also do it for our own when/then or
on triggers if we want to make them cancel-able (I marked in the code some
comments to show where this could be done in the future in another PR if we
like.)