### PR TITLE
Build and compile expressions as semantic tree nodes

### DIFF
--- a/kerboscript_tests/integration/func.ks
+++ b/kerboscript_tests/integration/func.ks
@@ -5,3 +5,9 @@ function a
 }
 
 a().
+
+set b to {
+  print("b").
+}.
+
+b().

--- a/kerboscript_tests/integration/short_circuit.ks
+++ b/kerboscript_tests/integration/short_circuit.ks
@@ -1,0 +1,15 @@
+
+function a {
+  print("a").
+  return false.
+}
+
+function b {
+  print("b").
+  return true.
+}
+
+print(a() and b()).
+print(a() or b()).
+print(b() and a()).
+print(b() or a()).

--- a/src/kOS.Safe.Test/Execution/SimpleTest.cs
+++ b/src/kOS.Safe.Test/Execution/SimpleTest.cs
@@ -41,7 +41,8 @@ namespace kOS.Safe.Test.Execution
             RunScript("integration/func.ks");
             RunSingleStep();
             AssertOutput(
-                "a"
+                "a",
+                "b"
             );
         }
 
@@ -118,19 +119,24 @@ namespace kOS.Safe.Test.Execution
         }
 
         [Test]
-        public void TestSuffixes()
+        public void TestShortCircuit()
         {
-            // Test that various suffix and index combinations work for getting and setting
-            RunScript("integration/suffixes.ks");
-            RunSingleStep();
+            // Test that boolean logic short circuits
+            RunScript("integration/short_circuit.ks");
             RunSingleStep();
             AssertOutput(
-                "0",
-                "1",
-                "2",
-                "3",
-                "0",
-                "False"
+                "a",
+                // short circuit away b
+                "False",
+                "a",
+                "b",
+                "True",
+                "b",
+                "a",
+                "False",
+                "b",
+                // short circuit away a
+                "True"
             );
         }
     }

--- a/src/kOS.Safe.Test/Execution/SimpleTest.cs
+++ b/src/kOS.Safe.Test/Execution/SimpleTest.cs
@@ -116,5 +116,22 @@ namespace kOS.Safe.Test.Execution
                 "False"
             );
         }
+
+        [Test]
+        public void TestSuffixes()
+        {
+            // Test that various suffix and index combinations work for getting and setting
+            RunScript("integration/suffixes.ks");
+            RunSingleStep();
+            RunSingleStep();
+            AssertOutput(
+                "0",
+                "1",
+                "2",
+                "3",
+                "0",
+                "False"
+            );
+        }
     }
 }

--- a/src/kOS.Safe/Compilation/KS/ExpressionBuilder.cs
+++ b/src/kOS.Safe/Compilation/KS/ExpressionBuilder.cs
@@ -1,0 +1,370 @@
+﻿using System;
+using kOS.Safe.Encapsulation;
+using kOS.Safe.Exceptions;
+namespace kOS.Safe.Compilation.KS
+{
+    public static class ExpressionBuilder
+    {
+        public static ExpressionNode BuildExpression(ParseNode node)
+        {
+            switch (node.Token.Type)
+            {
+            case TokenType.expr:
+                // just a wrapper around another node
+                return BuildExpression(node.Nodes[0]);
+            case TokenType.or_expr:
+                return BuildLogicExpression(node, new OrExpressionNode() { ParseNode = node });
+            case TokenType.and_expr:
+                return BuildLogicExpression(node, new AndExpressionNode() { ParseNode = node });
+            case TokenType.compare_expr:
+                return BuildBinaryExpression(node, (separator) => new CompareExpressionNode() {
+                    Comparator = separator.Token.Text,
+                    ParseNode = separator
+                });
+            case TokenType.arith_expr:
+                return BuildBinaryExpression(node, (separator) => (
+                    separator.Token.Text == "+"
+                    ? (BinaryExpressionNode) new AddExpressionNode() { ParseNode = separator }
+                    : (BinaryExpressionNode) new SubtractExpressionNode() { ParseNode = separator }
+                ));
+            case TokenType.multdiv_expr:
+                return BuildBinaryExpression(node, (separator) => (
+                    separator.Token.Type == TokenType.MULT
+                    ? (BinaryExpressionNode) new MultiplyExpressionNode() { ParseNode = separator }
+                    : (BinaryExpressionNode) new DivideExpressionNode() { ParseNode = separator }
+                ));
+            case TokenType.unary_expr:
+                return BuildUnaryExpression(node);
+            case TokenType.factor:
+                return BuildBinaryExpression(node, (separator) => new PowerExpressionNode() { ParseNode = separator });
+            case TokenType.suffix:
+                return BuildSuffix(node);
+            case TokenType.atom:
+                return BuildAtom(node);
+            case TokenType.onoff_trailer:
+                return BuildOnOff(node);
+            case TokenType.varidentifier:
+                // just a wrapper around a suffix
+                return BuildSuffix(node.Nodes[0]);
+            case TokenType.instruction_block:
+                return BuildLambda(node);
+            default:
+                throw new KOSYouShouldNeverSeeThisException("Unknown expression token: " + node.Token.Type);
+            }
+        }
+
+        private static ExpressionNode BuildLogicExpression(ParseNode node, LogicExpressionNode logicNode)
+        {
+            // these are of the form
+            // expr -> sub_expr (SEPARATOR sub_expr)*
+            // these are logic operations, so we group them all up in one node so we can short circuit easily
+
+            if (node.Nodes.Count == 1)
+            {
+                // just a passthrough
+                return BuildExpression(node.Nodes[0]);
+            }
+
+            int count = (node.Nodes.Count + 1) / 2;
+            ExpressionNode[] exprs = new ExpressionNode[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                exprs[i] = BuildExpression(node.Nodes[i*2]);
+            }
+
+            logicNode.Expressions = exprs;
+
+            return logicNode;
+        }
+
+        private delegate BinaryExpressionNode BinaryExpressioner(ParseNode separator);
+
+        private static ExpressionNode BuildBinaryExpression(ParseNode node, BinaryExpressioner expressioner)
+        {
+            // these all take the form
+            // expr -> sub_expr (SEPARATOR sub_expr)*
+
+            // start with the leftmost subexpression
+            ExpressionNode expr = BuildExpression(node.Nodes[0]);
+
+            // build up the tree
+            for (int i = 1; i < node.Nodes.Count; i += 2)
+            {
+                // Construct the parent node from the separator
+                BinaryExpressionNode next = expressioner(node.Nodes[i]);
+                // Add its left and right children
+                next.Left = expr;
+                next.Right = BuildExpression(node.Nodes[i+1]);
+
+                // this is our new root expression
+                expr = next;
+            }
+
+            return expr;
+        }
+
+        private static ExpressionNode BuildUnaryExpression(ParseNode node)
+        {
+            // unary_expr -> (PLUSMINUS|NOT|DEFINED)? factor
+
+            if (node.Nodes.Count == 1)
+            {
+                // just a passthrough node
+                return BuildExpression(node.Nodes[0]);
+            }
+
+            Token op = node.Nodes[0].Token;
+            ExpressionNode target = BuildExpression(node.Nodes[1]);
+
+            switch (op.Type)
+            {
+            case TokenType.PLUSMINUS:
+                if (op.Text == "+")
+                {
+                    // +foo is the same as foo
+                    return target;
+                }
+                else
+                {
+                    return new NegateExpressionNode() {
+                        ParseNode = node,
+                        Target = target
+                    };
+                }
+            case TokenType.NOT:
+                return new NotExpressionNode() {
+                    ParseNode = node,
+                    Target = target
+                };
+            case TokenType.DEFINED:
+                if (target is IdentifierAtomNode)
+                {
+                    return new DefinedExpressionNode() {
+                        ParseNode = node,
+                        Identifier = ((IdentifierAtomNode)target).Identifier
+                    };
+                }
+                else
+                {
+                    throw new KOSCompileException(node.Token, "DEFINED can only operate on an identifier");
+                }
+            default:
+                throw new KOSYouShouldNeverSeeThisException("Unexpected unary_expr op: " + op.Type);
+            }
+        }
+
+        private static ExpressionNode BuildSuffix(ParseNode node)
+        {
+            // suffix -> suffixterm (suffix_trailer)*
+
+            ExpressionNode expr = BuildSuffixTerm(node.Nodes[0], null);
+            for (int i = 1; i < node.Nodes.Count; i++)
+            {
+                // suffix_trailer -> COLON suffixterm
+                ParseNode trailer = node.Nodes[i];
+
+                expr = BuildSuffixTerm(trailer.Nodes[1], expr);
+            }
+
+            return expr;
+        }
+
+        private static ExpressionNode BuildSuffixTerm(ParseNode node, ExpressionNode baseNode)
+        {
+            // suffixterm -> atom suffixterm_trailer*
+            ExpressionNode expr = BuildExpression(node.Nodes[0]);
+
+            // If we have a baseNode, the first expression is a suffix and must be an IdentifierAtomNode
+            if (baseNode != null)
+            {
+                if (expr is IdentifierAtomNode)
+                {
+                    expr = new GetSuffixNode() {
+                        ParseNode = node,
+                        Base = baseNode,
+                        Suffix = ((IdentifierAtomNode)expr).Identifier
+                    };
+                }
+                else
+                {
+                    throw new KOSCompileException(node.Token, "Suffix must be an identifier");
+                }
+            }
+
+            for (int i = 1; i < node.Nodes.Count; i++)
+            {
+                // suffixterm_trailer -> (function_trailer | array_trailer)
+                // immediately unwrap it into the trailer
+                ParseNode trailer = node.Nodes[i].Nodes[0];
+
+                switch (trailer.Token.Type)
+                {
+                case TokenType.function_trailer:
+                    // function_trailer -> (BRACKETOPEN arglist? BRACKETCLOSE) | ATSIGN
+
+                    if (trailer.Nodes[0].Token.Type == TokenType.ATSIGN)
+                    {
+                        // this is only valid on identifiers
+                        if (expr is IdentifierAtomNode)
+                        {
+                            expr = new FunctionAddressNode() {
+                                ParseNode = trailer,
+                                Identifier = ((IdentifierAtomNode)expr).Identifier
+                            };
+                        }
+                        else
+                        {
+                            throw new KOSCompileException(trailer.Token, "function address only valid on identifiers");
+                        }
+                    }
+                    else
+                    {
+                        ExpressionNode[] args = new ExpressionNode[0];
+                        if (trailer.Nodes.Count == 3)
+                        {
+                            args = BuildArglist(trailer.Nodes[1]);
+                        }
+
+                        if (expr is IdentifierAtomNode)
+                        {
+                            expr = new DirectCallNode() {
+                                ParseNode = trailer,
+                                Identifier = ((IdentifierAtomNode)expr).Identifier,
+                                Arguments = args
+                            };
+                        }
+                        else if (expr is GetSuffixNode)
+                        {
+                            expr = new CallSuffixNode() {
+                                ParseNode = trailer,
+                                Base = ((GetSuffixNode)expr).Base,
+                                Suffix = ((GetSuffixNode)expr).Suffix,
+                                Arguments = args
+                            };
+                        }
+                        else
+                        {
+                            expr = new IndirectCallNode() {
+                                ParseNode = trailer,
+                                Base = expr,
+                                Arguments = args
+                            };
+                        }
+                    }
+                    break;
+                case TokenType.array_trailer:
+                    // array_trailer -> (ARRAYINDEX (IDENTIFIER | INTEGER)) | (SQUAREOPEN expr SQUARECLOSE)
+                    // either way the array index is node #1
+                    expr = new GetIndexNode() {
+                        ParseNode = trailer,
+                        Base = expr,
+                        Index = BuildExpression(trailer.Nodes[1])
+                    };
+                    break;
+                default:
+                    throw new KOSYouShouldNeverSeeThisException("unknown suffixterm_trailer: " + trailer.Token.Type);
+                }
+            }
+
+            return expr;
+        }
+
+        private static ExpressionNode[] BuildArglist(ParseNode node)
+        {
+            // arglist -> expr (COMMA expr)*
+            int count = (node.Nodes.Count + 1) / 2;
+            ExpressionNode[] args = new ExpressionNode[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                // arguments are children 0, 2, 4, 6, etc.
+                args[i] = BuildExpression(node.Nodes[i*2]);
+            }
+
+            return args;
+        }
+
+        private static ExpressionNode BuildAtom(ParseNode node)
+        {
+            // atom -> sci_number | TRUEFALSE | IDENTIFIER | FILEIDENT | STRING | (BRACKETOPEN expr BRACKETCLOSE)
+
+            // If its a parenthesized expression, just return the inner expression
+            if (node.Nodes.Count == 3)
+            {
+                return BuildExpression(node.Nodes[1]);
+            }
+
+            ParseNode atom = node.Nodes[0];
+
+            switch (atom.Token.Type)
+            {
+            case TokenType.sci_number:
+                return BuildNumber(atom);
+            case TokenType.TRUEFALSE:
+                return new BooleanAtomNode() {
+                    ParseNode = atom,
+                    Value = atom.Token.Text.ToLower() == "true"
+                };
+            case TokenType.IDENTIFIER:
+            case TokenType.FILEIDENT:
+                return new IdentifierAtomNode() {
+                    ParseNode = atom,
+                    Identifier = atom.Token.Text
+                };
+            case TokenType.STRING:
+                // strip off the quotes
+                return new StringAtomNode() {
+                    ParseNode = atom,
+                    Value = atom.Token.Text.Substring(1, atom.Token.Text.Length - 2)
+                };
+            default:
+                throw new KOSYouShouldNeverSeeThisException("Unknown atom token: " + atom.Token.Type);
+            }
+        }
+
+        private static ExpressionNode BuildNumber(ParseNode node)
+        {
+            // sci_number -> number (E PLUSMINUS? INTEGER)?
+
+            // We just join all the strings together, then try to parse it as an int,
+            // falling back to a double if that doesn't work.
+
+            // number is just a wrapper around a numeric token
+            string numberText = node.Nodes[0].Nodes[0].Token.Text;
+
+            // add all the suffixes
+            for (int i = 1; i < node.Nodes.Count; i++)
+            {
+                numberText += node.Nodes[i].Token.Text;
+            }
+
+            numberText = numberText.Replace("_", "");
+
+            ScalarValue value;
+
+            if (ScalarValue.TryParseInt(numberText, out value) || ScalarValue.TryParseDouble(numberText, out value)) {
+                return new ScalarAtomNode() {
+                    ParseNode = node,
+                    Value = value
+                };
+            }
+
+            throw new KOSCompileException(node.Token, string.Format(KOSNumberParseException.TERSE_MSG_FMT, node.Token.Text));
+        }
+
+        private static ExpressionNode BuildOnOff(ParseNode node)
+        {
+            // onoff_trailer -> (ON | OFF)
+            return new BooleanAtomNode() {
+                ParseNode = node,
+                Value = node.Nodes[0].Token.Type == TokenType.ON
+            };
+        }
+
+        private static ExpressionNode BuildLambda(ParseNode node)
+        {
+            return new LambdaNode() { ParseNode = node };
+        }
+    }
+}

--- a/src/kOS.Safe/Compilation/KS/ExpressionNode.cs
+++ b/src/kOS.Safe/Compilation/KS/ExpressionNode.cs
@@ -1,0 +1,234 @@
+﻿using System;
+using kOS.Safe.Encapsulation;
+namespace kOS.Safe.Compilation.KS
+{
+    public abstract class ExpressionNode
+    {
+        public ParseNode ParseNode { get; set; }
+
+        public abstract void Accept(IExpressionVisitor visitor);
+    }
+
+    public abstract class LogicExpressionNode : ExpressionNode
+    {
+        public ExpressionNode[] Expressions { get; set; }
+    }
+
+    public class OrExpressionNode : LogicExpressionNode
+    {
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+
+    public class AndExpressionNode : LogicExpressionNode
+    {
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+
+    public abstract class BinaryExpressionNode : ExpressionNode
+    {
+        public ExpressionNode Left { get; set; }
+        public ExpressionNode Right { get; set; }
+    }
+
+    public class CompareExpressionNode : BinaryExpressionNode
+    {
+        public string Comparator { get; set; }
+
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+
+    public class AddExpressionNode : BinaryExpressionNode
+    {
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+
+    public class SubtractExpressionNode : BinaryExpressionNode
+    {
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+
+    public class MultiplyExpressionNode : BinaryExpressionNode
+    {
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+
+    public class DivideExpressionNode : BinaryExpressionNode
+    {
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+
+    public class PowerExpressionNode : BinaryExpressionNode
+    {
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+
+    public class NegateExpressionNode : ExpressionNode
+    {
+        public ExpressionNode Target { get; set; }
+
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+
+    public class NotExpressionNode : ExpressionNode
+    {
+        public ExpressionNode Target { get; set; }
+
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+
+    public class DefinedExpressionNode : ExpressionNode
+    {
+        public string Identifier { get; set; }
+
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+
+    public class GetSuffixNode : ExpressionNode
+    {
+        public ExpressionNode Base { get; set; }
+        public string Suffix { get; set; }
+
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+
+    public class CallSuffixNode : ExpressionNode
+    {
+        public ExpressionNode Base { get; set; }
+        public string Suffix { get; set; }
+        public ExpressionNode[] Arguments { get; set; }
+
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+
+    public class GetIndexNode : ExpressionNode
+    {
+        public ExpressionNode Base { get; set; }
+        public ExpressionNode Index { get; set; }
+
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+
+    public class DirectCallNode : ExpressionNode
+    {
+        public string Identifier { get; set; }
+        public ExpressionNode[] Arguments { get; set; }
+
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+
+    public class IndirectCallNode : ExpressionNode
+    {
+        public ExpressionNode Base { get; set; }
+        public ExpressionNode[] Arguments { get; set; }
+
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+
+    public class FunctionAddressNode : ExpressionNode
+    {
+        public string Identifier { get; set; }
+
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+
+    public class LambdaNode : ExpressionNode
+    {
+        // TODO: what needs to be here
+
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+
+    public class ScalarAtomNode : ExpressionNode
+    {
+        public ScalarValue Value { get; set; }
+
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+
+    public class StringAtomNode : ExpressionNode
+    {
+        public string Value { get; set; }
+
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+
+    public class BooleanAtomNode : ExpressionNode
+    {
+        public bool Value { get; set; }
+
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+
+    public class IdentifierAtomNode : ExpressionNode
+    {
+        public string Identifier { get; set; }
+
+        public override void Accept(IExpressionVisitor visitor)
+        {
+            visitor.VisitExpression(this);
+        }
+    }
+}

--- a/src/kOS.Safe/Compilation/KS/IExpressionVisitor.cs
+++ b/src/kOS.Safe/Compilation/KS/IExpressionVisitor.cs
@@ -1,0 +1,29 @@
+﻿using System;
+namespace kOS.Safe.Compilation.KS
+{
+    public interface IExpressionVisitor
+    {
+        void VisitExpression(OrExpressionNode node);
+        void VisitExpression(AndExpressionNode node);
+        void VisitExpression(CompareExpressionNode node);
+        void VisitExpression(AddExpressionNode node);
+        void VisitExpression(SubtractExpressionNode node);
+        void VisitExpression(MultiplyExpressionNode node);
+        void VisitExpression(DivideExpressionNode node);
+        void VisitExpression(PowerExpressionNode node);
+        void VisitExpression(NegateExpressionNode node);
+        void VisitExpression(NotExpressionNode node);
+        void VisitExpression(DefinedExpressionNode node);
+        void VisitExpression(GetSuffixNode node);
+        void VisitExpression(CallSuffixNode node);
+        void VisitExpression(GetIndexNode node);
+        void VisitExpression(DirectCallNode node);
+        void VisitExpression(IndirectCallNode node);
+        void VisitExpression(FunctionAddressNode node);
+        void VisitExpression(LambdaNode node);
+        void VisitExpression(ScalarAtomNode node);
+        void VisitExpression(StringAtomNode node);
+        void VisitExpression(BooleanAtomNode node);
+        void VisitExpression(IdentifierAtomNode node);
+    }
+}

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -713,15 +713,22 @@ namespace kOS.Safe.Compilation
         }
     }
     
-    public class OpcodeGetMember : Opcode
+    public class OpcodeGetMember : OpcodeIdentifierBase
     {
         protected override string Name { get { return "getmember"; } }
         public override ByteCode Code { get { return ByteCode.GETMEMBER; } }
         protected bool IsMethodCallAttempt = false;
 
+        public OpcodeGetMember(string identifier) : base(identifier)
+        {
+        }
+
+        protected OpcodeGetMember() : base("")
+        {
+        }
+
         public override void Execute(ICpu cpu)
         {
-            string suffixName = cpu.PopArgumentStack().ToString();
             object popValue = cpu.PopValueEncapsulatedArgument();
 
             var specialValue = popValue as ISuffixed;
@@ -731,7 +738,7 @@ namespace kOS.Safe.Compilation
                 throw new Exception(string.Format("Values of type {0} cannot have suffixes", popValue.GetType()));
             }
 
-            ISuffixResult result = specialValue.GetSuffix(suffixName);
+            ISuffixResult result = specialValue.GetSuffix(Identifier);
 
             // If the result is a suffix that is still in need of being invoked and hasn't resolved to a value yet:
             if (result != null && !IsMethodCallAttempt && !result.HasValue)
@@ -778,6 +785,15 @@ namespace kOS.Safe.Compilation
     {
         protected override string Name { get { return "getmethod"; } }
         public override ByteCode Code { get { return ByteCode.GETMETHOD; } }
+
+        public OpcodeGetMethod(string identifier) : base(identifier)
+        {
+        }
+
+        protected OpcodeGetMethod() : base("")
+        {
+        }
+
         public override void Execute(ICpu cpu)
         {
             IsMethodCallAttempt = true;

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -802,15 +802,22 @@ namespace kOS.Safe.Compilation
     }
 
     
-    public class OpcodeSetMember : Opcode
+    public class OpcodeSetMember : OpcodeIdentifierBase
     {
         protected override string Name { get { return "setmember"; } }
         public override ByteCode Code { get { return ByteCode.SETMEMBER; } }
 
+        public OpcodeSetMember(string identifier) : base(identifier)
+        {
+        }
+
+        protected OpcodeSetMember() : base("")
+        {
+        }
+
         public override void Execute(ICpu cpu)
         {
             Structure value = cpu.PopStructureEncapsulatedArgument();         // new value to set it to
-            string suffixName = cpu.PopArgumentStack().ToString();            // name of suffix being set
             Structure popValue = cpu.PopStructureEncapsulatedArgument();      // object to which the suffix is attached.
 
             // We aren't converting the popValue to a Scalar, Boolean, or String structure here because
@@ -827,9 +834,9 @@ namespace kOS.Safe.Compilation
             // TODO: When we refactor to make every structure use the new suffix style, this conversion
             // to primative can be removed.  Right now there are too many structures that override the
             // SetSuffix method while relying on unboxing the object rahter than using Convert
-            if (!specialValue.SetSuffix(suffixName, Structure.ToPrimitive(value)))
+            if (!specialValue.SetSuffix(Identifier, Structure.ToPrimitive(value)))
             {
-                throw new Exception(string.Format("Suffix {0} not found on object", suffixName));
+                throw new Exception(string.Format("Suffix {0} not found on object", Identifier));
             }
         }
     }

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -284,6 +284,9 @@
     <Compile Include="Function\Suffixed.cs" />
     <Compile Include="Function\Trigonometry.cs" />
     <Compile Include="Utilities\StringUtil.cs" />
+    <Compile Include="Compilation\KS\ExpressionNode.cs" />
+    <Compile Include="Compilation\KS\ExpressionBuilder.cs" />
+    <Compile Include="Compilation\KS\IExpressionVisitor.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Compilation\CompiledObject-doc.md" />


### PR DESCRIPTION
Includes changes from #2181. Just look at the last commit for only these changes.

This changes expression compilation to first build semantic ExpressionNodes and compile those instead.

This has 3 goals:
- Replace complicated code with simple code
  - This is pretty subjective, but I think that this code is at least not *more* complicated
- Reduce the chance of introducing bugs in compiler changes
  - The highest bug risk I see here is all of the boolean global state variables. These will cause incorrect behavior if they are not set or checked properly everywhere that may be affected by them. With this change, I'm removing 3 of the most heavily used flags (which were the source of every compiler bug I've run into while trying to make changes).
- Make further changes to the compiler easier
  - By grouping related information together and only sharing code that is actually reused, it is easier to make changes to one piece of functionality without affecting others.