### PR TITLE
Force CultureInvariant for all TryParse's.

### DIFF
--- a/src/kOS.Safe/Encapsulation/ScalarValue.cs
+++ b/src/kOS.Safe/Encapsulation/ScalarValue.cs
@@ -112,7 +112,7 @@ namespace kOS.Safe.Encapsulation
             result = null; // default the out value to null
             int val;
             str = str.Replace("_","");
-            if (int.TryParse(str, out val))
+            if (int.TryParse(str, NumberStyles.Integer, CultureInfo.InvariantCulture, out val))
             {
                 result = new ScalarIntValue(val);
                 return true;
@@ -125,7 +125,7 @@ namespace kOS.Safe.Encapsulation
             result = null; // default the out value to null
             str = trimPattern.Replace(str, "E").Replace("_",""); // remove white space around "e" and strip spacing underscores.
             double val;
-            if (double.TryParse(str, out val))
+            if (double.TryParse(str, NumberStyles.Float, CultureInfo.InvariantCulture, out val))
             {
                 // use Create instead of new ScalarDoubleValue so doubles that
                 // represent integers will output a ScalarIntValue instead

--- a/src/kOS.Safe/Persistence/GlobalPath.cs
+++ b/src/kOS.Safe/Persistence/GlobalPath.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using kOS.Safe.Persistence;
@@ -44,7 +45,7 @@ namespace kOS.Safe.Persistence
             }
 
             int result;
-            if (volumeId is string && int.TryParse(volumeId as string, out result))
+            if (volumeId is string && int.TryParse(volumeId as string, NumberStyles.Integer, CultureInfo.InvariantCulture, out result))
             {
                 volumeId = result;
             }

--- a/src/kOS.Safe/Persistence/PersistenceUtilities.cs
+++ b/src/kOS.Safe/Persistence/PersistenceUtilities.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -113,7 +114,7 @@ namespace kOS.Safe.Persistence
                     if (semicolonPos < 0)
                         throw new KOSPersistenceException("Improperly encoded saved file contains '&' without closing ';'");
                     int charOrdinal;
-                    if (!int.TryParse(input.Substring(inputPos + 2, semicolonPos - (inputPos + 2)), out charOrdinal))
+                    if (!int.TryParse(input.Substring(inputPos + 2, semicolonPos - (inputPos + 2)), NumberStyles.Integer, CultureInfo.InvariantCulture, out charOrdinal))
                         throw new KOSPersistenceException("Improperly encoded saved file contains non-digits between the '&#' and the ';'");
                     output.Append((char)charOrdinal);
                     inputPos = semicolonPos; // skip to the end of the encoding section, as if everything between '&' and ';' was one char of input.

--- a/src/kOS/Function/Suffixed.cs
+++ b/src/kOS/Function/Suffixed.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Collections.Generic;
 using System.Linq;
 using kOS.Execution;
@@ -587,7 +588,7 @@ namespace kOS.Function
             }
 
             double parsedAmount;
-            if (Double.TryParse(amount.ToString(), out parsedAmount))
+            if (Double.TryParse(amount.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out parsedAmount))
             {
                 object toPush = shared.TransferManager.CreateTransfer(resourceInfo, transferTo, transferFrom, parsedAmount);
                 ReturnValue = toPush;

--- a/src/kOS/Screen/KOSToolbarWindow.cs
+++ b/src/kOS/Screen/KOSToolbarWindow.cs
@@ -6,6 +6,7 @@ using kOS.UserIO;
 using kOS.Utilities;
 using KSP.UI.Screens;
 using System;
+using System.Globalization;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -624,7 +625,7 @@ namespace kOS.Screen
             int newInt = -99; // Nonzero value to act as a flag to detect if the following line got triggered:
             if (fieldValue.Length == 0)
                 newInt = 0;// Empty or whitespace input should be a zero, instead of letting int.TryParse() call it an error.
-            if (newInt == 0 || int.TryParse(fieldValue, out newInt))
+            if (newInt == 0 || int.TryParse(fieldValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out newInt))
             {
                 backingConfigInts[whichInt] = newInt;
                 // Don't commit the temp value back to the CONFIGs unless RETURN is being pressed right now:

--- a/src/kOS/Suffixed/FlightControl.cs
+++ b/src/kOS/Suffixed/FlightControl.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Collections.Generic;
 using kOS.AddOns.RemoteTech;
 using kOS.Safe.Encapsulation;
@@ -246,7 +247,7 @@ namespace kOS.Suffixed
         {
             var valueStr = value.ToString();
             float valueParsed;
-            if (float.TryParse(valueStr, out valueParsed))
+            if (float.TryParse(valueStr, NumberStyles.Float, CultureInfo.InvariantCulture, out valueParsed))
             {
                 doubleValue = valueParsed;
             }

--- a/src/kOS/UserIO/TelnetWelcomeMenu.cs
+++ b/src/kOS/UserIO/TelnetWelcomeMenu.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Collections.Generic;
 using System.Text;
 using System.Linq;
@@ -130,7 +131,7 @@ namespace kOS.UserIO
                 return;
             }
             int pickNumber;
-            if (!int.TryParse(cmd, out pickNumber) )
+            if (!int.TryParse(cmd, NumberStyles.Integer, CultureInfo.InvariantCulture, out pickNumber) )
             {
                 telnetServer.Write("Garbled selection. Try again." + (char)UnicodeCommand.STARTNEXTLINE);
                 forceMenuReprint = true;


### PR DESCRIPTION
Fixes #2163 (or so I believe)

I can't prove that this really fixes the problem because the problem was hard to reproduce anywhere other than the reporter's computer.  But I believe this is what caused it.

The regex rules in ``kRISC.tpg`` demand that our language's number format conform to the "C Locale" typically used in most programming languages.  If you wanted to write "three and 2 tenths" in kerboscript, the grammar file only supports doing it as "3.2", not "3,2".

But then once that "3.2" is turned into a single token, and that single token with text "3.2" is walked by the compiler, the compiler tries getting its Double value by using ``Double.TryParse()``, which *defaults to the user's locale settings when you don't specify a preference*, which may very well be set to expect "3,2" instead of "3.2", and thus it refuses to use the value as a Double.

The fix is that since we don't *actually* support using comma-decimals anyway, and the grammar file can't handle "3,2" as a single number, we may as well remove the *default to user's locale* behaviour from the Compiler code and force it to use invariant culture everywhere.

While I was at it, I carefully examined all the other instances of ``TryParse()`` and checked to see if they could use an explicit InvariantCulture as well.  In the end, we *never* want that varying behaviour depending on culture to surprise us anywhere else either.