### PR TITLE
Fixes #2200 making the delete primitive not die.

### DIFF
--- a/src/kOS.Safe/Persistence/Harddisk.cs
+++ b/src/kOS.Safe/Persistence/Harddisk.cs
@@ -104,6 +104,11 @@ namespace kOS.Safe.Persistence
 
             HarddiskDirectory directory = ParentDirectoryForPath(path);
 
+            if (directory == null)
+            {
+                return false;
+            }
+
             return directory.Delete(path.Name, ksmDefault);
         }
 


### PR DESCRIPTION
Previously - the harddisk volume delete primitive would die
with null ref when the path doesn't exist.  The problem
only happened on the local volume (archive didn't have the
same bug).

Now - it returns false like the archive version does.