### PR TITLE
Added exception detection to ThreadFinish()

### DIFF
--- a/src/kOS.Safe/Execution/YiedFinishedThreadedDetector.cs
+++ b/src/kOS.Safe/Execution/YiedFinishedThreadedDetector.cs
@@ -37,9 +37,19 @@ namespace kOS.Safe.Execution
                 childThread.Join();
                 if (childException == null)
                 {
-                    ThreadFinish();
+                    try
+                    {
+                        ThreadFinish();
+                    }
+                    catch (Exception ex)
+                    {
+                        childException = ex;
+                    }
                 }
-                else
+                // Note this is *deliberately* NOT an "else" of the above "if" even though
+                // it looks like it should be.  That is because the above IF clause can actually
+                // alter this flag and if it does so it needs to fall through to here and do this.
+                if (childException != null)
                 {
                     // If there was an error in the child thread, break execution and then
                     // throw the exception.  Because we're still executing the same opcode


### PR DESCRIPTION
This sort of fixes one half of issue #2203.

Issue #2203 had two halves to it:

part 1 - When the problem happened, the exception got re-thrown
in a loop forever, never relinquishing control.  Regardless
of the cause of the exception, throwing an exception shouldn't
cause kOS to get stuck in a loop like that.  Something is wrong
with the error handling system.

part 2  - The problem that threw the exception shouldn't have
happened in the first place.

This PR fixes just part 1.  Part 2 is in a separate PR.  That is
deliberate because you cannot test the exception message
handling if the bug that caused the exception is fixed.  That bug
needs to still be present to prove that the error message system
is handling it better.

-----------
The cause of the exception looping:

Compiling happens in a thread, using the YieldFinishedDetector system.

When the CPU wakes up each tick to see if a YieldFinishDetector thread
is done, it calls IsFinished() to do so.  If IsFinished() notices that
`ThreadExecute()` is done, then it calls `ThreadFinish()` to do any cleanup the
class wants to do, and after that sets some flags that tells it the
thread is done and IsFinished() no longer has to be called.

Compiling consists of 2 steps, Compile and BuildProgram, and only
Compile was put under the `ThreadExecute()` control.  The BuildProgram
step was being done inside `ThreadFinish()`.

The problem is that if ThreadFinish() aborts with an exception, then IsFinished
aborts, never reaching the code that sets flags telling the CPU the thread is done.
So on the next tick, the CPU tries calling IsFinished() again, which notices
that ThreadExecute() is done (still) so it tries calling ThreadFinish(), and
triggers the whole thing again.

--------------
The fix: there are two possible fixes, and I chose the one that didn't
involve touching code I didn't write.

possible fix 1 - move the BuildProgram step inside the `ThreadExecute()`.
This is more in keeping with the design intent of ThreadExecute(), but would
have involved touching code I don't want to touch.

possible fix 2 - Give `ThreadFinish()` the same exception checking that
`ThreadExecute()` has so an exception in ThreadFinished() won't prevent the
system from noticing that the thread indeed has finished.

I chose fix 2.