### PR TITLE
function global/local scoping hotfix

### DIFF
--- a/kerboscript_tests/user_functions/functest29.ks
+++ b/kerboscript_tests/user_functions/functest29.ks
@@ -1,0 +1,14 @@
+print "Testing default function scoping rules".
+
+run once "functest29_lib.ks".
+
+print "Should say Func1: " + func1().
+if (func1() <> "Func1") print "!!!!!!!!!! ERROR ERROR ERROR !!!!!!!!!!!" + char(7) + char(7).
+local f2 is getfunc2().
+print "Should say Func2: " + f2().
+if (f2() <> "Func2") print "!!!!!!!!!! ERROR ERROR ERROR !!!!!!!!!!!" + char(7) + char(7).
+
+local f3 is getfunc3().
+print "Should say Func3: " + f3().
+if (f3() <> "Func3") print "!!!!!!!!!! ERROR ERROR ERROR !!!!!!!!!!!" + char(7) + char(7).
+

--- a/kerboscript_tests/user_functions/functest29_lib.ks
+++ b/kerboscript_tests/user_functions/functest29_lib.ks
@@ -1,0 +1,17 @@
+function func1 {
+  return "Func1".
+}
+
+function getfunc2 {
+  function sameName {  // <--------+--- These two innner functions have the same name
+    return "Func2".    // <-----+--|--- But have different effects when called.
+  }                    //       |  |
+  return sameName@.    // <--+--|--|--- These should return the 2 different versions.
+}                      //    |  |  |
+                       //    |  |  |
+function getfunc3 {    //    |  |  |
+  function sameName {  // <--|--|--'
+    return "Func3".    // <--|--'
+  }                    //    |
+  return sameName@.    // <--'
+}                      //

--- a/kerboscript_tests/user_functions/functest30.ks
+++ b/kerboscript_tests/user_functions/functest30.ks
@@ -1,0 +1,17 @@
+print "Testing explicit function scope keywords override.".
+
+run once "functest30_lib.ks".
+local del is outer().
+
+print "Should say global1: " + global1().
+if (global1() <> "global1") print "!!!!!!!!!! ERROR ERRROR !!!!!!!!!!" + char(7) + char (7).
+print "Should say global2: " + global2().
+if (global2() <> "global2") print "!!!!!!!!!! ERROR ERRROR !!!!!!!!!!" + char(7) + char (7).
+print "Should say global3: " + global3().
+if (global3() <> "global3") print "!!!!!!!!!! ERROR ERRROR !!!!!!!!!!" + char(7) + char (7).
+print "Should say local2: " + del().
+if (del() <> "local2") print "!!!!!!!!!! ERROR ERRROR !!!!!!!!!!" + char(7) + char (7).
+
+print " ".
+print "PROGRAM SHOULD NOW FAIL WITH 'local1' NOT FOUND.".
+print local1().

--- a/kerboscript_tests/user_functions/functest30_lib.ks
+++ b/kerboscript_tests/user_functions/functest30_lib.ks
@@ -1,0 +1,11 @@
+global function global1 { return "global1". }
+function global2 { return "global2". }
+local function local1 { return "local1". }
+
+function outer {
+  function local2 { return "local2". } // local by default
+  global function global3 { return "global3". } // explicit global keyword despite being nested
+  function local1 { return local2(). } // Note this local1 should mask the outer local1
+
+  return local1@. // via this delegate, it actually will call local2().
+}


### PR DESCRIPTION
Fixes #2204 
Fixes #2203 

** PLEASE test and merge PR #2205 before this PR. **
(The reason is because PR #2205 is a fix to the error message that happens when this bug occurs.  If you merge this PR first, then the bug won't trigger anymore and you can't test the error message fix from 2205.)


Now the comment that claims function scope is
only global at file scope is actually telling the truth!

(The code contained a comment that described the correct
behaviour, but the code itself didn't actually implement
what the comment said it was doing.)