### PR TITLE
triggers from delegate with bound args - fixes #2236

### DIFF
--- a/src/kOS.Safe/Encapsulation/KOSDelegate.cs
+++ b/src/kOS.Safe/Encapsulation/KOSDelegate.cs
@@ -47,6 +47,21 @@ namespace kOS.Safe.Encapsulation
             PreBoundArgs.Add(arg);
         }
 
+		/// <summary>
+		/// Get list of pre-bound args and provided args.
+		/// Used by CPU.AddTrigger.
+		/// </summary>
+		/// <param name="args">Arguments to add to returned list</param>
+		/// <returns>PreBoundArgs + args (or args if PreBoundArgs.Count = 0)</returns>
+		public List<Structure> GetMergedArgs(List<Structure> args)
+		{
+			if (PreBoundArgs.Count == 0) return args;
+			var merged = new List<Structure>(PreBoundArgs.Count + args.Count);
+			merged.AddRange(PreBoundArgs);
+			merged.AddRange(args);
+			return merged;
+		}
+
         public Structure CallPassingArgs(params Structure[] args)
         {
             if (Cpu == null)

--- a/src/kOS.Safe/Execution/CPU.cs
+++ b/src/kOS.Safe/Execution/CPU.cs
@@ -1136,7 +1136,7 @@ namespace kOS.Safe.Execution
         {
             if (del.ProgContext != currentContext)
                 return null;
-            TriggerInfo callbackRef = new TriggerInfo(currentContext, del.EntryPoint, del.Closure, args);
+            TriggerInfo callbackRef = new TriggerInfo(currentContext, del.EntryPoint, del.Closure, del.GetMergedArgs(args));
             currentContext.AddPendingTrigger(callbackRef);
             return callbackRef;
         }


### PR DESCRIPTION
I have chosen to fix `CPU.AddTrigger` because this seems to be the point where `UserDelegate` gets converted to `EntryPoint` and `PreBoundArgs` were lost. Now passes the test with simple button:

```
local wnd is gui(0).
local btn is wnd:addButton("TEST").
local function click {
	parameter text.
	print text.
}
set btn:onClick to click@:bind("TEST").
wnd:show().
```
fixes #2236

P.S.: I seem to have different formatting options. Would it be possible to add [`.editorconfig`](http://editorconfig.org/)?