### PR TITLE
fix #2252 position at node

### DIFF
--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -173,7 +173,7 @@ namespace kOS.Suffixed
             // patch, then just return the last patch (this can happen because a patches' EndUT
             // is one period of time and we might be predicting for a point in time more than one
             // period into the future.)
-            while (!(orbitPatch.StartUT < desiredUT && desiredUT < orbitPatch.EndUT))
+            while (!(orbitPatch.StartUT <= desiredUT && desiredUT < orbitPatch.EndUT))
             {
                 // Sadly the way to detect that you are at the end of the orbitPatch list is
                 // messy and inconsistent.  Sometimes KSP's API gives you a list that ends


### PR DESCRIPTION
The single character fix as discussed. Resolved the problem, no more glitches when leaving SOI.

Was able to reproduce the problem whenever the trajectory following the node changed SOI, e.g. transfer from Kerbin to Mun, but can even escape Kerbin's SOI, does not matter as long as it changes SOI and therefore has more than one patch. The red vector always pointed somewhere at last patch (e.g. final orbit around Kerbin after passing Mun). Not with this.