### PR TITLE
Target of inactive vessel

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*.cs]
+indent_style = space
+indent_size = 4
+charset = utf-8
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_call_parameter_list_parentheses = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # VisualStudio
+.vs/
 [Bb]in/
 [Oo]bj/
 *.suo
@@ -11,6 +12,9 @@ packages/
 
 # VisualStudio Code
 .vscode/
+
+# Vim
+*.swp
 
 # Unity
 [Ll]ibrary/

--- a/doc/source/bindings.rst
+++ b/doc/source/bindings.rst
@@ -38,10 +38,11 @@ TARGET:
   docking port is selected as the target, it will be the corresponding part.
   If set to a string, it will assume the string is the name of a vessel being
   targeted and set it to a vessel by that name. For best results set it
-  to Body("some name") or Vessel("some name") explicitly.  This will
-  throw an exception if called from a vessel other than the active vessel,
+  to Body("some name") or Vessel("some name") explicitly. It will
+  throw an exception if changed from a vessel other than the active vessel,
   as limitations in how KSP sets the target vessel limit the
-  implementation to working with only the active vessel.
+  implementation to working with only the active vessel. The value
+  can always be retrieved but changed only from active vessel.
 
 .. _hastarget:
 
@@ -52,8 +53,6 @@ HASTARGET:
 - **Settable**: no
 - **Type**: boolean
 - **Description**: Will return true if the ship has a target selected.
-  This will always return false when not on the active vessel, due to
-  limitations in how KSP sets the target vessel.
 
 Alias shortcuts for SHIP fields
 -------------------------------

--- a/src/kOS/Binding/MissionSettings.cs
+++ b/src/kOS/Binding/MissionSettings.cs
@@ -60,36 +60,24 @@ namespace kOS.Binding
 
             shared.BindingMgr.AddGetter("TARGET", () =>
             {
-                if (shared.Vessel != FlightGlobals.ActiveVessel)
-                {
-                    throw new kOS.Safe.Exceptions.KOSSituationallyInvalidException("TARGET can only be returned for the Active Vessel");
-                }
-                var currentTarget = FlightGlobals.fetch.VesselTarget;
+                var target = shared.Vessel == FlightGlobals.ActiveVessel ?
+                    FlightGlobals.fetch.VesselTarget : shared.Vessel.targetObject;
 
-                var vessel = currentTarget as Vessel;
-                if (vessel != null)
-                {
+                if (target is Vessel vessel)
                     return VesselTarget.CreateOrGetExisting(vessel, shared);
-                }
-                var body = currentTarget as CelestialBody;
-                if (body != null)
-                {
+                if (target is CelestialBody body)
                     return BodyTarget.CreateOrGetExisting(body, shared);
-                }
-                var dockingNode = currentTarget as ModuleDockingNode;
-                if (dockingNode != null)
-                {
+                if (target is ModuleDockingNode dockingNode)
                     return new DockingPortValue(dockingNode, shared);
-                }
 
                 throw new kOS.Safe.Exceptions.KOSSituationallyInvalidException("No TARGET is selected");
             });
 
             shared.BindingMgr.AddGetter("HASTARGET", () =>
             {
-                if (shared.Vessel != FlightGlobals.ActiveVessel) return false;
                 // the ship has a target if the object does not equal null.
-                return FlightGlobals.fetch.VesselTarget != null;
+                return (shared.Vessel == FlightGlobals.ActiveVessel ?
+                    FlightGlobals.fetch.VesselTarget : shared.Vessel.targetObject) != null;
             });
 
         }


### PR DESCRIPTION
fix #2257
Works fine when switching vessels, I can even control the inactive from a GUI I have created,
I can make it point at active vessel or away from it on a press of a button, nice!

I am still not sure if it will work when I switch to KSC/Tracking and back, but that would require some clever boot script, but I seem to have problems with booting on loading. All ships boot correctly when I approach them, but not when I switch to them from Tracking Station.