### PR TITLE
Fixes #2231 by shortening the test string.

### DIFF
--- a/src/kOS/UserIO/TerminalUnicodeMapper.cs
+++ b/src/kOS/UserIO/TerminalUnicodeMapper.cs
@@ -60,8 +60,9 @@ namespace kOS.UserIO
         {
             if (typeString.Substring(0,5).Equals("xterm", StringComparison.CurrentCultureIgnoreCase))
                 return TerminalType.XTERM;
-            if (typeString.Substring(0,4).Equals("vt100", StringComparison.CurrentCultureIgnoreCase))
-                return TerminalType.XTERM;
+            // This should catch either vt100 or vt102:
+            if (typeString.Substring(0,4).Equals("vt10", StringComparison.CurrentCultureIgnoreCase))
+                return TerminalType.VT100;
 
                 //
                 // The following condition isn't implemented yet:


### PR DESCRIPTION
The original intent was to support either vt100 or vt102
with the same thing (vt100).  That's why the check only
checked the 4 characters.  It was looking for vt10_ where
the _ could be anything.  But it wasn't done right before.