### PR TITLE
Fix rehook counter

### DIFF
--- a/src/kOS/AddOns/RemoteTech/RemoteTechConnectivityManager.cs
+++ b/src/kOS/AddOns/RemoteTech/RemoteTechConnectivityManager.cs
@@ -92,6 +92,8 @@ namespace kOS.AddOns.RemoteTech
                     callbacks[hook] = action;
                 }
                 RemoteTechHook.Instance.AddSanctionedPilot(vessel.id, action);
+                // removing the callback from stock if not already added doesn't throw an error
+                vessel.OnPreAutopilotUpdate -= hook;
             }
             else // fallback to stock events when RT isn't available, this may have unexpected results if RT availability changes
             {
@@ -111,6 +113,8 @@ namespace kOS.AddOns.RemoteTech
             {
                 RemoteTechHook.Instance.RemoveSanctionedPilot(vessel.id, action);
                 callbacks.Remove(hook);
+                // removing the callback from stock if not already added doesn't throw an error
+                vessel.OnPreAutopilotUpdate -= hook;
             }
             else // remove fallback event hook
             {

--- a/src/kOS/Module/kOSVesselModule.cs
+++ b/src/kOS/Module/kOSVesselModule.cs
@@ -335,6 +335,7 @@ namespace kOS.Module
                 if (++autopilotRehookCounter > autopilotRehookPeriod)
                 {
                     ConnectivityManager.AddAutopilotHook(Vessel, UpdateAutopilot);
+                    autopilotRehookCounter = 0;
                 }
             }
             else


### PR DESCRIPTION
Fixes #2261

kOSVesselModule.cs
* Fix the CheckRehookAutopilot to reset autopilotRehookCounter when it
triggers.

RemoteTechConnectivityManager.cs
* Fix autopilot hook calls to clear stock events when clearing or adding
RT events