### PR TITLE
Fixes #2239 user callbacks immediately

### DIFF
--- a/kerboscript_tests/gui/gui_callback_1.ks
+++ b/kerboscript_tests/gui/gui_callback_1.ks
@@ -14,12 +14,12 @@ PRINT "How Button 1 would behave without takepress.".
   set B2:toggle to true.
 
   local B3 is g:addbutton("button 3 (callback, not a toggle)").
-  set B3:onchange to {parameter newval. print "Button 3 onchange(" + newval + ")".}.
+  set B3:ontoggle to {parameter newval. print "Button 3 onchange(" + newval + ")".}.
   set B3:onclick to {print "Button 3 onclick.".}.
 
   local B4 is g:addbutton("button 4 (callback, a toggle)").
   set B4:toggle to true.
-  set B4:onchange to {parameter newval. print "Button 4 onchange(" + newval + ")".}.
+  set B4:ontoggle to {parameter newval. print "Button 4 onchange(" + newval + ")".}.
   set B4:onclick to {print "Button 4 onclick".}.
 
   local q_button is g:addbutton("Quit").

--- a/kerboscript_tests/gui/gui_callback_2.ks
+++ b/kerboscript_tests/gui/gui_callback_2.ks
@@ -18,19 +18,19 @@ print " ".
   local b1_label is set1:addlabel("Choose"+char(10)+"radio"+char(10)+"station").
 
   global b1_jazz is set1:addradiobutton("Jazz",false).
-  set b1_jazz:onchange to {parameter val. print "Jazz is " + val.}.
+  set b1_jazz:ontoggle to {parameter val. print "Jazz is " + val.}.
   set1:addlabel("Jazz").
 
   global b1_blues is set1:addradiobutton("Blues",false).
-  set b1_blues:onchange to {parameter val. print "Blues is " + val.}.
+  set b1_blues:ontoggle to {parameter val. print "Blues is " + val.}.
   set1:addlabel("Blues").
 
   global b1_funk is set1:addradiobutton("Funk",false).
-  set b1_funk:onchange to {parameter val. print "Funk is " + val.}.
+  set b1_funk:ontoggle to {parameter val. print "Funk is " + val.}.
   set1:addlabel("Funk").
 
   global b1_rock is set1:addradiobutton("Rock",false).
-  set b1_rock:onchange to {parameter val. print "Rock is " + val.}.
+  set b1_rock:ontoggle to {parameter val. print "Rock is " + val.}.
   set1:addlabel("Rock").
 
   set SET1:ONRADIOCHANGE to my_set1_radio_monitor@.
@@ -49,17 +49,17 @@ print " ".
   local b2_1 is set2:addradiobutton("Human", false).
   set b2_1:style:width to 80.
   set b2_1:style to G:Skin:Button. // toggle looks like buttons do.
-  set b2_1:onchange to {parameter val. print "Human is " + val.}.
+  set b2_1:ontoggle to {parameter val. print "Human is " + val.}.
 
   local b2_2 is set2:addradiobutton("Kerbal", false).
   set b2_2:style:width to 80.
   set b2_2:style to G:Skin:Button. // toggle looks like buttons do.
-  set b2_2:onchange to {parameter val. print "Kerbal is " + val.}.
+  set b2_2:ontoggle to {parameter val. print "Kerbal is " + val.}.
 
   local b2_3 is set2:addradiobutton("Other", false).
   set b2_3:style:width to 80.
   set b2_3:style to G:Skin:Button. // toggle looks like buttons do.
-  set b2_3:onchange to {parameter val. print "Other is " + val.}.
+  set b2_3:ontoggle to {parameter val. print "Other is " + val.}.
 
   local q_button is g:addbutton("Quit").
   set q_button:onclick to {

--- a/kerboscript_tests/user_functions/functest10_inner.ks
+++ b/kerboscript_tests/user_functions/functest10_inner.ks
@@ -3,6 +3,6 @@ declare parameter inner1, inner2, inner3.
 print "This is functest10_inner talking.".
 print "I think my args are:".
 
-print "  arg1="+arg1.
-print "  arg2="+arg2.
-print "  arg3="+arg3.
+print "  arg1="+inner1.
+print "  arg2="+inner2.
+print "  arg3="+inner3.

--- a/src/kOS.Safe.Test/Opcode/FakeCpu.cs
+++ b/src/kOS.Safe.Test/Opcode/FakeCpu.cs
@@ -10,6 +10,8 @@ namespace kOS.Safe.Test.Opcode
         private readonly Stack<object> fakeStack;
         public bool IsPoppingContext { get { return false; } }
 
+        public int NextTriggerInstanceId { get { return -99;} }
+
         public FakeCpu()
         {
             fakeStack = new Stack<object>();
@@ -180,17 +182,17 @@ namespace kOS.Safe.Test.Opcode
         {
             get { throw new NotImplementedException(); }
         }
-        public TriggerInfo AddTrigger(int triggerFunctionPointer, List<VariableScope> closure)
+        public TriggerInfo AddTrigger(int triggerFunctionPointer, int instanceId, List<VariableScope> closure)
         {
             throw new NotImplementedException();
         }
 
-        public TriggerInfo AddTrigger(UserDelegate del, List<kOS.Safe.Encapsulation.Structure> args)
+        public TriggerInfo AddTrigger(UserDelegate del, int instanceId, List<kOS.Safe.Encapsulation.Structure> args)
         {
             throw new NotImplementedException();
         }
 
-        public TriggerInfo AddTrigger(UserDelegate del, params kOS.Safe.Encapsulation.Structure[] args)
+        public TriggerInfo AddTrigger(UserDelegate del, int instanceId, params kOS.Safe.Encapsulation.Structure[] args)
         {
             throw new NotImplementedException();
         }
@@ -200,7 +202,7 @@ namespace kOS.Safe.Test.Opcode
             throw new NotImplementedException();
         }
 
-        public void RemoveTrigger(int triggerFunctionPointer)
+        public void RemoveTrigger(int triggerFunctionPointer, int instanceId)
         {
             throw new NotImplementedException();
         }
@@ -210,7 +212,7 @@ namespace kOS.Safe.Test.Opcode
             throw new NotImplementedException();
         }
 
-        public void CancelCalledTriggers(int triggerFunctionPointer)
+        public void CancelCalledTriggers(int triggerFunctionPointer, int instanceId)
         {
             throw new NotImplementedException();
         }

--- a/src/kOS.Safe.Test/Opcode/FakeCpu.cs
+++ b/src/kOS.Safe.Test/Opcode/FakeCpu.cs
@@ -182,22 +182,22 @@ namespace kOS.Safe.Test.Opcode
         {
             get { throw new NotImplementedException(); }
         }
-        public TriggerInfo AddTrigger(int triggerFunctionPointer, int instanceId, List<VariableScope> closure)
+        public TriggerInfo AddTrigger(int triggerFunctionPointer, int instanceId, bool immediate, List<VariableScope> closure)
         {
             throw new NotImplementedException();
         }
 
-        public TriggerInfo AddTrigger(UserDelegate del, int instanceId, List<kOS.Safe.Encapsulation.Structure> args)
+        public TriggerInfo AddTrigger(UserDelegate del, int instanceId,bool immediate, List<kOS.Safe.Encapsulation.Structure> args)
         {
             throw new NotImplementedException();
         }
 
-        public TriggerInfo AddTrigger(UserDelegate del, int instanceId, params kOS.Safe.Encapsulation.Structure[] args)
+        public TriggerInfo AddTrigger(UserDelegate del, int instanceId, bool immediate, params kOS.Safe.Encapsulation.Structure[] args)
         {
             throw new NotImplementedException();
         }
 
-        public TriggerInfo AddTrigger(TriggerInfo trigger)
+        public TriggerInfo AddTrigger(TriggerInfo trigger, bool immediate)
         {
             throw new NotImplementedException();
         }

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -469,8 +469,11 @@ namespace kOS.Safe.Compilation.KS
             VisitNode(node.Nodes[1]);
             AddOpcode(new OpcodeEval());
             AddOpcode(new OpcodeDup());
-            // Put one of those two copies of the new value into the old value identifier for next time:
-            AddOpcode(new OpcodeStoreGlobal(triggerObject.OldValueIdentifier));
+            // Put one of those two copies of the new value into the old value identifier for next time.
+            // This is local because triggers have scope and this will keep multiple instances of the
+            // same ON trigger (i.e. executing the ON statement in a loop) to each have thier own copy
+            // of thier own OldValue.
+            AddOpcode(new OpcodeStoreLocal(triggerObject.OldValueIdentifier));
             // Use the other dup'ed copy of the new value to actually do the equals
             // comparison with the old value that's still under it on the stack:
             AddOpcode(new OpcodeCompareEqual());
@@ -485,7 +488,7 @@ namespace kOS.Safe.Compilation.KS
             string triggerKeepName = "$keep-" + triggerIdentifier;
             PushTriggerKeepName(triggerKeepName);
             AddOpcode(new OpcodePush(false));
-            AddOpcode(new OpcodeStoreGlobal(triggerKeepName));
+            AddOpcode(new OpcodeStoreLocal(triggerKeepName));
 
             VisitNode(node.Nodes[2]);
 
@@ -527,7 +530,7 @@ namespace kOS.Safe.Compilation.KS
             string triggerKeepName = "$keep-" + triggerIdentifier;
             PushTriggerKeepName(triggerKeepName);
             AddOpcode(new OpcodePush(false));
-            AddOpcode(new OpcodeStoreGlobal(triggerKeepName));
+            AddOpcode(new OpcodeStoreLocal(triggerKeepName));
 
             VisitNode(node.Nodes[3]);
 

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -1955,7 +1955,7 @@ namespace kOS.Safe.Compilation
                 else
                     if (returnVal is bool || returnVal is BooleanValue )
                         if (Convert.ToBoolean(returnVal))
-                            cpu.AddTrigger(trigger.EntryPoint, trigger.InstanceCount, trigger.Closure);
+                            cpu.AddTrigger(trigger.EntryPoint, trigger.InstanceCount, false /*next update, not right now*/, trigger.Closure);
             }
             
             int destinationPointer = contextRecord.CameFromInstPtr;
@@ -2512,7 +2512,7 @@ namespace kOS.Safe.Compilation
             int functionPointer = Convert.ToInt32(cpu.PopValueArgument()); // in case it got wrapped in a ScalarIntValue
 
             List<Structure> args = new List<Structure>();
-            cpu.AddTrigger(functionPointer, cpu.NextTriggerInstanceId, cpu.GetCurrentClosure());
+            cpu.AddTrigger(functionPointer, cpu.NextTriggerInstanceId, false, cpu.GetCurrentClosure());
         }
 
         public override string ToString()

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -1955,7 +1955,7 @@ namespace kOS.Safe.Compilation
                 else
                     if (returnVal is bool || returnVal is BooleanValue )
                         if (Convert.ToBoolean(returnVal))
-                            cpu.AddTrigger(trigger.EntryPoint, trigger.Closure);
+                            cpu.AddTrigger(trigger.EntryPoint, trigger.InstanceCount, trigger.Closure);
             }
             
             int destinationPointer = contextRecord.CameFromInstPtr;
@@ -2499,10 +2499,20 @@ namespace kOS.Safe.Compilation
         protected override string Name { get { return "addtrigger"; } }
         public override ByteCode Code { get { return ByteCode.ADDTRIGGER; } }
 
+        /// <summary>
+        /// True if the trigger being added should be called with an argument
+        /// that identifies this instance/entrypoint uniquely at runtime.
+        /// (For example, ON triggers need this, but WHEN triggers do not).
+        /// </summary>
+        [MLField(1,false)]
+        public bool InstanceArg { get; set; }
+
         public override void Execute(ICpu cpu)
         {
             int functionPointer = Convert.ToInt32(cpu.PopValueArgument()); // in case it got wrapped in a ScalarIntValue
-            cpu.AddTrigger(functionPointer, cpu.GetCurrentClosure());
+
+            List<Structure> args = new List<Structure>();
+            cpu.AddTrigger(functionPointer, cpu.NextTriggerInstanceId, cpu.GetCurrentClosure());
         }
 
         public override string ToString()
@@ -2527,8 +2537,8 @@ namespace kOS.Safe.Compilation
         public override void Execute(ICpu cpu)
         {
             var functionPointer = Convert.ToInt32(cpu.PopValueArgument()); // in case it got wrapped in a ScalarIntValue
-            cpu.RemoveTrigger(functionPointer);
-            cpu.CancelCalledTriggers(functionPointer);
+            cpu.RemoveTrigger(functionPointer, 0);
+            cpu.CancelCalledTriggers(functionPointer, 0);
         }
     }
 

--- a/src/kOS.Safe/Encapsulation/TerminalStruct.cs
+++ b/src/kOS.Safe/Encapsulation/TerminalStruct.cs
@@ -68,7 +68,7 @@ namespace kOS.Safe.Encapsulation
                 // also immediately inserts it into the execution list to start firing off right away.  We want
                 // to delay that, so here's an alternate way to construct a TriggerInfo that isn't running yet,
                 // that we'll wait until a later step to schedule to run:
-                TriggerInfo notYetExecutingTrigger = new TriggerInfo(watcher.ProgContext, watcher.EntryPoint, null, argList);
+                TriggerInfo notYetExecutingTrigger = new TriggerInfo(watcher.ProgContext, watcher.EntryPoint, 0, null, argList);
                 pendingResizeTriggers.Enqueue(notYetExecutingTrigger);
             }
 

--- a/src/kOS.Safe/Encapsulation/TerminalStruct.cs
+++ b/src/kOS.Safe/Encapsulation/TerminalStruct.cs
@@ -97,7 +97,7 @@ namespace kOS.Safe.Encapsulation
                     // Try calling it again, and by the way any time we notice an attempt
                     // to call it again has failed, then go back and trim our list of
                     // watchers so it won't happen again:
-                    if (Shared.Cpu.AddTrigger(currentResizeTrigger) == null)
+                    if (Shared.Cpu.AddTrigger(currentResizeTrigger, false) == null)
                         TrimStaleWatchers();
                 }
             }

--- a/src/kOS.Safe/Encapsulation/UserDelegate.cs
+++ b/src/kOS.Safe/Encapsulation/UserDelegate.cs
@@ -230,11 +230,11 @@ namespace kOS.Safe.Encapsulation
         /// do so (the UserDelegate knows which Cpu it was created with so it can get to
         /// it directly from that).
         /// </summary>
-        public TriggerInfo TriggerNextUpdate(params Structure[] args)
+        public TriggerInfo TriggerOnNextOpcode(params Structure[] args)
         {
             if (CheckForDead(false))
                 return null;
-            return Cpu.AddTrigger(this, Cpu.NextTriggerInstanceId, args);
+            return Cpu.AddTrigger(this, Cpu.NextTriggerInstanceId, true, args);
         }
     }
 }

--- a/src/kOS.Safe/Encapsulation/UserDelegate.cs
+++ b/src/kOS.Safe/Encapsulation/UserDelegate.cs
@@ -234,7 +234,7 @@ namespace kOS.Safe.Encapsulation
         {
             if (CheckForDead(false))
                 return null;
-            return Cpu.AddTrigger(this, args);
+            return Cpu.AddTrigger(this, Cpu.NextTriggerInstanceId, args);
         }
     }
 }

--- a/src/kOS.Safe/Execution/ICpu.cs
+++ b/src/kOS.Safe/Execution/ICpu.cs
@@ -38,10 +38,10 @@ namespace kOS.Safe.Execution
         double SessionTime { get; }
         List<string> ProfileResult { get; }
         int NextTriggerInstanceId {get; }
-        TriggerInfo AddTrigger(int triggerFunctionPointer, int instanceId, List<VariableScope> closure);
-        TriggerInfo AddTrigger(TriggerInfo trigger);
-        TriggerInfo AddTrigger(UserDelegate del, int instanceId, List<Structure> args);
-        TriggerInfo AddTrigger(UserDelegate del, int instanceId, params Structure[] args);
+        TriggerInfo AddTrigger(int triggerFunctionPointer, int instanceId, bool immediate, List<VariableScope> closure);
+        TriggerInfo AddTrigger(TriggerInfo trigger, bool immediate);
+        TriggerInfo AddTrigger(UserDelegate del, int instanceId, bool immediate, List<Structure> args);
+        TriggerInfo AddTrigger(UserDelegate del, int instanceId, bool immediate, params Structure[] args);
         void RemoveTrigger(int triggerFunctionPointer, int instanceId);
         void RemoveTrigger(TriggerInfo trigger);
         void CancelCalledTriggers(int triggerFunctionPointer, int instanceId);

--- a/src/kOS.Safe/Execution/ICpu.cs
+++ b/src/kOS.Safe/Execution/ICpu.cs
@@ -37,13 +37,14 @@ namespace kOS.Safe.Execution
         int InstructionPointer { get; set; }
         double SessionTime { get; }
         List<string> ProfileResult { get; }
-        TriggerInfo AddTrigger(int triggerFunctionPointer, List<VariableScope> closure);
+        int NextTriggerInstanceId {get; }
+        TriggerInfo AddTrigger(int triggerFunctionPointer, int instanceId, List<VariableScope> closure);
         TriggerInfo AddTrigger(TriggerInfo trigger);
-        TriggerInfo AddTrigger(UserDelegate del, List<Structure> args);
-        TriggerInfo AddTrigger(UserDelegate del, params Structure[] args);
-        void RemoveTrigger(int triggerFunctionPointer);
+        TriggerInfo AddTrigger(UserDelegate del, int instanceId, List<Structure> args);
+        TriggerInfo AddTrigger(UserDelegate del, int instanceId, params Structure[] args);
+        void RemoveTrigger(int triggerFunctionPointer, int instanceId);
         void RemoveTrigger(TriggerInfo trigger);
-        void CancelCalledTriggers(int triggerFunctionPointer);
+        void CancelCalledTriggers(int triggerFunctionPointer, int instanceId);
         void CancelCalledTriggers(TriggerInfo trigger);
         void CallBuiltinFunction(string functionName);
         bool BuiltInExists(string functionName);

--- a/src/kOS.Safe/Execution/IProgramContext.cs
+++ b/src/kOS.Safe/Execution/IProgramContext.cs
@@ -16,6 +16,8 @@ namespace kOS.Safe.Execution
         List<string> GetCodeFragment(int start, int stop, bool doProfile = false);
         List<Opcode> Program { get; set; }
         int InstructionPointer { get; set; }
+        int NextTriggerInstanceId { get; }
+        void ResetTriggerInstanceIdCounter();
         bool Silent { get; set; }
     }
 }

--- a/src/kOS.Safe/Execution/ProgramContext.cs
+++ b/src/kOS.Safe/Execution/ProgramContext.cs
@@ -193,6 +193,16 @@ namespace kOS.Safe.Execution
             if (! ContainsTrigger(trigger))
                 TriggersToInsert.Add(trigger);
         }
+
+        /// <summary>
+        /// Adds a trigger to happen immediately on the next opcode, instead of
+        /// waiting for the next fixedupdate tick like AddPendingTrigger does.
+        /// </summary>
+        /// <param name="trigger">Trigger to be inserted</param>
+        public void AddImmediateTrigger(TriggerInfo trigger)
+        {
+            Triggers.Add(trigger);
+        }
         
         /// <summary>
         /// Remove a trigger from current triggers or pending insertion

--- a/src/kOS.Safe/Execution/ProgramContext.cs
+++ b/src/kOS.Safe/Execution/ProgramContext.cs
@@ -27,7 +27,14 @@ namespace kOS.Safe.Execution
         /// List of triggers that are currently active
         /// </summary>
         private List<TriggerInfo> Triggers { get; set; }
-        
+
+        private int nextTriggerInstanceId = 1;
+        public int NextTriggerInstanceId { get {return nextTriggerInstanceId++;} }
+        public void ResetTriggerInstanceIdCounter()
+        {
+            nextTriggerInstanceId = 1;
+        }
+
         /// <summary>
         /// List of triggers that are *about to become* currently active, but only after
         /// the CPU tells us it's a good safe time to re-insert them.  This delay is done
@@ -194,8 +201,8 @@ namespace kOS.Safe.Execution
         /// <param name="trigger"></param>
         public void RemoveTrigger(TriggerInfo trigger)
         {
-            Triggers.Remove(trigger); // can ignore if it wasn't in the list.
-            TriggersToInsert.Remove(trigger); // can ignore if it wasn't in the list.
+            Triggers.RemoveAll((item) => item == trigger); // can ignore if it wasn't in the list.
+            TriggersToInsert.RemoveAll((item) => item == trigger); // can ignore if it wasn't in the list.
         }
         
         /// <summary>

--- a/src/kOS.Safe/Execution/TriggerInfo.cs
+++ b/src/kOS.Safe/Execution/TriggerInfo.cs
@@ -26,8 +26,8 @@ public class TriggerInfo
     public List<VariableScope> Closure {get; private set;}
 
     /// <summary>
-    /// If true, this is a callback invoked by our own C# code, which will
-    /// be awaiting the answer the user's code returns.
+    /// If true, this is a callback inserted by our own C# code, which will
+    /// might be awaiting the answer the user's code returns.
     /// </summary>
     public bool IsCSharpCallback { get; private set; }
     /// <summary>

--- a/src/kOS/Callback/KOSGameEventDispatcher.cs
+++ b/src/kOS/Callback/KOSGameEventDispatcher.cs
@@ -156,7 +156,7 @@ namespace kOS.Callback
             UniqueSetValue<UserDelegate> notifyees = GetSwitchVesselNotifyees();
             foreach (UserDelegate del in notifyees)
                 if (UserDelgateIsAcceptable(del))
-                    Shared.Cpu.AddTrigger(del, Shared.Cpu.NextTriggerInstanceId, VesselTarget.CreateOrGetExisting(fromVes, Shared), VesselTarget.CreateOrGetExisting(toVes, Shared));
+                    Shared.Cpu.AddTrigger(del, Shared.Cpu.NextTriggerInstanceId, false, VesselTarget.CreateOrGetExisting(fromVes, Shared), VesselTarget.CreateOrGetExisting(toVes, Shared));
         }
 
         // SOIChange:
@@ -181,7 +181,7 @@ namespace kOS.Callback
             UniqueSetValue<UserDelegate> notifyees = GetSOIChangeNotifyees(evt.host);
             foreach (UserDelegate del in notifyees)
                 if (UserDelgateIsAcceptable(del))
-                    Shared.Cpu.AddTrigger(del, Shared.Cpu.NextTriggerInstanceId, BodyTarget.CreateOrGetExisting(evt.@from, Shared), BodyTarget.CreateOrGetExisting(evt.to, Shared));
+                    Shared.Cpu.AddTrigger(del, Shared.Cpu.NextTriggerInstanceId, false, BodyTarget.CreateOrGetExisting(evt.@from, Shared), BodyTarget.CreateOrGetExisting(evt.to, Shared));
         }
 
         // PartCouple:
@@ -208,7 +208,7 @@ namespace kOS.Callback
             // Use GetFooNotifyees to activate the lazy-build logic if need be.
             foreach (UserDelegate del in notifyees)
                 if (UserDelgateIsAcceptable(del))
-                    Shared.Cpu.AddTrigger(del, Shared.Cpu.NextTriggerInstanceId, PartValueFactory.Construct(evt.to, Shared));
+                    Shared.Cpu.AddTrigger(del, Shared.Cpu.NextTriggerInstanceId, false, PartValueFactory.Construct(evt.to, Shared));
 
             // Also notify any hooks attached to the part on the "to" side of the event.  Let's not
             // confuse users with KSP's strange notion of the "from" and the "to" of a docking, and just
@@ -216,7 +216,7 @@ namespace kOS.Callback
             notifyees = GetPartCoupleNotifyees(evt.to);
             foreach (UserDelegate del in notifyees)
                 if (UserDelgateIsAcceptable(del))
-                    Shared.Cpu.AddTrigger(del, Shared.Cpu.NextTriggerInstanceId, PartValueFactory.Construct(evt.@from, Shared));
+                    Shared.Cpu.AddTrigger(del, Shared.Cpu.NextTriggerInstanceId, false, PartValueFactory.Construct(evt.@from, Shared));
         }
 
         // PartUndock:
@@ -242,14 +242,14 @@ namespace kOS.Callback
             UniqueSetValue<UserDelegate> notifyees = GetPartUndockNotifyees(p);
             foreach (UserDelegate del in notifyees)
                 if (UserDelgateIsAcceptable(del))
-                    Shared.Cpu.AddTrigger(del, Shared.Cpu.NextTriggerInstanceId);
+                    Shared.Cpu.AddTrigger(del, Shared.Cpu.NextTriggerInstanceId, false);
 
             // Notify any hooks attached to the part on the "to" side of the event:
             ModuleDockingNode dockModule = (ModuleDockingNode) p.Modules["ModuleDockingNode"];
             notifyees = GetPartUndockNotifyees(dockModule.otherNode.part);
             foreach (UserDelegate del in notifyees)
                 if (UserDelgateIsAcceptable(del))
-                    Shared.Cpu.AddTrigger(del, Shared.Cpu.NextTriggerInstanceId);
+                    Shared.Cpu.AddTrigger(del, Shared.Cpu.NextTriggerInstanceId, false);
 
             // The event has no data available on which other part it had been attached to, apparently.
         }

--- a/src/kOS/Callback/KOSGameEventDispatcher.cs
+++ b/src/kOS/Callback/KOSGameEventDispatcher.cs
@@ -156,7 +156,7 @@ namespace kOS.Callback
             UniqueSetValue<UserDelegate> notifyees = GetSwitchVesselNotifyees();
             foreach (UserDelegate del in notifyees)
                 if (UserDelgateIsAcceptable(del))
-                    Shared.Cpu.AddTrigger(del, VesselTarget.CreateOrGetExisting(fromVes, Shared), VesselTarget.CreateOrGetExisting(toVes, Shared));
+                    Shared.Cpu.AddTrigger(del, Shared.Cpu.NextTriggerInstanceId, VesselTarget.CreateOrGetExisting(fromVes, Shared), VesselTarget.CreateOrGetExisting(toVes, Shared));
         }
 
         // SOIChange:
@@ -181,7 +181,7 @@ namespace kOS.Callback
             UniqueSetValue<UserDelegate> notifyees = GetSOIChangeNotifyees(evt.host);
             foreach (UserDelegate del in notifyees)
                 if (UserDelgateIsAcceptable(del))
-                    Shared.Cpu.AddTrigger(del, BodyTarget.CreateOrGetExisting(evt.@from, Shared), BodyTarget.CreateOrGetExisting(evt.to, Shared));
+                    Shared.Cpu.AddTrigger(del, Shared.Cpu.NextTriggerInstanceId, BodyTarget.CreateOrGetExisting(evt.@from, Shared), BodyTarget.CreateOrGetExisting(evt.to, Shared));
         }
 
         // PartCouple:
@@ -208,7 +208,7 @@ namespace kOS.Callback
             // Use GetFooNotifyees to activate the lazy-build logic if need be.
             foreach (UserDelegate del in notifyees)
                 if (UserDelgateIsAcceptable(del))
-                    Shared.Cpu.AddTrigger(del, PartValueFactory.Construct(evt.to, Shared));
+                    Shared.Cpu.AddTrigger(del, Shared.Cpu.NextTriggerInstanceId, PartValueFactory.Construct(evt.to, Shared));
 
             // Also notify any hooks attached to the part on the "to" side of the event.  Let's not
             // confuse users with KSP's strange notion of the "from" and the "to" of a docking, and just
@@ -216,7 +216,7 @@ namespace kOS.Callback
             notifyees = GetPartCoupleNotifyees(evt.to);
             foreach (UserDelegate del in notifyees)
                 if (UserDelgateIsAcceptable(del))
-                    Shared.Cpu.AddTrigger(del, PartValueFactory.Construct(evt.@from, Shared));
+                    Shared.Cpu.AddTrigger(del, Shared.Cpu.NextTriggerInstanceId, PartValueFactory.Construct(evt.@from, Shared));
         }
 
         // PartUndock:
@@ -242,14 +242,14 @@ namespace kOS.Callback
             UniqueSetValue<UserDelegate> notifyees = GetPartUndockNotifyees(p);
             foreach (UserDelegate del in notifyees)
                 if (UserDelgateIsAcceptable(del))
-                    Shared.Cpu.AddTrigger(del);
+                    Shared.Cpu.AddTrigger(del, Shared.Cpu.NextTriggerInstanceId);
 
             // Notify any hooks attached to the part on the "to" side of the event:
             ModuleDockingNode dockModule = (ModuleDockingNode) p.Modules["ModuleDockingNode"];
             notifyees = GetPartUndockNotifyees(dockModule.otherNode.part);
             foreach (UserDelegate del in notifyees)
                 if (UserDelgateIsAcceptable(del))
-                    Shared.Cpu.AddTrigger(del);
+                    Shared.Cpu.AddTrigger(del, Shared.Cpu.NextTriggerInstanceId);
 
             // The event has no data available on which other part it had been attached to, apparently.
         }

--- a/src/kOS/Suffixed/VectorRenderer.cs
+++ b/src/kOS/Suffixed/VectorRenderer.cs
@@ -197,19 +197,19 @@ namespace kOS.Suffixed
             // -------------------------------------------------------------------------------------------------------------------------
             if (StartDelegate != null && (StartTrigger == null || StartTrigger.CallbackFinished))
             {
-                StartTrigger = StartDelegate.TriggerNextUpdate();
+                StartTrigger = StartDelegate.TriggerOnNextOpcode();
                 if (StartTrigger == null) // Delegate must be from a stale ProgramContext.  Stop trying to call it.
                     StartDelegate = null;
             }
             if (VectorDelegate != null && (VectorTrigger == null || VectorTrigger.CallbackFinished))
             {
-                VectorTrigger = VectorDelegate.TriggerNextUpdate();
+                VectorTrigger = VectorDelegate.TriggerOnNextOpcode();
                 if (VectorTrigger == null) // Delegate must be from a stale ProgramContext.  Stop trying to call it.
                     VectorDelegate = null;
             }
             if (ColorDelegate != null && (ColorTrigger == null || ColorTrigger.CallbackFinished))
             {
-                ColorTrigger = ColorDelegate.TriggerNextUpdate();
+                ColorTrigger = ColorDelegate.TriggerOnNextOpcode();
                 if (ColorTrigger == null) // Delegate must be from a stale ProgramContext.  Stop trying to call it.
                     ColorDelegate = null;
             }

--- a/src/kOS/Suffixed/Widget/Box.cs
+++ b/src/kOS/Suffixed/Widget/Box.cs
@@ -76,7 +76,7 @@ namespace kOS.Suffixed.Widget
         public void ScheduleOnRadioChange(Button b)
         {
             if (UserOnRadioChange != null)
-                UserOnRadioChange.TriggerNextUpdate(b);
+                UserOnRadioChange.TriggerOnNextOpcode(b);
         }
 
         /// <summary>

--- a/src/kOS/Suffixed/Widget/Button.cs
+++ b/src/kOS/Suffixed/Widget/Button.cs
@@ -81,7 +81,7 @@ namespace kOS.Suffixed.Widget
 
             if (UserOnToggle != null)
             {
-                UserOnToggle.TriggerNextUpdate(new BooleanValue(pressed));
+                UserOnToggle.TriggerOnNextOpcode(new BooleanValue(pressed));
 
             }
 
@@ -100,7 +100,7 @@ namespace kOS.Suffixed.Widget
             // not the button-goes-out state that should auto-activate when it's read:
             if (UserOnClick != null && (IsToggle || pressed))
             {
-                UserOnClick.TriggerNextUpdate();
+                UserOnClick.TriggerOnNextOpcode();
                 if (!IsToggle)
                     causeRelease = true;
             }

--- a/src/kOS/Suffixed/Widget/Label.cs
+++ b/src/kOS/Suffixed/Widget/Label.cs
@@ -100,7 +100,7 @@ namespace kOS.Suffixed.Widget
                 if (UserTextUpdateResult.CallbackFinished)
                 {
                     SetText(UserTextUpdateResult.ReturnValue.ToString());
-                    UserTextUpdateResult = UserTextUpdater.TriggerNextUpdate();
+                    UserTextUpdateResult = UserTextUpdater.TriggerOnNextOpcode();
                 }
                 // Else just do nothing because a previous call is still pending its return result.
                 // don't start up a second call while still waiting for the first one to finish.  (we
@@ -108,7 +108,7 @@ namespace kOS.Suffixed.Widget
             }
             else
             {
-                UserTextUpdateResult = UserTextUpdater.TriggerNextUpdate();
+                UserTextUpdateResult = UserTextUpdater.TriggerOnNextOpcode();
             }
         }
 

--- a/src/kOS/Suffixed/Widget/PopupMenu.cs
+++ b/src/kOS/Suffixed/Widget/PopupMenu.cs
@@ -73,7 +73,7 @@ namespace kOS.Suffixed.Widget
         {
             if (UserOnChange != null)
             {
-                UserOnChange.TriggerNextUpdate(GetValue());
+                UserOnChange.TriggerOnNextOpcode(GetValue());
                 changed = false;
             }
         }

--- a/src/kOS/Suffixed/Widget/Slider.cs
+++ b/src/kOS/Suffixed/Widget/Slider.cs
@@ -66,7 +66,7 @@ namespace kOS.Suffixed.Widget
         private void ScheduleOnChange()
         {
             if (UserOnChange != null)
-                UserOnChange.TriggerNextUpdate(new ScalarDoubleValue((double)val));
+                UserOnChange.TriggerOnNextOpcode(new ScalarDoubleValue((double)val));
         }
 
         public override string ToString()

--- a/src/kOS/Suffixed/Widget/TextField.cs
+++ b/src/kOS/Suffixed/Widget/TextField.cs
@@ -81,7 +81,7 @@ namespace kOS.Suffixed.Widget
         {
             if (UserOnConfirm != null)
             {
-                UserOnConfirm.TriggerNextUpdate(new StringValue(Text));
+                UserOnConfirm.TriggerOnNextOpcode(new StringValue(Text));
                 Confirmed = false;
             }
         }
@@ -90,7 +90,7 @@ namespace kOS.Suffixed.Widget
         {
             if (UserOnChange != null)
             {
-                UserOnChange.TriggerNextUpdate(new StringValue(Text));
+                UserOnChange.TriggerOnNextOpcode(new StringValue(Text));
                 Changed = false;
             }
         }


### PR DESCRIPTION
Please merge #2275 first - this branch was made on top of that branch, because they edited some of the same lines of code and would have had a merge conflict if I tried to implement them separately.

(Some of the diff's you see will go away if you merge 2275 first.)

```
    Made it able to schedule triggers next opcode.

    When Adding a trigger, the caller can now choose if that
    trigger should wait for the next KOSFixedUpdate, or if
    it should execute immediately.

    If Cpu.AddTrigger() is called with arg Immediate=False:

      The system works like before - the trigger will not
      get pushed onto the callstack until the start of
      the next KOSFixedUpdate.  If there are instructions
      remaining this Update, then the rest of the IPU's
      worth of instructions will happen first, before this
      trigger will fire off.

    If Cpu.AddTrigger() is called with arg Immediate=True:

      The trigger's call will get pushed onto the callstack
      just before the next Opcode would have been executed
      in the ContinueExecution() main loop, even if that's
      in the middle of a KOSFixedUpdate.  If we are not in the
      middle of a KOSFixedUpdate right now, then the effect
      ends up being the same as if Immediate=False, since the
      time the "next opcode would have been executed" is during
      the next KOSFixedUpdate anyway.

    From the point of view of C# code that's waiting for a
    return value from the user's callback, there's not really
    any difference between these two since it has to wait for
    the user's code to happen anyway before it can get the
    answer.

    Immediate=True should never be used in cases where a trigger
    gets re-inserted automatically on a timer, as that can
    make it recurse forever and never give time back to the mainline
    code.
```
