### PR TITLE
Fixes #2228 triggers in anonymous delegates

### DIFF
--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -422,7 +422,7 @@ namespace kOS.Safe.Compilation.KS
                     PreProcessChildNodes(node);
                     PreProcessWhenStatement(node);
                     break;
-		default:
+                default:
                     PreProcessChildNodes(node);
                     break;
             }

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -414,18 +414,6 @@ namespace kOS.Safe.Compilation.KS
 
             switch (node.Token.Type)
             {
-                // statements that can have a lock inside
-                case TokenType.Start:
-                case TokenType.instruction_block:
-                case TokenType.instruction:
-                case TokenType.if_stmt:
-                case TokenType.fromloop_stmt:
-                case TokenType.until_stmt:
-                case TokenType.for_stmt:
-                case TokenType.declare_function_clause:
-                case TokenType.declare_stmt:
-                    PreProcessChildNodes(node);
-                    break;
                 case TokenType.on_stmt:
                     PreProcessChildNodes(node);
                     PreProcessOnStatement(node);
@@ -433,6 +421,9 @@ namespace kOS.Safe.Compilation.KS
                 case TokenType.when_stmt:
                     PreProcessChildNodes(node);
                     PreProcessWhenStatement(node);
+                    break;
+		default:
+                    PreProcessChildNodes(node);
                     break;
             }
         }


### PR DESCRIPTION
Make the compiler visit any node in the parse tree when looking for ON and WHEN.
This fixes #2228