### PR TITLE
Fixes #2283 Mission Builder boot system

### DIFF
--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -460,8 +460,8 @@ namespace kOS.Module
                 }
 
                 var path = BootFilePath;
-                // populate it with the boot file, but only if using a new disk and in PRELAUNCH situation:
-                if (vessel.situation == Vessel.Situations.PRELAUNCH && path != null && !SafeHouse.Config.StartOnArchive)
+                // populate it with the boot file, but only if using a new disk:
+                if (path != null && !SafeHouse.Config.StartOnArchive)
                 {
                     var bootVolumeFile = Archive.Open(BootFilePath) as VolumeFile;
                     if (bootVolumeFile != null)


### PR DESCRIPTION
Don't require a vessel to be in `PRELAUNCH` situation for a bootfile to be copied to the vessels HardDisk.
This fixes #2283 