### PR TITLE
Fixes #2297 - misplaced Jump in trigger locks.

### DIFF
--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -723,7 +723,7 @@ namespace kOS.Safe.Compilation.KS
                     AddOpcode(new OpcodePush(userFuncObject.ScopelessPointerIdentifier));
                     AddOpcode(new OpcodeExists());
                     var branch = new OpcodeBranchIfTrue();
-                    branch.Distance = 4;
+                    branch.Distance = 3;
                     AddOpcode(branch);
                     AddOpcode(new OpcodePushRelocateLater(null), userFuncObject.DefaultLabel);
                     AddOpcode(new OpcodeStore(userFuncObject.ScopelessPointerIdentifier));


### PR DESCRIPTION
It turns out there was a problem buried deep in
the compiler, and it was introduced first with commit
number #06506dc, with Pull Request #2156.

That commit altered the boilerplate code inserted for
triggered locks (steering, throttle, etc), reducing
the number of instructions that existed in the
boilerplate code chunk.  But just prior to those
edits, on the line above, there was a br.true +4.
Becuse of those edits, there was now one fewer
opcode to skip over and the br.true +4 needed to be
changed to a br.true +3, and it hadn't been.

The result is that when the function ``$steering*``
already exists, and it tries to skip over the
setting of it, it jumps one step too far forward, which
misses a "push", and thus everything on the stack is
mis-aligned after that.

The reason it hasn't been noticed before is that usually,
this case doesn't happen in typical cases.  It requires
running a boot file that runs a compiled KSM file to
encounter the case where the steering trigger is such
that the br.true will fire off. Most of the time it was false
and not jumping.  Since the conditional jump wasn't
happening, the fact that it jumps the wrong distance
wasn't being exercised.