### PR TITLE
Fixes #2301 - Make steering let go

### DIFF
--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -2545,19 +2545,6 @@ namespace kOS.Safe.Compilation.KS
         {
             if (lockObject.IsSystemLock())
             {
-                // disable this FlyByWire parameter
-                AddOpcode(new OpcodePush(new KOSArgMarkerType()));
-                AddOpcode(new OpcodePush(lockObject.ScopelessIdentifier));
-                AddOpcode(new OpcodePush(false));
-                AddOpcode(new OpcodeCall("toggleflybywire()"));
-                // add a pop to clear out the dummy return value from toggleflybywire()
-                AddOpcode(new OpcodePop());
-
-                // Adding these opcodes forces the IPU boundary to always come    //ereseme
-                // between these two bits of code, so the problem happens 100% of //eraseme
-                // the time, instead of inconsistently.                           //eraseme
-                AddOpcode(new OpcodePush(0)); AddOpcode(new OpcodeWait());        //eraseme
-
                 // remove update trigger
                 string triggerIdentifier = "lock-" + lockObject.ScopelessIdentifier;
                 if (context.Triggers.Contains(triggerIdentifier))
@@ -2566,6 +2553,20 @@ namespace kOS.Safe.Compilation.KS
                     AddOpcode(new OpcodePushRelocateLater(null), triggerObject.GetFunctionLabel());
                     AddOpcode(new OpcodeRemoveTrigger());
                 }
+
+                // Adding these opcodes forces the IPU boundary to always come    //ereseme
+                // between these two bits of code, so the problem happens 100% of //eraseme
+                // the time, instead of inconsistently.                           //eraseme
+                AddOpcode(new OpcodePush(0)); AddOpcode(new OpcodeWait());        //eraseme
+
+                // disable this FlyByWire parameter
+                AddOpcode(new OpcodePush(new KOSArgMarkerType()));
+                AddOpcode(new OpcodePush(lockObject.ScopelessIdentifier));
+                AddOpcode(new OpcodePush(false));
+                AddOpcode(new OpcodeCall("toggleflybywire()"));
+                // add a pop to clear out the dummy return value from toggleflybywire()
+                AddOpcode(new OpcodePop());
+
             }
 
             // unlock variable

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -2553,12 +2553,6 @@ namespace kOS.Safe.Compilation.KS
                     AddOpcode(new OpcodePushRelocateLater(null), triggerObject.GetFunctionLabel());
                     AddOpcode(new OpcodeRemoveTrigger());
                 }
-
-                // Adding these opcodes forces the IPU boundary to always come    //ereseme
-                // between these two bits of code, so the problem happens 100% of //eraseme
-                // the time, instead of inconsistently.                           //eraseme
-                AddOpcode(new OpcodePush(0)); AddOpcode(new OpcodeWait());        //eraseme
-
                 // disable this FlyByWire parameter
                 AddOpcode(new OpcodePush(new KOSArgMarkerType()));
                 AddOpcode(new OpcodePush(lockObject.ScopelessIdentifier));

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -2553,6 +2553,11 @@ namespace kOS.Safe.Compilation.KS
                 // add a pop to clear out the dummy return value from toggleflybywire()
                 AddOpcode(new OpcodePop());
 
+                // Adding these opcodes forces the IPU boundary to always come    //ereseme
+                // between these two bits of code, so the problem happens 100% of //eraseme
+                // the time, instead of inconsistently.                           //eraseme
+                AddOpcode(new OpcodePush(0)); AddOpcode(new OpcodeWait());        //eraseme
+
                 // remove update trigger
                 string triggerIdentifier = "lock-" + lockObject.ScopelessIdentifier;
                 if (context.Triggers.Contains(triggerIdentifier))

--- a/src/kOS/Control/SteeringManager.cs
+++ b/src/kOS/Control/SteeringManager.cs
@@ -367,6 +367,7 @@ namespace kOS.Control
 
         public void EnableControl(SharedObjects sharedObj)
         {
+            Console.WriteLine("eraseme: EnableControl() being called.");
             shared = sharedObj;
             partId = sharedObj.KSPPart.flightID;
             ResetIs();
@@ -381,6 +382,7 @@ namespace kOS.Control
 
         public void DisableControl()
         {
+            Console.WriteLine("eraseme: DisableControl() being called.");
             shared = null;
             partId = 0;
             Enabled = false;

--- a/src/kOS/Control/SteeringManager.cs
+++ b/src/kOS/Control/SteeringManager.cs
@@ -367,7 +367,6 @@ namespace kOS.Control
 
         public void EnableControl(SharedObjects sharedObj)
         {
-            Console.WriteLine("eraseme: EnableControl() being called.");
             shared = sharedObj;
             partId = sharedObj.KSPPart.flightID;
             ResetIs();
@@ -382,7 +381,6 @@ namespace kOS.Control
 
         public void DisableControl()
         {
-            Console.WriteLine("eraseme: DisableControl() being called.");
             shared = null;
             partId = 0;
             Enabled = false;


### PR DESCRIPTION
Fixes #2301

Here's a description of the problem, copied here from Slack so it's saved with the PR (Slack comments don't last forever, and besides this should be connected to the github merge history):

__[Start of section cut from Slack]__

Here's the work you have to do when you unlock steering.
It does these opcodes, which were built by the compiler when it compiles ``unlock steering`` or ``unlock throttle``:
1 - Push "toggleFlyByWire".
2 - Call
3 - Pop
4 - Push (the trigger's entry point)
5 - RemoveTrigger.
Because this isn't an atomic operation, the boundary between IPU chunks could come between (1) and (5).
Thus the flyby wire is toggled, but the RemoveTrigger that goes along with it hasn't happened yet.
I was spending time concentrating on how the RemoveTrigger might be implmented wrong.  It never occurred to me to test for maybe it's not happening at all before the end of the physics tic.
This schedules *one more* call of the trigger (because it wasnt removed between calls), which RE-LOCKS the steering by setting the `$steering` variable one more time.
THEN in the start of this next physics tick, it reaches point (5) above and NOW it finally removes the trigger, but after the steeringmanager got re-enabled.

__[End of section cut from Slack]__

The reason the problem was inconsistent is that the boundary between two FixedUpdates *had* to happen in just one small critical section of code to trigger it.  If the IPU was such that this critical section of instructions all "fit" in the same update, the bug didn't appear.

This consists of 3 commits, which in order were used to test this.  You (reviewer) may want to try the commits one at a time to make a proof of the problem and the fix.

First commit: #d21a3cb
This commit just inserts a WAIT 0 (well, equivalent Opcodes to do a WAIT 0) into the critical section of code to force the IPU boundary to happen there.  If I was right about the cause of the problem, should force the problem to happen 100% of the time instead of only in rare occasions.  (The problem being that steering doesn't "let go" when your program does an ``unlock steering`` (or unlock throttl,e etc) then ends the script.  After the program is over, you still can't use the WASD keys to do anything and are locked out.)

Second commit: #3e739dc  
This commit keeps the "proving" WAIT 0 in the code, but swaps the order of the two parts of the critical section, which is what I thought would fix the problem.  I keep the WAIT 0 in the code so that I can prove I fixed it (i.e. it's the WAIT that is causing the problem to happen 100% of the time instead of like 5% of the time, so I left it in to prove the fix really fixed it.)

Third commit: #6eaa773 
This commit just removes the "proving" WAIT now that I'm sure the problem is fixed.
