### PR TITLE
Fixes #1669 - changing clamping of hyperbolic orbits

### DIFF
--- a/src/kOS/Suffixed/OrbitInfo.cs
+++ b/src/kOS/Suffixed/OrbitInfo.cs
@@ -45,8 +45,14 @@ namespace kOS.Suffixed
             AddSuffix("SEMIMINORAXIS", new Suffix<ScalarValue>(() => orbit.semiMinorAxis));
             AddSuffix(new[]{"LAN", "LONGITUDEOFASCENDINGNODE"}, new Suffix<ScalarValue>(() => orbit.LAN));
             AddSuffix("ARGUMENTOFPERIAPSIS", new Suffix<ScalarValue>(() => orbit.argumentOfPeriapsis));
-            AddSuffix("TRUEANOMALY", new Suffix<ScalarValue>(() => Utilities.Utils.DegreeFix(Utilities.Utils.RadiansToDegrees(orbit.trueAnomaly),0.0)));
-            AddSuffix("MEANANOMALYATEPOCH", new Suffix<ScalarValue>(() => Utilities.Utils.DegreeFix(Utilities.Utils.RadiansToDegrees(orbit.meanAnomalyAtEpoch), 0.0)));
+            AddSuffix("TRUEANOMALY", new Suffix<ScalarValue>(() => orbit.eccentricity < 1.0 ? 
+                                                             Utilities.Utils.DegreeFix(Utilities.Utils.RadiansToDegrees(orbit.trueAnomaly),0.0) :
+                                                             Utilities.Utils.DegreeFix (Utilities.Utils.RadiansToDegrees (orbit.trueAnomaly), -180.0)
+                                                            ));
+            AddSuffix("MEANANOMALYATEPOCH", new Suffix<ScalarValue>(() => orbit.eccentricity < 1.0 ? 
+                                                                    Utilities.Utils.DegreeFix(Utilities.Utils.RadiansToDegrees(orbit.meanAnomalyAtEpoch), 0.0) :
+                                                                    Utilities.Utils.RadiansToDegrees(orbit.meanAnomalyAtEpoch)
+                                                                   ));
             AddSuffix("EPOCH", new Suffix<ScalarValue>(() => orbit.epoch));
             AddSuffix("TRANSITION", new Suffix<StringValue>(() => orbit.patchEndTransition.ToString()));
             AddSuffix("POSITION", new Suffix<Vector>(() => GetPositionAtUT( new TimeSpan(Planetarium.GetUniversalTime() ) )));


### PR DESCRIPTION
The position on an elliptic orbit is expressed in terms of trig functions of mean anomaly, and on a hyperbolic trajectory in terms of hyperbolic trig functions. The latter are non-periodic, so when mean anomaly is clamped to [0; 360] range, it gives identical answers for essentially different orbital points.
The true anomalies for hyperbolic trajectories make more sense in [-180; 180] range: negative values mean points before periapsis, and positive ones after periapsis.
Simple eccentricity check is added to dispatch the values returned by `obt:trueanomaly` and `obt:meananomalyatepoch` suffixes.
For elliptic orbits, this keeps the [0; 360] clamping, as before.