### PR TITLE
Adding Core:DoEvent("Close Window") for symmetry

### DIFF
--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -136,8 +136,15 @@ namespace kOS.Module
         [KSPEvent(guiActive = true, guiName = "Open Terminal", category = "skip_delay;")]
         public void Activate()
         {
-            SafeHouse.Logger.Log("Activate");
+            SafeHouse.Logger.Log("Open Window by event");
             OpenWindow();
+        }
+
+        [KSPEvent(guiActive = true, guiName = "Close Terminal", category = "skip_delay;")]
+        public void Deactivate()
+        {
+            SafeHouse.Logger.Log("Close Window by event");
+            CloseWindow();
         }
 
         [KSPField(isPersistant = true, guiName = "kOS Average Power", guiActive = true, guiActiveEditor = true, guiUnits = "EC/s", guiFormat = "0.000")]
@@ -154,7 +161,7 @@ namespace kOS.Module
         [KSPAction("Open Terminal", actionGroup = KSPActionGroup.None)]
         public void Activate(KSPActionParam param)
         {
-            SafeHouse.Logger.Log("Open Terminal from Dialog");
+            SafeHouse.Logger.Log("Open Terminal from ActionGroup");
             Activate();
         }
 


### PR DESCRIPTION
Adding symmetry so that a player without action groups can have a kOS script call Core:DoEvent("Close Window") sometime after it called Core:DoEvent("Open Window").  Updated the messages from open and close, events and actions to be consistent all four ways.