### PR TITLE
possible fix to the linux e,s,r bug in text editor.

### DIFF
--- a/src/kOS/Screen/KOSTextEditPopup.cs
+++ b/src/kOS/Screen/KOSTextEditPopup.cs
@@ -334,20 +334,26 @@ namespace kOS.Screen
 
                     case KeyCode.E:
                         if (Event.current.control)
+                        {
                             ExitEditor();
-                        Event.current.Use();
+                            Event.current.Use();
+                        }
                         break;
 
                     case KeyCode.S:
                         if (Event.current.control)
+                        {
                             SaveContents();
-                        Event.current.Use();
+                            Event.current.Use();
+                        }
                         break;
 
                     case KeyCode.R:
                         if (Event.current.control)
+                        {
                             ReloadContents();
-                        Event.current.Use();
+                            Event.current.Use();
+                        }
                         break;
                 }
             }


### PR DESCRIPTION
So it was a bug in kOS, but a bug that got hidden by Unity's order of handling input events on Windows.

The bug - While I was only reacting to the E, S, or T keys when "control" was pressed, which is correct, I was still "consuming" those keyboard events unconditionally whether the control key was down or not.

Why it didn't affect Windows:  Apparently in Windows the generic Textfield GUI widget from Unity's IMGUI (the thing the text editor *really* is), got first dibs on the keyboard events before my code did, so my code never got to see key events that the Textfield used, so S, E, and R never got seen by my code unless they were accompanied by special ctrl- or alt- keys.  Vanilla S, E, and R keys never reached my code - the Textfield got them first and consumed them.

On Linux they seem to be queued in the opposite order so that my mistaken consuming of the key happened before the Textfield got to see it.
