### PR TITLE
Fixes #2317 - Disable Wheels, if cpu shut down due to electric starving

### DIFF
--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -884,6 +884,8 @@ namespace kOS.Module
                     if (shared.Window != null) shared.Window.IsPowered = false;
                     if (shared.SoundMaker != null) shared.SoundMaker.StopAllVoices();
                     foreach (var w in shared.ManagedWindows) w.IsPowered = false;
+                    // Give rovers a chance to load energy
+                    kOSVesselModule.GetInstance(shared.Vessel).GetFlightControlParameter("wheelthrottle").UpdateValue(0.0d, shared);
                     break;
             }
 

--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -884,8 +884,8 @@ namespace kOS.Module
                     if (shared.Window != null) shared.Window.IsPowered = false;
                     if (shared.SoundMaker != null) shared.SoundMaker.StopAllVoices();
                     foreach (var w in shared.ManagedWindows) w.IsPowered = false;
-                    // Give rovers a chance to load energy
-                    kOSVesselModule.GetInstance(shared.Vessel).GetFlightControlParameter("wheelthrottle").UpdateValue(0.0d, shared);
+                    kOSVesselModule vesselModule = kOSVesselModule.GetInstance(shared.Vessel);
+                    if (!vesselModule.ProcessorAvailable()) vesselModule.OnAllProcessorsStarved();
                     break;
             }
 

--- a/src/kOS/Module/kOSVesselModule.cs
+++ b/src/kOS/Module/kOSVesselModule.cs
@@ -435,6 +435,35 @@ namespace kOS.Module
         }
 
         /// <summary>
+        /// Checks if there is any kOSProcessor active
+        /// </summary>
+        public bool ProcessorAvailable()
+        {
+            IEnumerable<PartModule> processorModules = Vessel.parts
+                .SelectMany(p => p.Modules.Cast<PartModule>()
+                .Where(pMod => pMod is kOSProcessor));
+            foreach (kOSProcessor processor in processorModules)
+            {
+                if (processor.ProcessorMode == Safe.Module.ProcessorModes.READY)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Disables the controlls
+        /// </summary>
+        public void OnAllProcessorsStarved()
+        {
+            foreach (IFlightControlParameter f in flightControlParameters.Values)
+            {
+                f.DisableControl();
+            }
+        }
+
+        /// <summary>
         /// Return the kOSVesselModule instance associated with the given Vessel object
         /// </summary>
         /// <param name="vessel">the vessel for which the module should be returned</param>


### PR DESCRIPTION
Rover can now load energy, without wasting it immediatly on the motor, what prevented the user from taking control.