### PR TITLE
Disabled unreachable-code warnings for debug code.

### DIFF
--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -121,8 +121,10 @@ namespace kOS.Safe.Compilation.KS
         {
             if (node == null) { throw new ArgumentNullException("node"); }
 
+#pragma warning disable CS0162
             if (TRACE_PARSE)
                 SafeHouse.Logger.Log("traceParse: visiting node: " + node.Token.Type.ToString() + ", " + node.Token.Text);
+#pragma warning restore CS0162
 
             LineCol location = GetLineCol(node);
             lastLine = location.Line;

--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -527,8 +527,10 @@ namespace kOS.Screen
                 
                 if (!IsSpecial(c)) // printable characters
                 {
+#pragma warning disable CS0162
                     if (DebugInternational)
                         c = DebugInternationalMapping(c);
+#pragma warning restore CS0162
                     ProcessOneInputChar(c, null);
                     consumeEvent = true;
                     cursorBlinkTime = 0.0f; // Don't blink while the user is still actively typing.

--- a/src/kOS/UserIO/TelnetSingletonServer.cs
+++ b/src/kOS/UserIO/TelnetSingletonServer.cs
@@ -351,7 +351,8 @@ namespace kOS.UserIO
                 else
                     throw; // Not one of the expected thread-closed IO exceptions, so don't hide it - let it get reported.
             }
-            
+
+#pragma warning disable CS0162
             if (VERBOSE_DEBUG_SEND) // compiler warning - this code block is hardcoded to be unreachable.  But that's deliberate.
             {
                 StringBuilder logMessage = new StringBuilder();
@@ -364,6 +365,7 @@ namespace kOS.UserIO
                 }
                 SafeHouse.Logger.Log(logMessage.ToString());
             }
+#pragma warning restore CS0162
         }
 
         public void StopListening()

--- a/src/kOS/Utilities/Utils.cs
+++ b/src/kOS/Utilities/Utils.cs
@@ -111,10 +111,11 @@ namespace kOS.Utilities
         /// <param name="a">Does this body</param>
         /// <param name="b">Orbit around this body</param>
         /// <returns>True if a orbits b.  </returns>
+        #pragma warning disable CS0162
         public static Boolean BodyOrbitsBody(CelestialBody a, CelestialBody b)
         {
             const bool DEBUG_WALK = false;
-            
+
             if (DEBUG_WALK) SafeHouse.Logger.Log("BodyOrbitsBody(" + a.name + "," + b.name + ")");
             if (DEBUG_WALK) SafeHouse.Logger.Log("a's ref body = " + (a.referenceBody == null ? "null" : a.referenceBody.name));
             Boolean found = false;
@@ -130,7 +131,8 @@ namespace kOS.Utilities
             }
             return found;
         }
-        
+        #pragma warning restore CS0162
+
         /// <summary>
         /// Given any CSharp object, return the string name of the type in
         /// a way that makes more sense to kOS users, using kOS names rather


### PR DESCRIPTION
The coding style causes unused debug code to be unreachable by design, so I disabled the warnings for this code.

Closes #2343.