### PR TITLE
[Fixes #2345] Quick fix for handling files with BOMs in them.

### DIFF
--- a/src/kOS.Safe/Persistence/FileContent.cs
+++ b/src/kOS.Safe/Persistence/FileContent.cs
@@ -35,10 +35,25 @@ namespace kOS.Safe.Persistence
         {
             Bytes = fileEncoding.GetBytes(content);
         }
-
+       
         public FileContent(byte[] content) : this()
         {
-            Bytes = content;
+            string decodedString;
+
+            // Issue #2345: kOS reading UTF-8 can't handle a file with a BOM in it.
+            //
+            // In order to allow kOS to read files with a BOM in them
+            // we first pass them through a StreamReader, which handles
+            // the BOM and gives us a string with only the text data.
+            using (MemoryStream ms = new MemoryStream(content))
+            {
+                using (StreamReader sr = new StreamReader(ms))
+                {
+                    decodedString = sr.ReadToEnd();
+                }
+            }
+
+            Bytes = fileEncoding.GetBytes(decodedString);
         }
 
         public FileContent(List<CodePart> parts) : this()


### PR DESCRIPTION
Fixes [https://github.com/KSP-KOS/KOS/issues/2345](https://github.com/KSP-KOS/KOS/issues/2345)

I've got the idea [here](https://www.andrewthompson.co/2011/02/byte-order-mark-found-using-net.html). I've run some tests with differently encoded files (clean, UTF-8, UTF-16 LE, and UTF-16 BE) and everything seems to work correctly.

The linked page and the comments in the code should be self-explanatory.
I don't know how solid this is, but I think it simple and stable enough to be easily merged into the main develop branch.

Also, this is my first PR... :-)