### PR TITLE
Fixes #2356 and clears some 'eraseme' printouts.

### DIFF
--- a/src/kOS.Safe/Execution/CPU.cs
+++ b/src/kOS.Safe/Execution/CPU.cs
@@ -210,6 +210,7 @@ namespace kOS.Safe.Execution
                 // remove the last context
                 ProgramContext contextRemove = contexts.Last();
                 NotifyPopContextNotifyees(contextRemove);
+                contextRemove.ClearTriggers();
                 contexts.Remove(contextRemove);
                 shared.GameEventDispatchManager.RemoveDispatcherFor(currentContext);
                 contextRemove.DisableActiveFlyByWire(shared.BindingMgr);
@@ -435,19 +436,14 @@ namespace kOS.Safe.Execution
             {
                 if (globalVariables.Contains(item.Key))
                 {
-                    // if the pointer exists it means it was redefined from inside a program
-                    // and it's going to be invalid outside of it, so we remove it
+                    // If the pointer exists it means it was redefined from inside a program
+                    // and it's going to be invalid outside of it, so just to be sure, remove
+                    // it entirely in preparation for restoring the old one:
                     globalVariables.Remove(item.Key);
                     deletedPointers++;
-                    // also remove the corresponding trigger if exists
-                    if (item.Value.Value is int)
-                        RemoveTrigger((int)item.Value.Value, 0);
                 }
-                else
-                {
-                    globalVariables.Add(item.Key, item.Value);
-                    restoredPointers++;
-                }
+                globalVariables.Add(item.Key, item.Value);
+                restoredPointers++;
             }
 
             SafeHouse.Logger.Log(string.Format("Deleting {0} pointers and restoring {1} pointers", deletedPointers, restoredPointers));
@@ -498,7 +494,8 @@ namespace kOS.Safe.Execution
             }
             else
             {
-                currentContext.ClearTriggers();   // remove all the triggers
+                if (manual)
+                    currentContext.ClearTriggers(); // Removes the interpreter's triggers on Control-C and the like, but not on errors.
                 SkipCurrentInstructionId();
             }
             CurrentPriority = InterruptPriority.Normal;
@@ -1439,7 +1436,6 @@ namespace kOS.Safe.Execution
             bool okayToActivatePendingTriggers = false;
 
             executeLog.Remove(0, executeLog.Length); // In .net 2.0, StringBuilder had no Clear(), which is what this is simulating.
-            SafeHouse.Logger.Log("eraseme: ContinueExecution before While loop.");
             while (InstructionsThisUpdate < instructionsPerUpdate &&
                    executeNext &&
                    currentContext != null)
@@ -1456,7 +1452,6 @@ namespace kOS.Safe.Execution
                     ! currentContext.HasActiveTriggersAtLeastPriority(InterruptPriority.Recurring))
                 {
                     okayToActivatePendingTriggers = true;
-                    SafeHouse.Logger.Log("eraseme: okayToActivatePendingTriggers just became true.");
                 }
 
                 if (IsYielding())
@@ -1485,7 +1480,6 @@ namespace kOS.Safe.Execution
             if (okayToActivatePendingTriggers)
             {
                 currentContext.ActivatePendingTriggers();
-                SafeHouse.Logger.Log("eraseme: ActivatedPendingTriggers.");
             }
 
             if (executeLog.Length > 0)


### PR DESCRIPTION
(Getting rid of the "eraseme" printouts was not part of the
fix, but is something that needed cleaning up anyway.  Whenever
I put the word "eraseme" in a line of code it is meant to be
a reminder to go back and delete that line before merging it
in, because it only existed to log some debug info for a
specific problem I was looking at at the time.  I must have
forgotten to do so at some point in the past for those lines
to still be there now.)

The bug fix is to unconditionally restore the global pointers,
regardless of whether the program context also set them.  The
fact that the restoration had been inside an "else" meant it
was being skipped when the "if" happened, and that's incorrect.

As part of this, the logic of when to remove triggers from a
program context has been moved to the PopContext() so that all
old triggers from a context being popped will always go away.
The logic that previously tried doing it inside RestorePointers()
was wrong because by the time that is called, the currentContext
no longer points at the Program that's going away.  It points to
the new context being popped TO, not the one popped FROM.  So
the RemoveTrigger call was trying to remove it from the wrong context
anwyway.  It was meant to remove it from the stale context being
popped, which it was not doing given where it was located.  Luckily
it never caused a bug, because of a *second* bug that made it never
trigger, which is that the values it removes are no longer of type
(int) like they used to be and are now of type (UserDelegate) so the
check against their type was skipping over the offending code anyway.
(Two wrongs kind of made a right - sort of.)