### PR TITLE
Update scanner to ignore command characters

### DIFF
--- a/src/kOS.Safe/Compilation/KS/Scanner.cs
+++ b/src/kOS.Safe/Compilation/KS/Scanner.cs
@@ -360,7 +360,7 @@ namespace kOS.Safe.Compilation.KS
             Patterns.Add(TokenType.EOF, regex);
             Tokens.Add(TokenType.EOF);
 
-            regex = new Regex(@"\G(?:\s+)");
+            regex = new Regex(@"\G(?:(\s|\p{C})+)");
             Patterns.Add(TokenType.WHITESPACE, regex);
             Tokens.Add(TokenType.WHITESPACE);
 

--- a/src/kOS.Safe/Compilation/KS/kRISC.tpg
+++ b/src/kOS.Safe/Compilation/KS/kRISC.tpg
@@ -90,7 +90,7 @@ LAZYGLOBAL   -> @"lazyglobal\b";
 //Special
 EOF          -> @"$";
 [Skip]
-WHITESPACE   -> @"\s+";
+WHITESPACE   -> @"(\s|\p{C})+";
 [Skip]
 COMMENTLINE  -> @"//[^\n]*\n?";
 


### PR DESCRIPTION
Fixes #2345 

Because BOM is a command code, updating the scanner such that these codes are ignored as white space fixes the error when running a script with BOM, without having to actually modify file's contents.

kRISC.tpg
* modify WHITESPACE token to include command codes
* command codes are zero length, so they can safely be treated the same as white space

Scanner.cs
* Update auto generated file