### PR TITLE
#2394 - Expose terminal cursor

### DIFF
--- a/doc/source/structures/misc/terminal.rst
+++ b/doc/source/structures/misc/terminal.rst
@@ -55,6 +55,21 @@ Structure
           - get and set
           - Height of a character cell in pixels.
 
+        * - :attr:`CURSORCOL`
+          - :struct:`Scalar`
+          - get and set
+          - Current cursor column, between 0 and WIDTH-1.
+        
+        * - :attr:`CURSORROW`
+          - :struct:`Scalar`
+          - get and set
+          - Current cursor row, between 0 and HEIGHT-1.
+
+        * - :meth:`PUT(string)`
+          - None
+          - Method Call
+          - Output string without newline.
+
         * - :attr:`INPUT`
           - :struct:`TerminalInput`
           - get
@@ -165,6 +180,26 @@ Structure
     The value is forced to remain in the range [4..24] and be
     divisible by 2.  If you try to set it to any other value, it
     will snap to the allowed range and increment.
+
+.. attribute:: Terminal:CURSORCOL
+
+    :access: Get/Set
+    :type: :struct:`Scalar`
+
+    Current cursor column, between 0 and WIDTH-1.
+
+.. attribute:: Terminal:CURSORROW
+
+    :access: Get/Set
+    :type: :struct:`Scalar`
+
+    Current cursor row, between 0 and HEIGHT-1.
+
+.. method:: Terminal:PUT(text)
+
+    :parameter text: (string) Text to print
+
+    Put string at current cursor position (without implied newline).
 
 .. attribute:: Terminal:INPUT
 

--- a/kerboscript_tests/terminalcursor.ks
+++ b/kerboscript_tests/terminalcursor.ks
@@ -3,15 +3,20 @@
 local teststring is "This is a teststring".
 local words is teststring:split(" ").
 
-local remember is terminal:width.
-set terminal:width to teststring:length.
 print "The following lines should all look identical".
 print teststring. //comparison, do not go back to this line
 print words[0].
-set terminal:cursorcol to terminal:cursorcol - terminal:width + words[0]:length + 1.
+set terminal:cursorcol to words[0]:length + 1.
+set terminal:cursorrow to terminal:cursorrow - 1.
 print words[1].
 set terminal:cursorrow to terminal:cursorrow - 1.
 set terminal:cursorcol to words[0]:length + words[1]:length + 2.
 print words[2] + " " + words[3].
-
-set terminal:width to remember.
+print words[0] + " " + words[1].
+set terminal:cursorrow to terminal:cursorrow - 2.
+set terminal:cursorcol to words[0]:length + words[1]:length +2.
+terminal:put(words[2]).
+set terminal:cursorrow to terminal:cursorrow + 1.
+set terminal:cursorcol to terminal:cursorcol - words[2]:length.
+terminal:put(words[2]).
+print " " + words[3]. 

--- a/kerboscript_tests/terminalcursor.ks
+++ b/kerboscript_tests/terminalcursor.ks
@@ -1,0 +1,17 @@
+@lazyglobal off.
+
+local teststring is "This is a teststring".
+local words is teststring:split(" ").
+
+local remember is terminal:width.
+set terminal:width to teststring:length.
+print "The following lines should all look identical".
+print teststring. //comparison, do not go back to this line
+print words[0].
+set terminal:cursorcol to terminal:cursorcol - terminal:width + words[0]:length + 1.
+print words[1].
+set terminal:cursorrow to terminal:cursorrow - 1.
+set terminal:cursorcol to words[0]:length + words[1]:length + 2.
+print words[2] + " " + words[3].
+
+set terminal:width to remember.

--- a/src/kOS.Safe/Encapsulation/TerminalStruct.cs
+++ b/src/kOS.Safe/Encapsulation/TerminalStruct.cs
@@ -2,6 +2,7 @@
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Screen;
 using kOS.Safe.Execution;
+using kOS.Safe.Utilities;
 
 namespace kOS.Safe.Encapsulation
 {
@@ -161,6 +162,20 @@ namespace kOS.Safe.Encapsulation
                                                                     "Character height on in-game terminal screen in pixels"));
             AddSuffix("RESIZEWATCHERS", new NoArgsSuffix<UniqueSetValue<UserDelegate>>(() => resizeWatchers));
             AddSuffix("INPUT", new Suffix<TerminalInput>(GetTerminalInputInstance));
+            AddSuffix("CURSORCOL", new SetSuffix<ScalarValue>(() => Shared.Screen.CursorColumnShow,
+                                                              value => { //Screen.MoveCursor rolls over the end of line, but not over the front, so we have to implement the latter ourselves.
+                                                                  int row = Shared.Screen.CursorRowShow;
+                                                                  while(value < 0)
+                                                                  {
+                                                                      row--;
+                                                                      value += Shared.Screen.ColumnCount;
+                                                                  }
+                                                                  Shared.Screen.MoveCursor(row, value);
+                                                              },
+                                                              "Current cursor column.  Will roll over the screen edges into the next or previous row."));
+            AddSuffix("CURSORROW", new SetSuffix<ScalarValue>(() => Shared.Screen.CursorRowShow,
+                                                              value => Shared.Screen.MoveCursor((int)KOSMath.Clamp(value,0,Shared.Screen.RowCount), Shared.Screen.CursorColumnShow),
+                                                              "Current cursor row, between 0 and HEIGHT-1"));
         }
 
         private void CannotSetWidth(ScalarValue newWidth)

--- a/src/kOS.Safe/Encapsulation/TerminalStruct.cs
+++ b/src/kOS.Safe/Encapsulation/TerminalStruct.cs
@@ -164,10 +164,10 @@ namespace kOS.Safe.Encapsulation
             AddSuffix("INPUT", new Suffix<TerminalInput>(GetTerminalInputInstance));
             AddSuffix("CURSORCOL", new SetSuffix<ScalarValue>(() => Shared.Screen.CursorColumnShow,
                                                               value => Shared.Screen.MoveCursor(Shared.Screen.CursorRowShow, (int)KOSMath.Clamp(value,0,Shared.Screen.ColumnCount)),
-                                                              "Current cursor column.  Will roll over the screen edges into the next or previous row."));
+                                                              "Current cursor column, between 0 and WIDTH-1."));
             AddSuffix("CURSORROW", new SetSuffix<ScalarValue>(() => Shared.Screen.CursorRowShow,
                                                               value => Shared.Screen.MoveCursor((int)KOSMath.Clamp(value,0,Shared.Screen.RowCount), Shared.Screen.CursorColumnShow),
-                                                              "Current cursor row, between 0 and HEIGHT-1"));
+                                                              "Current cursor row, between 0 and HEIGHT-1."));
             AddSuffix("PUT", new OneArgsSuffix<StringValue>(value => Shared.Screen.Print(value,false),
                                                             "Put string at current cursor position (without implied newline)."));
         }

--- a/src/kOS.Safe/Encapsulation/TerminalStruct.cs
+++ b/src/kOS.Safe/Encapsulation/TerminalStruct.cs
@@ -163,19 +163,13 @@ namespace kOS.Safe.Encapsulation
             AddSuffix("RESIZEWATCHERS", new NoArgsSuffix<UniqueSetValue<UserDelegate>>(() => resizeWatchers));
             AddSuffix("INPUT", new Suffix<TerminalInput>(GetTerminalInputInstance));
             AddSuffix("CURSORCOL", new SetSuffix<ScalarValue>(() => Shared.Screen.CursorColumnShow,
-                                                              value => { //Screen.MoveCursor rolls over the end of line, but not over the front, so we have to implement the latter ourselves.
-                                                                  int row = Shared.Screen.CursorRowShow;
-                                                                  while(value < 0)
-                                                                  {
-                                                                      row--;
-                                                                      value += Shared.Screen.ColumnCount;
-                                                                  }
-                                                                  Shared.Screen.MoveCursor(row, value);
-                                                              },
+                                                              value => Shared.Screen.MoveCursor(Shared.Screen.CursorRowShow, (int)KOSMath.Clamp(value,0,Shared.Screen.ColumnCount)),
                                                               "Current cursor column.  Will roll over the screen edges into the next or previous row."));
             AddSuffix("CURSORROW", new SetSuffix<ScalarValue>(() => Shared.Screen.CursorRowShow,
                                                               value => Shared.Screen.MoveCursor((int)KOSMath.Clamp(value,0,Shared.Screen.RowCount), Shared.Screen.CursorColumnShow),
                                                               "Current cursor row, between 0 and HEIGHT-1"));
+            AddSuffix("PUT", new OneArgsSuffix<StringValue>(value => Shared.Screen.Print(value,false),
+                                                            "Put string at current cursor position (without implied newline)."));
         }
 
         private void CannotSetWidth(ScalarValue newWidth)

--- a/src/kOS.Safe/Screen/TextEditor.cs
+++ b/src/kOS.Safe/Screen/TextEditor.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text;
 using System;
 using kOS.Safe.UserIO;
@@ -12,7 +12,7 @@ namespace kOS.Safe.Screen
         private int cursorColumnBuffer;
         private int cursorRowBuffer;
         
-        public override int CursorColumnShow { get { return cursorColumnBuffer; } }
+        public override int CursorColumnShow { get { return CursorColumn + cursorColumnBuffer; } }
         public override int CursorRowShow { get { return CursorRow + cursorRowBuffer; } }
 
         protected StringBuilder LineBuilder { get; set; }


### PR DESCRIPTION
Fixes #2394 

- new Suffixes for `terminal` mostly as described in the Issue
- I decided to implement `put` as a suffix, too. But I don't personally have a strong opinion on that and would be willing to make it a builtin or implement `terminal:println` and `terminal:printat` for consistency.
- New testscript: terminalcursor.ks to test the new suffixes
- Possibly unexpected behaviour:
  - Setting `cursorcol` or `cursorrow` on the interpreter leads to the prompt moving around (but, what else would you want to achieve with that?)
  - If a script leaves `cursorcol` on a non-zero value, the `Program ended`-Message is offset by that