### PR TITLE
Fixes #2399 bulkhead profile fields added to parts

### DIFF
--- a/Resources/GameData/kOS/Parts/KOSCherryLight/part.cfg
+++ b/Resources/GameData/kOS/Parts/KOSCherryLight/part.cfg
@@ -5,6 +5,7 @@ PART
     module = Part
     author = Peter Goddard (pgodd) and Brad White (hvacengi)
     mesh = model/cherrylight.mu
+    bulkheadProfiles = size0, srf
     scale = 1
     rescaleFactor = 1
     node_stack_bottom = 0, -0.01, 0, 0, -90, 0, 0

--- a/Resources/GameData/kOS/Parts/kOSMachine0m/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSMachine0m/part.cfg
@@ -27,6 +27,7 @@ subcategory = 0
 title = KR-2042 b Scriptable Control System
 manufacturer = Compotronix
 description = Would you trust life and limb to a mindless autopilot, powered by untested software you hastily wrote yourself? Spacefaring kerbals would!
+bulkheadProfiles = size0
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,0,1,0,0

--- a/Resources/GameData/kOS/Parts/kOSMachine0mLegacy/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSMachine0mLegacy/part.cfg
@@ -27,6 +27,7 @@ subcategory = 0
 title = KR-2042 b Scriptable Control System
 manufacturer = Compotronix
 description = Would you trust life and limb to a mindless autopilot, powered by untested software you hastily wrote yourself? Spacefaring kerbals would!
+bulkheadProfiles = size0
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,0,1,1,0

--- a/Resources/GameData/kOS/Parts/kOSMachine1m/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSMachine1m/part.cfg
@@ -27,6 +27,7 @@ subcategory = 0
 title = CX-4181 Scriptable Control System
 manufacturer = Compotronix
 description = Would you trust life and limb to a mindless autopilot, powered by untested software you hastily wrote yourself? Spacefaring kerbals would!
+bulkheadProfiles = size1
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,0,1,1,0

--- a/Resources/GameData/kOS/Parts/kOSMachineRad/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSMachineRad/part.cfg
@@ -25,6 +25,7 @@ subcategory = 0
 title = CompoMax Radial Tubeless
 manufacturer = Squalid-State Devices Inc.
 description = Would you trust life and limb to a mindless autopilot, powered by untested software you hastily wrote yourself? Spacefaring kerbals would!
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,0,1

--- a/Resources/GameData/kOS/Parts/kOSkal9000/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSkal9000/part.cfg
@@ -24,6 +24,7 @@ subcategory = 0
 title = KAL9000 Scriptable Control System
 manufacturer = Squalid State Devices
 description = Mildly Malevolent artificial entity, use caution on EVA's
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,0,0


### PR DESCRIPTION
Note, to be certain when testing, be sure that kOS is the only mod installed.
Many other mods have the same bug, and if any one of them has it, the effect looks the same in the VAB regardless of which mod caused it.

The effect of the bug:  In the VAB click on the "<|||" button in the parts panel (the one that pulls a side panel into view with additional filtering options).  Click the "cross section" button and pick any of its filters.  If you have the bug, then from now on the VAB will not let you switch parts tabs to any other subset of parts.  It's frozen on this particular set of parts, until you leave the VAB and re-enter it.

