### PR TITLE
Change input locks to fix map spin, Fixes #2126

### DIFF
--- a/src/kOS/Screen/GUIWindow.cs
+++ b/src/kOS/Screen/GUIWindow.cs
@@ -83,15 +83,7 @@ namespace kOS.Screen
         void OnShowUI()
         {
             uiGloballyHidden = false;            
-        }
-        
-        public override void GetFocus()
-        {
-        }
-        
-        public override void LoseFocus()
-        {
-        }
+        }        
 
         public override void Open()
         {

--- a/src/kOS/Screen/KOSManagedWindow.cs
+++ b/src/kOS/Screen/KOSManagedWindow.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace kOS.Screen
@@ -13,7 +13,7 @@ namespace kOS.Screen
     public abstract class KOSManagedWindow : MonoBehaviour
     {
         // The static values are for the way the windows keep track of each other:
-        
+
         // Give each instance of TermWindow a unique ID block to ensure it can create
         // Unity windows that don't clash:
         private static int termWindowIDRange = 215300; // I literally just mashed the keyboard to get a unique number.
@@ -43,11 +43,18 @@ namespace kOS.Screen
 
         private bool isOpen;
 
-        protected KOSManagedWindow()
+        private string lockIdName;
+
+        protected KOSManagedWindow(string lockIdName = "")
         {
             // multiply by 50 so there's a range for future expansion for other GUI objects inside the window:
             uniqueId = termWindowIDRange + (windowsMadeSoFar * 50);
-            ++windowsMadeSoFar;            
+            ++windowsMadeSoFar;
+            // When the lockIdName is not given, then manufacture a unique one:
+            if (lockIdName.Length == 0)
+                this.lockIdName = "KOSManagedWindow ID:" + uniqueId;
+            else
+                this.lockIdName = lockIdName;
         }
 
         public bool IsPowered { get; set; }
@@ -130,14 +137,27 @@ namespace kOS.Screen
 
 
         /// <summary>
-        /// Implement this for how to make your widget get the keyboard focus:
+        /// Implement this for how to make your widget get the keyboard focus.
+        /// It is VITAL that if you override this method in a derived class,
+        /// that you also call this base version in that overridden method.  Otherwise
+        /// you will get the map view spinning bug when the focus is in this window.
         /// </summary>
-        public abstract void GetFocus();
+        public virtual void GetFocus()
+        {
+            if (HighLogic.LoadedSceneIsFlight || HighLogic.LoadedSceneHasPlanetarium)
+                InputLockManager.SetControlLock(ControlTypes.ALLBUTCAMERAS, lockIdName);
+        }
 
         /// <summary>
         /// Implement this for how to make your widget give up the keyboard focus:
+        /// It is VITAL that if you override this method in a derived class,
+        /// that you also call this base version in that overridden method.  Otherwise
+        /// you will get the map view spinning bug when the focus is in this window.
         /// </summary>
-        public abstract void LoseFocus();
+        public virtual void LoseFocus()
+        {
+            InputLockManager.RemoveControlLock(lockIdName);
+        }
         
         /// <summary>
         /// Implement this to make the window appear when it wasn't there before.

--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -15,7 +15,7 @@ namespace kOS.Screen
     // Blockotronix 550 Computor Monitor
     public class TermWindow : KOSManagedWindow , ITermWindow
     {
-        private const string CONTROL_LOCKOUT = "kOSTerminal";
+        public const string CONTROL_LOCKOUT = "kOSTerminal";
 
         /// <summary>
         /// Set to true only when compiling a version specifically for the purpose
@@ -259,11 +259,13 @@ namespace kOS.Screen
         
         public override void GetFocus()
         {
+            base.GetFocus();
             Lock();
         }
-        
+
         public override void LoseFocus()
         {
+            base.LoseFocus();
             Unlock();
         }
 
@@ -322,9 +324,7 @@ namespace kOS.Screen
             BringToFront();
 
 
-            // Exclude the TARGETING ControlType so that we can set the target vessel with the terminal open.
-            InputLockManager.SetControlLock(ControlTypes.All & ~ControlTypes.TARGETING, CONTROL_LOCKOUT);
-
+            InputLockManager.SetControlLock(ControlTypes.All, CONTROL_LOCKOUT);
             // Prevent editor keys from being pressed while typing
             EditorLogic editor = EditorLogic.fetch;
                 //TODO: POST 0.90 REVIEW

--- a/src/kOS/Utilities/VesselUtils.cs
+++ b/src/kOS/Utilities/VesselUtils.cs
@@ -160,7 +160,26 @@ namespace kOS.Utilities
             else if (val.GetVessel() == currentVessel)
                 throw new Safe.Exceptions.KOSInvalidTargetException("A ship cannot set TARGET to a part of itself.");
 
+            // If any kOS terminal (not just the one this CPU uses as its Shared.Window, but ANY kOS terminal
+            // from any kOS CPU) is the focused window right now, causing input lockouts, we must
+            // temporarily turn off that input lock in order for the main game allow the SetVesselTarget()
+            // call in the lines below to perform its task fully:
+            //
+            // Note the preferred solution would be to walk all control locks and suppress *any* that are turning
+            // off the targeting, regardless of whether they're kOS or not, but InputLockManager does not provide
+            // any methods for iteratinng the collection of all control lock masks, and it's also not possible to turn
+            // a lock OFF by masking it with a new control lock, since all the locks in the stack are OR'ed together.)
+
+            ControlTypes termInputLock = InputLockManager.GetControlLock(Screen.TermWindow.CONTROL_LOCKOUT);
+            // (Note, KSP returns ControlTypes.None rather than null when no such lock was found, because it's
+            // a non-nullable enum)
+            if (termInputLock != ControlTypes.None)
+                InputLockManager.RemoveControlLock(Screen.TermWindow.CONTROL_LOCKOUT);
+
             FlightGlobals.fetch.SetVesselTarget(val, true);
+
+            if (termInputLock != ControlTypes.None)
+                InputLockManager.SetControlLock(termInputLock, Screen.TermWindow.CONTROL_LOCKOUT);
         }
 
         public static float AngleDelta(float a, float b)


### PR DESCRIPTION
I also added some input locking to all kOS windows
including the GUI, to help get rid of some of the
click-through problems some of them had.

It is unclear WHY the stock game has this weird behavior in regards to the TARGETING input lock flag, but it does, so this ad-hoc ugly fix was my way around it - I go ahead and lock everything in the terminal including TARGETING (this gets rid of the spinning bug but introduces a new bug that you cannot SET TARGET from inside a script while the terminal window is focused).  Then I get around that new bug by using a different technique to allow TARGETING than we used before - I simply temporarily turn off the terminal input lock the line before setting the target, then restore the terminal input lock immediately afterward on the next line.