### PR TITLE
fix #2422 broken ship:maxthrust

### DIFF
--- a/src/kOS/Suffixed/Part/EngineValue.cs
+++ b/src/kOS/Suffixed/Part/EngineValue.cs
@@ -256,11 +256,7 @@ namespace kOS.Suffixed.Part
 
     public static class ModuleEnginesExtensions
     {
-        public static float GetThrust(this ModuleEngines engine, bool useThrustLimit = false, float throttle = 1.0f, bool operational = true)
-        {
-            return GetThrust(engine, engine.part.staticPressureAtm, useThrustLimit, throttle, operational);
-        }
-        public static float GetThrust(this ModuleEngines engine, double atmPressure, bool useThrustLimit = false, float throttle = 1.0f, bool operational = true)
+        public static float GetThrust(this ModuleEngines engine, double? atmPressure = null, bool useThrustLimit = false, float throttle = 1.0f, bool operational = true)
         {
             if (engine == null || operational && !engine.isOperational)
                 return 0f;
@@ -278,13 +274,9 @@ namespace kOS.Suffixed.Part
             return Mathf.Lerp(engine.minFuelFlow, engine.maxFuelFlow, throttle) * flowMod * GetIsp(engine, atmPressure) * engine.g * velMod;
         }
 
-        public static float GetIsp(this ModuleEngines engine)
+        public static float GetIsp(this ModuleEngines engine, double? atmPressure = null)
         {
-            return GetIsp(engine, engine.part.staticPressureAtm);
-        }
-        public static float GetIsp(this ModuleEngines engine, double staticPressureAtm)
-        {
-            return engine == null ? 0f : engine.atmosphereCurve.Evaluate((float)staticPressureAtm);
+            return engine == null ? 0f : engine.atmosphereCurve.Evaluate((float)(atmPressure ?? engine.part.staticPressureAtm));
         }
 
         public static float GetVacuumSpecificImpluse(this ModuleEngines engine)

--- a/src/kOS/Suffixed/Part/EngineValue.cs
+++ b/src/kOS/Suffixed/Part/EngineValue.cs
@@ -256,6 +256,15 @@ namespace kOS.Suffixed.Part
 
     public static class ModuleEnginesExtensions
     {
+        /// <summary>
+        /// Get engine thrust
+        /// </summary>
+        /// <param name="engine">The engine (can be null - returns zero in that case)</param>
+        /// <param name="atmPressure">Atmospheric pressure (current if omitted/null, 1.0 means sea level, 0.0 is vacuum)</param>
+        /// <param name="useThrustLimit">Use current thrust limit (assume 100% if false)</param>
+        /// <param name="throttle">Throttle (full if omitted)</param>
+        /// <param name="operational">Return zero if this is true and engine is not operational (enabled/staged)</param>
+        /// <returns>The thrust</returns>
         public static float GetThrust(this ModuleEngines engine, double? atmPressure = null, bool useThrustLimit = false, float throttle = 1.0f, bool operational = true)
         {
             if (engine == null || operational && !engine.isOperational)
@@ -273,19 +282,16 @@ namespace kOS.Suffixed.Part
             // thrust is modified fuel flow rate times isp time g times the velocity modifier for jet engines (as of KSP 1.0)
             return Mathf.Lerp(engine.minFuelFlow, engine.maxFuelFlow, throttle) * flowMod * GetIsp(engine, atmPressure) * engine.g * velMod;
         }
-
+        /// <summary>
+        /// Get engine ISP
+        /// </summary>
+        /// <param name="engine">The engine (can be null - returns zero in that case)</param>
+        /// <param name="atmPressure">Atmospheric pressure (current if omitted/null, 1.0 means sea level, 0.0 is vacuum)</param>
+        /// <returns></returns>
         public static float GetIsp(this ModuleEngines engine, double? atmPressure = null)
         {
-            return engine == null ? 0f : engine.atmosphereCurve.Evaluate((float)(atmPressure ?? engine.part.staticPressureAtm));
-        }
-
-        public static float GetVacuumSpecificImpluse(this ModuleEngines engine)
-        {
-            return engine.atmosphereCurve.Evaluate(0);
-        }
-        public static float GetSeaLevelSpecificImpulse(this ModuleEngines engine)
-        {
-            return engine.atmosphereCurve.Evaluate(1);
+            return engine == null ? 0f : engine.atmosphereCurve.Evaluate(Mathf.Max(0f,
+                (float)(atmPressure ?? engine.part.staticPressureAtm)));
         }
     }
 }

--- a/src/kOS/Utilities/VesselUtils.cs
+++ b/src/kOS/Utilities/VesselUtils.cs
@@ -102,7 +102,7 @@ namespace kOS.Utilities
             return list;
         }
 
-        public static double GetMaxThrust(Vessel vessel, double atmPressure = -1.0)
+        public static double GetMaxThrust(Vessel vessel, double? atmPressure = null)
         {
             var thrust = 0.0;
 
@@ -758,7 +758,7 @@ namespace kOS.Utilities
             FlightGlobals.fetch.SetVesselTarget(null);
         }
 
-        public static double GetAvailableThrust(Vessel vessel, double atmPressure = -1.0)
+        public static double GetAvailableThrust(Vessel vessel, double? atmPressure = null)
         {
             var thrust = 0.0;
 

--- a/src/kOS/Utilities/VesselUtils.cs
+++ b/src/kOS/Utilities/VesselUtils.cs
@@ -102,7 +102,15 @@ namespace kOS.Utilities
             return list;
         }
 
-        public static double GetMaxThrust(Vessel vessel, double? atmPressure = null)
+        /// <summary>
+        /// Get total thrust (of operational engines at full throttle,
+        /// not counting with thrust limits - assuming 100% unless useThrustLimit: true)
+        /// </summary>
+        /// <param name="vessel">The vessel/ship</param>
+        /// <param name="atmPressure">Atmospheric pressure (current if omitted/null, 1.0 means sea level, 0.0 is vacuum)</param>
+        /// <param name="useThrustLimit">Use current thrust limit (assume 100% if false)</param>
+        /// <returns>Total thrust</returns>
+        public static double GetMaxThrust(Vessel vessel, double? atmPressure = null, bool useThrustLimit = false)
         {
             var thrust = 0.0;
 
@@ -113,12 +121,21 @@ namespace kOS.Utilities
                     if (!module.isEnabled) continue;
                     var engine = module as ModuleEngines;
                     if (engine != null)
-                        thrust += engine.GetThrust(atmPressure: atmPressure);
+                        thrust += engine.GetThrust(useThrustLimit: useThrustLimit, atmPressure: atmPressure);
                 }
             }
 
             return thrust;
         }
+        /// <summary>
+        /// Get total available thrust (of operational engines at full throttle,
+        /// counting with thrust limits)
+        /// </summary>
+        /// <param name="vessel">The vessel/ship</param>
+        /// <param name="atmPressure">Atmospheric pressure (current if omitted/null, 1.0 means sea level, 0.0 is vacuum)</param>
+        /// <returns>Total available thrust</returns>
+        public static double GetAvailableThrust(Vessel vessel, double? atmPressure = null)
+            => GetMaxThrust(vessel, atmPressure, useThrustLimit: true);
 
         private static Vessel TryGetVesselByName(string name, Vessel origin)
         {
@@ -756,23 +773,6 @@ namespace kOS.Utilities
         public static void UnsetTarget()
         {
             FlightGlobals.fetch.SetVesselTarget(null);
-        }
-
-        public static double GetAvailableThrust(Vessel vessel, double? atmPressure = null)
-        {
-            var thrust = 0.0;
-
-            foreach (var p in vessel.parts)
-            {
-                foreach (PartModule module in p.Modules)
-                {
-                    var engine = module as ModuleEngines;
-                    if (module.isEnabled && engine != null)
-                        thrust += engine.GetThrust(useThrustLimit: true, atmPressure: atmPressure);
-                }
-            }
-
-            return thrust;
         }
 
         public static Direction GetFacing(Vessel vessel)


### PR DESCRIPTION
fix #2422 

Changed all `double atmPressure = -1.0` to `double? atmPressure = null` and altered `GetIsp` to `... .Evaluate((float)(atmPressure ?? engine.part.staticPressureAtm));`