### PR TITLE
stage:resources(lex) vs. sepratrons

### DIFF
--- a/src/kOS/Suffixed/StageValues.cs
+++ b/src/kOS/Suffixed/StageValues.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using KSP.UI.Screens;
 using kOS.Module;
 using kOS.Safe.Utilities;
+using kOS.Suffixed.Part;
 
 namespace kOS.Suffixed
 {
@@ -127,9 +128,14 @@ namespace kOS.Suffixed
                 // All tanks accessible to this engine ...
                 foreach (var crossPart in part.crossfeedPartSet.GetParts())
                 {
+                    var xpart = vesselTarget[crossPart];
                     // ... that are to be separated by next decoupler
-                    if (vesselTarget[crossPart].DecoupledIn >= nextDecoupler)
+                    if (xpart.DecoupledIn >= nextDecoupler
+                        // ... but are not other boosters
+                        && !(crossPart != part && xpart is EngineValue))
+                    {
                         partHash.Add(crossPart);
+                    }
                 }
             }
             partSet.RebuildInPlace();


### PR DESCRIPTION
Before:
![obrazek](https://user-images.githubusercontent.com/11376520/52525892-fb178680-2cb0-11e9-853e-73a7a64a29ae.png)

After:
![obrazek](https://user-images.githubusercontent.com/11376520/52525903-213d2680-2cb1-11e9-84b9-70259620e7b3.png)

Difference:
When any booster (that Hammer) is activated then any next-stage-booster's (including those non-active sepratron's) fuel is considered available (broken KSP cross-feed API) to all activated boosters (thus `stage:resources(Lex)` includes the fuel of them all - 37.5+6*8=85.5, not only for the Hammer = 37.5).

I beleive this is SQUAD's fault... should I file some bug report? Where and how? `part.crossfeedPartSet` does not return what is trully accessible (boosters cannot drain fuel from other boosters).

P.S.: I think that kOS should have some kind of `OrderedDictionary` for `stage:resource` to act both like `Lexicon` and `List` so that `stage:resources["SomeFuel"]` acts just like `stage:resourcesLex["SomeFuel"]`. Do you agree? I can do that (and making it callable which means `stage:resources("SomeFuel")` act the same... I hope I can do that too if you like the idea).