### PR TITLE
Fixes #2443: ISCONNECTED() shouldn't crash on debris.

### DIFF
--- a/doc/source/commands/communication.rst
+++ b/doc/source/commands/communication.rst
@@ -189,12 +189,17 @@ you want to use.
           a relay on one or both of the vessels.
       .. note::
           **Debris Vessel**: To save on computer load, CommNet cuts all "debris"
-          vessels out of the system and does not track them.  Therefore any
-          vessel of type "debris" will be unable to have a connection,
-          regardless of what antennas it may have on it.  You can see this
-          effect by using the "rename vessel" button on a ship to categorize it
-          as "debris" and suddenly KSP will claim it has no connections to
-          anything.
+          vessels out of the system when loading the scene and does not track
+          them.  Therefore any vessel that was of type "debris" when the scene
+          was first loaded will be unable to have a connection, regardless of
+          what antennas it may have on it, and regardless of whether you change
+          its vessel type to something other than "debris" during the scene.
+          The vessel type has to be something other than "debris" *at the moment
+          the scene is first loaded* in order for it to be able to have CommNet
+          connections.  If you have a "debris" vessel that has no communication
+          connections, you can change the vessel type from "debris" to something
+          else, *and then go to the tracking station and come back*, then *that*
+          can cause the vessel to have a connection again.
           
     RemoteTechConnectivityManager
       This manager will use the RemoteTech mod to monitor connections. It will

--- a/doc/source/commands/communication.rst
+++ b/doc/source/commands/communication.rst
@@ -183,11 +183,19 @@ you want to use.
       difficulty settings.
 
       .. note::
-
-          CommNet has limitations on updating connections for vessels
+          **Active Vessel**: CommNet has limitations on updating connections for vessels
           which are not the active vessel.  The best way to ensure that a connection
           is updated is to include one of the kinds of antenna that can act as
           a relay on one or both of the vessels.
+      .. note::
+          **Debris Vessel**: To save on computer load, CommNet cuts all "debris"
+          vessels out of the system and does not track them.  Therefore any
+          vessel of type "debris" will be unable to have a connection,
+          regardless of what antennas it may have on it.  You can see this
+          effect by using the "rename vessel" button on a ship to categorize it
+          as "debris" and suddenly KSP will claim it has no connections to
+          anything.
+          
     RemoteTechConnectivityManager
       This manager will use the RemoteTech mod to monitor connections. It will
       only be available if RemoteTech is installed.  You can access more

--- a/doc/source/structures/communication/connection.rst
+++ b/doc/source/structures/communication/connection.rst
@@ -51,18 +51,66 @@ Structure
 
     :type: :struct:`Boolean`
 
-    True if the connection is opened and messages can be sent. For CPU connections this will be always true if the destionation CPU belongs to the same vessel as the current CPU.
-    For vessel connections this will be always true in stock game. :ref:`RemoteTech <remotetech>` introduces the concept of connectivity and may cause this to be false.
+    True if the connection is opened and messages can be sent.
+    
+    - For CPU connections:
+        - This will be true if the destination CPU belongs to the same vessel
+          as the current CPU, and will be false otherwise.
+    - For Vessel connections:
+        - If you are using Stock KSP and chose the PermitAll connectivity
+          manager, then this will aways return true.
+        - If you are using Stock KSP and chose the CommNet connectivity
+          manager, then this will obey the rules of the stock CommNet system
+          for whether a connection path exists between the source and
+          destination vessel.
+        - If you are using the RemoteTech and chose the RemoteTech
+          connectivity manager, then this will obey the rules of the
+          RemoteTech mod for whether a connection path exists between the
+          source and destination vessel.
+
     The connection has to be opened only in the moment of sending the message in order for it to arrive. If connection is lost after the message was sent,
-    but before it arrives at its destination it will have no effect on whether the message will reach its destination or not.
+    but before it arrives at its destination, this will have no effect on whether the message will reach its destination or not.
+
+    .. note::
+        **Debris Vessels**: If you are using the KSP Stock CommNet system,
+        be aware that it never includes "debris" type vessels in the
+        communications network.  ``ISCONNECTED`` will always be false
+        for any vessel of type "debris", no matter what antennas it
+        may have on it.
+
+     .. note::
+        **ISCONNECTION fails just after scene load**: If you have just loaded
+        the scene, such as after a vessel switch, then both the Stock CommNet
+        system and the RemoteTech mod often have a slight delay before they
+        "find" all the communication paths that exist.  This means that
+        ISCONNECTION will often return ``False`` for the first second or two
+        after a scene load, even when the correct answer should be ``True``.
+        It will be unable to report the correct answer until a second or so
+        later after the communications paths have all been discovered by the
+        game.  Because of this, if you have a boot script that depends on an
+        accurate answer for ISCONNECTED, it's a good idea for that boot
+        script to start with a short wait of a second or two at the top of
+        the script.
 
 .. attribute:: Connection:DELAY
 
     The number of seconds that it will take for messages sent using this connection to arrive at their destination. This value will be equal to -1 if connection is not opened.
-    For CPU connections this will be always equal to 0 if the destination CPU belongs to the same vessel as the current CPU.  Otherwise it will be equal to -1.
-    For vessel connections this will be always zero in stock game as messages arrive instantaneously. :ref:`RemoteTech <remotetech>` introduces the concept of
-    connectivity and may cause this to be a positive number (if there is some signal delay due to the large distance between the vessels) or -1 (if there is no connection
-    between the vessels).
+    - For CPU connections:
+        - This will be always equal to 0 if the destination CPU belongs
+          to the same vessel as the current CPU.  Otherwise it will be
+          equal to -1 as no such connection is allowed.
+    - For vessel connections:
+        - If you are using the PermitAll Connectivity Manager, then this
+          will always be zero, as messages arrive instantly.
+        - If you are using the stock CommNet Connectivirty Manager, then this
+          will always be zero, as stock CommNet does not impose any delay
+          from radio signals.
+        - If you are using the RemoteTech Connectivity Manager, then this
+          will report RemoteTech's signal delay along the path being used
+          to form the connection.  RemoteTech calculates the number of 
+          seconds of delay due radio signals traveling at the speed of light,
+          which can be quite significant when dealing with interplanetary
+          distances.
 
 .. attribute:: Connection:DESTINATION
 

--- a/src/kOS/Communication/CommNetConnectivityManager.cs
+++ b/src/kOS/Communication/CommNetConnectivityManager.cs
@@ -34,6 +34,16 @@ namespace kOS.Communication
             }
         }
 
+        /// <summary>A sanity check to avoid nullref errors when the vessel is
+        /// not a participant in the stock CommNet system and is thus lacking
+        /// certain properties. (Debris vessels lack CommNet info.)</summary>
+        public static bool IsCommnetParticipant(Vessel v)
+        {
+            if (v == null || v.Connection == null || v.Connection.Comm == null)
+                return false;
+            return true;
+        }
+
         public double GetDelay(Vessel vessel1, Vessel vessel2)
         {
             if (!IsEnabled)
@@ -61,6 +71,8 @@ namespace kOS.Communication
         {
             if (!IsEnabled)
                 return true;
+            if (!IsCommnetParticipant(vessel))
+                return false;
 
             // IsConnectedHome is only set to true on the active vessel, so we have to manually
             // call the FindHome method to evaluate the home connection.
@@ -82,7 +94,7 @@ namespace kOS.Communication
         {
             if (!IsEnabled)
                 return true;
-            if (vessel == null) // null check to handle fringe instances where connection is checked after nullified
+            if (!IsCommnetParticipant(vessel))
                 return false;
 
             // IsConnected is only set to true on the active vessel, so we have to manually
@@ -105,6 +117,8 @@ namespace kOS.Communication
         {
             if (!IsEnabled)
                 return true;
+            if (!IsCommnetParticipant(vessel1) || !IsCommnetParticipant(vessel2))
+                return false;
 
             // We next need to query the network to find a connection between the two vessels.
             // I found no exposed method for accessing cached paths directly, other than the


### PR DESCRIPTION
Fixes #2443.

The stock CommNet problem, that things classified as debris
are missing properties (they are null) on scene load isn't
something we can fix.  It's probably the stock game's way
of reducing system load by culling out all debris from the
comms system when loading a scene.  The weird fact that even
changing the vessel type doesn't really do anything until
the next scene reload isn't something we can do anything about
either.

But what we can do it make sure that calling ISCONNECTED()
merely returns false, rather than crashing with nullref, when
the vessel is not a participant in the stock CommNet system.

As I went to mention this in the docs, I also noticed some
out of date commentary in the docs. It claimed that ISCONNECTED
is always true in stock, and can only ever be false if you use
Remote Tech.  This needed fixing because it was written before
stock CommNet existed.  So I went through that section and
re-wrote those paragraphs to ensure the 3 options are expressly
described one at a time in bullet points (stock no comms, stock
with CommNet, and RemoteTech).