### PR TITLE
Fixes #2449 by slightly altering input locking.

### DIFF
--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -208,7 +208,7 @@ namespace kOS.Screen
 
         public void OnDestroy()
         {
-            Unlock();
+            LoseFocus();
             GameEvents.onHideUI.Remove(OnHideUI);
             GameEvents.onShowUI.Remove(OnShowUI);
         }


### PR DESCRIPTION
Fixes #2449 

**The bug was caused by this:**

TermWindow WAS unlocking its own inputlock flags when OnDestroy()
was being called, which seems like it should avoid the problem.
However TermWindow is a derived class from KOSManagedWindow, which
has its *own* input locks that getcleared by its LoseFocus() method, which was
skipped in the OnDestroy() hook of TermWindow.  So TermWindow's locks
were being cleared, but the base KOSManagedWindow's locks were not.