### PR TITLE
Fixes #2450 - blizzy icon fix

### DIFF
--- a/src/kOS/Screen/KOSToolbarWindow.cs
+++ b/src/kOS/Screen/KOSToolbarWindow.cs
@@ -189,7 +189,7 @@ namespace kOS.Screen
             if (!ToolbarManager.ToolbarAvailable) return;
 
             blizzyButton = ToolbarManager.Instance.add("kOS", "kOSButton");
-            blizzyButton.TexturePath = "kOS/GFX/launcher-button-blizzy";
+            blizzyButton.TexturePath = "kOS/GFX/dds_launcher-button-blizzy";
             blizzyButton.ToolTip = "kOS";
             blizzyButton.OnClick += e => CallbackOnClickBlizzy();
         }


### PR DESCRIPTION
Literally just forgot one line to change to the new
filenames when all the filenames changed to DDS.

To the reviwers

Testing will require installing Blizzy's Toolbar mod first,
verifying that the icon is blank purple without this PR,
and then it works after this PR.