### PR TITLE
Fixes #2457 by removing not-working IsAvailable checks.

### DIFF
--- a/src/kOS/AddOns/RemoteTech/Addon.cs
+++ b/src/kOS/AddOns/RemoteTech/Addon.cs
@@ -3,6 +3,7 @@ using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Suffixed;
 using kOS.Suffixed.Part;
 using System.Linq;
+using System;
 
 namespace kOS.AddOns.RemoteTech
 {
@@ -30,31 +31,32 @@ namespace kOS.AddOns.RemoteTech
         private static ScalarValue RTGetDelay(VesselTarget tgtVessel)
         {
             double waitTotal = 0;
-
-            if (RemoteTechHook.IsAvailable(tgtVessel.Vessel.id) && tgtVessel.Vessel.GetVesselCrew().Count == 0)
+            if (RemoteTechHook.IsAvailable())
             {
                 waitTotal = RemoteTechHook.Instance.GetShortestSignalDelay(tgtVessel.Vessel.id);
             }
-
-            return waitTotal;
+            return Double.IsPositiveInfinity(waitTotal) ? -1 : waitTotal;
         }
 
         private static ScalarValue RTGetKSCDelay(VesselTarget tgtVessel)
         {
             double waitTotal = 0;
 
-            if (RemoteTechHook.IsAvailable(tgtVessel.Vessel.id) && tgtVessel.Vessel.GetVesselCrew().Count == 0)
+            if (RemoteTechHook.IsAvailable() && tgtVessel.Vessel.GetVesselCrew().Count == 0)
             {
                 waitTotal = RemoteTechHook.Instance.GetSignalDelayToKSC(tgtVessel.Vessel.id);
             }
 
-            return waitTotal;
+            return Double.IsPositiveInfinity(waitTotal) ? -1 : waitTotal;
         }
 
         private static BooleanValue RTAntennaHasConnection(PartValue part)
         {
             bool result = false;
 
+            // IsAvailable(Id) is only able to return True on loaded vessels, but this
+            // is a test for a specific PART on a vessel, and individual parts on
+            // vessels don't exist when the vessel is unloaded anyway.
             if (RemoteTechHook.IsAvailable(part.Part.vessel.id))
             {
                 result = RemoteTechHook.Instance.AntennaHasConnection(part.Part);
@@ -67,7 +69,7 @@ namespace kOS.AddOns.RemoteTech
         {
             bool result = false;
 
-            if (RemoteTechHook.IsAvailable(tgtVessel.Vessel.id))
+            if (RemoteTechHook.IsAvailable())
             {
                 result = RemoteTechHook.Instance.HasAnyConnection(tgtVessel.Vessel.id);
             }
@@ -79,11 +81,11 @@ namespace kOS.AddOns.RemoteTech
         {
             bool result = false;
 
-            if (RemoteTechHook.IsAvailable(tgtVessel.Vessel.id))
+            if (RemoteTechHook.IsAvailable())
             {
                 result = RemoteTechHook.Instance.HasLocalControl(tgtVessel.Vessel.id);
             }
-
+    
             return result;
         }
 
@@ -91,7 +93,7 @@ namespace kOS.AddOns.RemoteTech
         {
             bool result = false;
 
-            if (RemoteTechHook.IsAvailable(tgtVessel.Vessel.id))
+            if (RemoteTechHook.IsAvailable())
             {
                 result = RemoteTechHook.Instance.HasConnectionToKSC(tgtVessel.Vessel.id);
             }

--- a/src/kOS/AddOns/RemoteTech/RemoteTechConnectivityManager.cs
+++ b/src/kOS/AddOns/RemoteTech/RemoteTechConnectivityManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using kOS.Communication;
 using kOS.Module;
 
@@ -39,26 +39,27 @@ namespace kOS.AddOns.RemoteTech
 
         public double GetDelay(Vessel vessel1, Vessel vessel2)
         {
-            if (!(RemoteTechHook.IsAvailable(vessel1.id) && RemoteTechHook.IsAvailable(vessel2.id)))
-                return -1; // default to no connection if one of the vessels isn't configured for RT.
+            if (!(RemoteTechHook.IsAvailable()))
+                return -1; // default to no connection if RT itself isn't available.
             double delay = RemoteTechHook.Instance.GetSignalDelayToSatellite(vessel1.id, vessel2.id);
-            return delay != double.PositiveInfinity ? delay : -1;
+            return Double.IsPositiveInfinity(delay) ? -1 : delay;
         }
 
         public double GetDelayToControl(Vessel vessel)
         {
-            if (!RemoteTechHook.IsAvailable(vessel.id))
-                return -1; // default to no connection if the vessel isn't configured for RT.
+            if (!RemoteTechHook.IsAvailable())
+                return -1; // default to no connection if RT itself isn't available.
             if (RemoteTechHook.Instance.HasLocalControl(vessel.id)) return 0d;
-            return RemoteTechHook.Instance.GetShortestSignalDelay(vessel.id);
+            double delay = RemoteTechHook.Instance.GetShortestSignalDelay(vessel.id);
+            return Double.IsPositiveInfinity(delay) ? -1 : delay;
         }
 
         public double GetDelayToHome(Vessel vessel)
         {
-            if (!RemoteTechHook.IsAvailable(vessel.id))
-                return -1; // default to no connection if the vessel isn't configured for RT.
+            if (!RemoteTechHook.IsAvailable())
+                return -1; // default to no connection if RT itself isn't available.
             double delay = RemoteTechHook.Instance.GetSignalDelayToKSC(vessel.id);
-            return delay != double.PositiveInfinity ? delay : -1;
+            return Double.IsPositiveInfinity(delay) ? -1 : delay;
         }
 
         public bool HasConnection(Vessel vessel1, Vessel vessel2)
@@ -69,15 +70,15 @@ namespace kOS.AddOns.RemoteTech
 
         public bool HasConnectionToHome(Vessel vessel)
         {
-            if (!RemoteTechHook.IsAvailable(vessel.id))
-                return false; // default to no connection if the vessel isn't configured for RT.
+            if (!RemoteTechHook.IsAvailable())
+                return false; // default to no connection if RT itself isn't available.
             return RemoteTechHook.Instance.HasConnectionToKSC(vessel.id);
         }
 
         public bool HasConnectionToControl(Vessel vessel)
         {
-            if (!RemoteTechHook.IsAvailable(vessel.id))
-                return vessel.CurrentControlLevel >= Vessel.ControlLevel.PARTIAL_MANNED; // default to checking for local control if the vessel isn't configured for RT.
+            if (!RemoteTechHook.IsAvailable())
+                return vessel.CurrentControlLevel >= Vessel.ControlLevel.PARTIAL_MANNED; // default to checking for local control if RT itself isn't available.
             return RemoteTechHook.Instance.HasAnyConnection(vessel.id) || RemoteTechHook.Instance.HasLocalControl(vessel.id);
         }
 

--- a/src/kOS/AddOns/RemoteTech/RemoteTechHook.cs
+++ b/src/kOS/AddOns/RemoteTech/RemoteTechHook.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using kOS.Safe.Utilities;
 using kOS.Suffixed;
@@ -24,6 +24,15 @@ namespace kOS.AddOns.RemoteTech
             }
         }
 
+        /// <summary>
+        /// True if Not ONLY does the vessel exist and Remote Tech is enabled,
+        /// but ALSO, the vessel is *loaded* and has a ModuleSPU.  Note that if
+        /// the vessel does have a ModuleSPU but is *NOT* loaded (i.e. it's outside
+        /// the physics bubble), then this will return False *no matter what*,
+        /// because Remote Tech removes the Flight Computer from all distant vessels.
+        /// </summary>
+        /// <param name="vesselId"></param>
+        /// <returns></returns>
         public static bool IsAvailable(Guid vesselId)
         {
             try


### PR DESCRIPTION
Fixes #2457 

The RT call HasFlightComputer(guid) will always return false
for any unloaded vessel.  Our protection check, IsAvailable(guid)
was there to stop us from calling API routines on vessels where
doing so would throw nullref, but it also used HasFlightComputer(),
which has this undesirable side-effect of failing on distant
unloaded vessels.

In the meantime since that code was written, Remote Tech has
made changes to their API routins that added protections against
these nullrefs so we can now unconditionally call them without
worry of a crash.  That removed the need for us to call
IsAvailable(guid) all over the place, but we still call
the other version of IsAvailable() (no guid), that is just
checking for whether RT exists period and not checking for
any specific vessel.

(Also, shifted some Infinity checks to the slightly more proper
Double.IsInfinity, just because IEEE suggests using that over
direct value equals).