### PR TITLE
Fixes #2470 by dropping priority after crash

### DIFF
--- a/src/kOS.Safe/Execution/CPU.cs
+++ b/src/kOS.Safe/Execution/CPU.cs
@@ -1322,6 +1322,12 @@ namespace kOS.Safe.Execution
                     // interpreter context
                     SkipCurrentInstructionId();
                     stack.Clear(); // Get rid of this interpreter command's cruft.
+
+                    // If it threw exception during a trigger with higher priority (like lock steering) before
+                    // reaching its OpcodeReturn, it's important to drop the interpreter context's priority
+                    // back down so interrupts will work correctly again.  Unlike with a *Program*, with the
+                    // interpreter we're re-using the same programcontext after the crash:
+                    CurrentPriority = InterruptPriority.Normal;
                 }
                 else
                 {
@@ -1367,7 +1373,7 @@ namespace kOS.Safe.Execution
             for (int index = 0 ; index < currentContext.ActiveTriggerCount() ; ++index)
             {
                 TriggerInfo trigger = currentContext.GetTriggerByIndex(index);
-                
+
                 // If the program is ended from within a trigger, the trigger list will be empty and the pointer
                 // will be invalid.  Only execute the trigger if it still exists, AND if it's of a higher priority
                 // than the current CPU priority level.  (If it's the same or less priority as the curent CPU priority,

--- a/src/kOS.Safe/Execution/ProgramContext.cs
+++ b/src/kOS.Safe/Execution/ProgramContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using kOS.Safe.Binding;
 using kOS.Safe.Compilation;

--- a/src/kOS.Safe/Execution/TriggerInfo.cs
+++ b/src/kOS.Safe/Execution/TriggerInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using kOS.Safe.Encapsulation;
 using kOS.Safe.Execution;
@@ -202,6 +202,7 @@ public class TriggerInfo
     
     public override string ToString()
     {
-        return string.Format("TriggerInfo: {0}:{1}:(arg count: {2})", EntryPoint, (IsCSharpCallback ? "callback" : "non-callback"), Args.Count);
+        return string.Format("TriggerInfo: {0}:{1}:(arg count: {2}):{3}",
+            EntryPoint, (IsCSharpCallback ? "callback" : "non-callback"), Args.Count, Priority);
     }
 }


### PR DESCRIPTION
Fixes #2470 

Unlike with programs, in the interpreter the program context
that "crashed" is being re-used when an exception is thrown.
That meant the execution priority needed a reset.