### PR TITLE
Fixes #2475 - add constructor for TimeSpan

### DIFF
--- a/doc/source/structures/misc/time.rst
+++ b/doc/source/structures/misc/time.rst
@@ -25,6 +25,26 @@ the following points illustrate:
 
 This allows you to use a :struct:`TimeSpan` such as is returned by the :global:`TIME` special variable to make correct physics calculations.
 
+Built-in function TIME
+----------------------
+
+.. function:: TIME(universal_time)
+
+    :parameter universal_time: (:struct:`Scalar`)
+    :return: A :struct`TimeSpan` of the time represented by the seconds timestamp passed in.
+    :rtype: :struct:`TimeSpan`
+
+    This creates a :struct:`TimeSpan` given a "universal time",
+    which is a number of seconds since the current game began,
+    IN GAMETIME.  example: ``TIME(3600)`` will give you a
+    :struct:`TimeSpan` representing the moment exactly 1 hour
+    (3600 seconds) since the current game first began.
+
+    The parameter is OPTIONAL.  If you leave it off,
+    and just call ``TIME()``, then you end up getting
+    the current time, which is the same thing that :global:`TIME`
+    gives you (without the parentheses).
+
 Special variable TIME
 ---------------------
 
@@ -33,9 +53,15 @@ Special variable TIME
     :access: Get only
     :type: :struct:`TimeSpan`
 
-    The special variable :global:`TIME` is used to get the current time.
+    The special variable :global:`TIME` is used to get the current time
+    in the gameworld (not the real world where you're sitting in a chair
+    playing Kerbal Space Program.)  It is the same thing as calling
+    :function:`TIME` with empty parentheses.
 
-    Any time you perform arithmetic on :global:`TIME` you get a result back that is also a :struct:`TimeSpan`. In other words, :global:`TIME` is a :struct:`TimeSpan`, but ``TIME + 100`` is also a :struct:`TimeSpan`.
+Using a TimeSpan
+----------------
+
+    Any time you perform arithmetic on a :global:`TIMESPAN` you get a result back that is also a :struct:`TimeSpan`. In other words, :global:`TIME` is a :struct:`TimeSpan`, but ``TIME + 100`` is also a :struct:`TimeSpan`.
 
     Note that Kerbals do not have the concept of "months"::
 
@@ -51,12 +77,12 @@ Special variable TIME
 
 .. highlight:: kerboscript
 
-Using TIME to detect when the physics have been updated 'one tick'
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Using TIME or TIME() to detect when the physics have been updated 'one tick'
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The game will make an effort to maintain regular physics updates at a fixed rate (defaulting to 25 updates per second), sacrificing animation rate as necessary.  When the game is unable to maintain regular updates at this rate, the clock time (in the upper left of the screen) will turn yellow or red instead of green.
 
-You can use the :global:`TIME` special variable to detect whether or not a real physics 'tic' has occurred yet, which can be important for scripts that need to take measurements from the simulated universe. If no physics tic has occurred, then :global:`TIME` will still be exactly the same value.
+You can use the time reported by :global:`TIME` to detect whether or not a real physics 'tic' has occurred yet, which can be important for scripts that need to take measurements from the simulated universe. If no physics tic has occurred, then :global:`TIME` will still be exactly the same value.
 
 .. warning::
 

--- a/src/kOS/Binding/FlightStats.cs
+++ b/src/kOS/Binding/FlightStats.cs
@@ -24,6 +24,10 @@ namespace kOS.Binding
             shared.BindingMgr.AddGetter("ETA", () => new VesselEta(shared));
             shared.BindingMgr.AddGetter("MISSIONTIME", () => shared.Vessel.missionTime);
             shared.BindingMgr.AddGetter(new [] { "OBT" , "ORBIT"}, () => new OrbitInfo(shared.Vessel.orbit,shared));
+            // Note: "TIME" is both a bound variable AND a built-in function now.
+            // While it would be cleaner to make it JUST a built -in function,
+            // the bound variable had to be retained for backward compatibility with scripts
+            // that call TIME without parentheses:
             shared.BindingMgr.AddGetter("TIME", () => new TimeSpan(Planetarium.GetUniversalTime()));
             shared.BindingMgr.AddGetter("ACTIVESHIP", () => VesselTarget.CreateOrGetExisting(FlightGlobals.ActiveVessel, shared));
             shared.BindingMgr.AddGetter("STATUS", () => shared.Vessel.situation.ToString());

--- a/src/kOS/Function/Misc.cs
+++ b/src/kOS/Function/Misc.cs
@@ -1,4 +1,4 @@
-﻿using kOS.Execution;
+using kOS.Execution;
 using kOS.Safe.Compilation;
 using kOS.Safe.Exceptions;
 using kOS.Safe.Execution;

--- a/src/kOS/Function/Suffixed.cs
+++ b/src/kOS/Function/Suffixed.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Collections.Generic;
 using System.Linq;
@@ -273,6 +273,34 @@ namespace kOS.Function
         public override void Execute(SharedObjects shared)
         {
             shared.SoundMaker.StopAllVoices();
+        }
+    }
+
+    [Function("time")]
+    public class Time : FunctionBase
+    {
+        // Note: "TIME" is both a bound variable AND a built-in function now.
+        // If it gets called with parentheses(), the script calls this built-in function.
+        // If it gets called without them, then the bound variable is what gets called instead.
+        // Calling it using parentheses but with empty args: TIME() gives the same result
+        // as the bound variable.  While it would be cleaner to make it JUST a built-in function,
+        // the bound variable had to be retained for backward compatibility with scripts
+        // that call TIME without parentheses.
+        public override void Execute(SharedObjects shared)
+        {
+            double ut;
+            // Accepts zero or one arg:
+            int argCount = CountRemainingArgs(shared);
+
+            // If zero args, then the default is to assume you want to
+            // make a Timespan of "now":
+            if (argCount == 0)
+                ut = Planetarium.GetUniversalTime();
+            else
+                ut = GetDouble(PopValueAssert(shared));
+            AssertArgBottomAndConsume(shared);
+
+            ReturnValue = new kOS.Suffixed.TimeSpan(ut);
         }
     }
 


### PR DESCRIPTION
Fixes #2475

Adds constructor for TimeSpan.

Had to leave the old bound variable TIME in place because you can't call the built-in function TIME() without parentheses unless you make special case rules in the parser, which doesn't seem like the right way to go.  To keep backward compatibility, we have to let scripts keep getting TIME with the parentheses left off.
