### PR TITLE
In converting the syntax form, an == became !=

### DIFF
--- a/src/kOS/Suffixed/Part/EngineValue.cs
+++ b/src/kOS/Suffixed/Part/EngineValue.cs
@@ -38,7 +38,7 @@ namespace kOS.Suffixed.Part
                 var e = module as ModuleEngines;
                 if (mme != null)
                 {
-                    if (Multi != null)
+                    if (Multi == null)
                         Multi = mme;
                     else
                         SafeHouse.Logger.LogWarning("Multiple MultiModeEngine on {0}: {1}", part.name, part.partInfo.title);


### PR DESCRIPTION
Fixes #2452:
The original PR had used newer C# syntactic sugar that wasn't
easy to read and so it was converted back to older syntax
styles.  But in so doing, a "==" was accidentally flipped to
a "!=" in one spot in the code, which is what caused the problem.