### PR TITLE
Fixes #2456 by moving the dialog box

### DIFF
--- a/src/kOS/Communication/kOSConnectivityParameters.cs
+++ b/src/kOS/Communication/kOSConnectivityParameters.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -185,6 +185,9 @@ namespace kOS.Communication
                     options.Add(new DialogGUIButton(text, () => { connectivityHandler = name; }, true));
                 }
                 Module.kOSSettingsChecker.QueueDialog(
+                    // Using 1.5, 1.5 fixes github issue #2456 by making it shift a
+                    // bit down and left from center (1.5 times box's own width)
+                    1.5f, 1.5f,
                     new MultiOptionDialog(
                         "Select Dialog",
                         SELECT_DIALOG_TEXT,

--- a/src/kOS/Module/kOSCustomParameters.cs
+++ b/src/kOS/Module/kOSCustomParameters.cs
@@ -1,4 +1,4 @@
-﻿using KSP.IO;
+using KSP.IO;
 using System;
 using System.Reflection;
 
@@ -181,7 +181,9 @@ namespace kOS.Module
                 // the new system, or that the user selected to prevent future migrations.
                 if (ipu > 0)
                 {
-                    kOSSettingsChecker.QueueDialog(new MultiOptionDialog(
+                    kOSSettingsChecker.QueueDialog(
+                        0.5f, 0.5f, // causes it to be centered (half of box's own width left and down from center is the corner).
+                        new MultiOptionDialog(
                             "Migration Dialog",
                             MIGRATION_DIALOG_TEXT,
                             "kOS",

--- a/src/kOS/Module/kOSSettingsChecker.cs
+++ b/src/kOS/Module/kOSSettingsChecker.cs
@@ -75,11 +75,14 @@ namespace kOS.Module
             // that (1.5f) for "X coord" means "150% of the width it
             // took to draw the box".  Also, positive is to the lower-
             // left and negative is to the upper-right, for some
-            // godforsaken reason.  Also, setting Min and Max to the
+            // reason I don't understand.  Setting Min and Max to the
             // same numbers works, while setting them to different
-            // numbers starts doing random gibberish things, therefore
-            // we will just pass in the same value for mins and maxes
-            // when using this:
+            // numbers starts doing random things I don't understand.
+            // Therefore we will just pass in the same value for mins
+            // and maxes when using this.  There is a chance this system
+            // actually does make sense, but it's undocumented what these
+            // numbers were meant to represent, so it's hard by trial
+            // and error to make sense of it:
             public Vector2 anchor;
         }
     }

--- a/src/kOS/Module/kOSSettingsChecker.cs
+++ b/src/kOS/Module/kOSSettingsChecker.cs
@@ -1,4 +1,4 @@
-﻿using kOS.Communication;
+using kOS.Communication;
 using kOS.Safe.Utilities;
 using System.Collections.Generic;
 using UnityEngine;
@@ -8,7 +8,7 @@ namespace kOS.Module
     [KSPAddon(KSPAddon.Startup.SpaceCentre, false)]
     public class kOSSettingsChecker : MonoBehaviour
     {
-        private static Queue<MultiOptionDialog> dialogsToSpawn = new Queue<MultiOptionDialog>();
+        private static Queue<MultiOptionDialogWithAnchor> dialogsToSpawn = new Queue<MultiOptionDialogWithAnchor>();
         private static bool dialogShown = false;
 
         public void Start()
@@ -27,22 +27,22 @@ namespace kOS.Module
         // Because rapidly showing dialogs can prevent some from being shown, we can just queue up
         // any dialogs that we want to show.  This also ensures that the first dialog displayed is
         // guaranteed to be the first one queued.
-        public static void QueueDialog(MultiOptionDialog dialog)
+        public static void QueueDialog(float xAnchor, float yAnchor, MultiOptionDialog dialog)
         {
             if (dialogShown)
             {
-                dialogsToSpawn.Enqueue(dialog);
+                dialogsToSpawn.Enqueue(new MultiOptionDialogWithAnchor() { dialog = dialog, anchor = new Vector2(xAnchor, yAnchor) });
             }
             else
             {
-                ShowDialog(dialog);
+                ShowDialog(new MultiOptionDialogWithAnchor() { dialog = dialog, anchor = new Vector2(xAnchor, yAnchor) });
             }
         }
 
-        private static void ShowDialog(MultiOptionDialog dialog)
+        private static void ShowDialog(MultiOptionDialogWithAnchor dialog)
         {
             dialogShown = true;
-            var popup = PopupDialog.SpawnPopupDialog(dialog, true, HighLogic.UISkin);
+            var popup = PopupDialog.SpawnPopupDialog(dialog.anchor, dialog.anchor, dialog.dialog, true, HighLogic.UISkin);
             popup.onDestroy.AddListener(new UnityEngine.Events.UnityAction(OnDialogDestroy));
         }
 
@@ -61,6 +61,26 @@ namespace kOS.Module
                 // on those settings, it should be signaled to refresh the values.
                 GameEvents.OnGameSettingsApplied.Fire();
             }
+        }
+
+        private struct MultiOptionDialogWithAnchor
+        {
+            public MultiOptionDialog dialog;
+
+            // Passed into KSP's dialog call directly:
+            // KSP's standard dialog box maker allows you to pass in
+            // settings for AnchorMax and AnchorMin, which as far as
+            // I can tell from experimentation, seems to be coords
+            // relative to the size of the dialog box itself.  So
+            // that (1.5f) for "X coord" means "150% of the width it
+            // took to draw the box".  Also, positive is to the lower-
+            // left and negative is to the upper-right, for some
+            // godforsaken reason.  Also, setting Min and Max to the
+            // same numbers works, while setting them to different
+            // numbers starts doing random gibberish things, therefore
+            // we will just pass in the same value for mins and maxes
+            // when using this:
+            public Vector2 anchor;
         }
     }
 }


### PR DESCRIPTION
Fixes #2456

The PopupDialog.SpawnPopupDialog() call from stock KSP's API
allows you to pass in some "anchor" coordinates to move
the window - but it took trial and error to work out what
those coordinates really meant.  They weren't intuitive
(see the comment in the PR for further explanation).

But in the end I finally managed to move the window.
Note that the same call is in a spot of our code used
by another dialog window, so I had to make a way to preserve
it's previous (centered) behavior, so I had to add a little
extra stuff to make it possible to pass in x,y values to
QueueDialog and remember them with the dialog box.

It's very hard to regression-test that I didn't break that
second dialog box (the "migration dialog") because it's
only triggered if you take a very old saved game and try
to migrate it to newer kOS.  It was years ago when that was
a relevant thing and it's nearly impossible to test now
without getting some old copies of KSP.  I'm happy leaving
that part untested, as I couldn't easily make it happen, and
anyone who thinks their 3-year old KSP saved game will still
work fine today is going to run into lots of other migration
issues besides just kOS.