### PR TITLE
Fixes #2461 adding LIST FONTS command.

### DIFF
--- a/doc/source/commands/list.rst
+++ b/doc/source/commands/list.rst
@@ -43,6 +43,14 @@ These generate :struct:`lists <List>` that are not dependent on which :struct:`V
 ``Targets``
     :struct:`List` of possible target :struct:`Vessels <Vessel>`
 
+.. _list_fonts:
+
+``Fonts``
+    :struct:`List` of available font names for use with either
+    :attr:`Style:FONT` or :attr:`Skin:FONT`. This list includes
+    everything that has been loaded into the game engine by
+    either KSP itself or by one of the KSP mods you have installed.
+
 Vessel Lists
 ^^^^^^^^^^^^
 

--- a/doc/source/structures/gui_widgets/skin.rst
+++ b/doc/source/structures/gui_widgets/skin.rst
@@ -230,6 +230,17 @@ Skin
         :access: Get/Set
 
         The name of the font used (if STYLE:FONT does not change it for an element).
+        If you want to see the list of available font names, you can do
+        so with :ref:`List Fonts. <list_fonts>`.  Please note that just
+        because you see a font in that list on your computer,
+        that doesn't always mean that same font will exist on
+        someone else's computer.  KSP ships with a few fonts that it
+        does universally put on all platform installs, but other
+        fonts in that list might be installed locally on your computer
+        only by other mods (like kOS itself, which loads all your
+        monospaced fonts for optional use as the terminal font).
+        Fonts that we know KSP itself tends to install are:
+        Arial, CALIBRI, HEADINGFONT, calibri, calibrib, calibriz, calibril, and dotty
 
     .. attribute:: SELECTIONCOLOR
 

--- a/doc/source/structures/gui_widgets/style.rst
+++ b/doc/source/structures/gui_widgets/style.rst
@@ -114,6 +114,17 @@ Style
         :access: Get/Set
 
         The name of the font of the text on the content or "" if the default.
+        If you want to see the list of available font names, you can do
+        so with :ref:`List Fonts. <list_fonts>`.  Please note that just
+        because you see a font in that list on your computer,
+        that doesn't always mean that same font will exist on
+        someone else's computer.  KSP ships with a few fonts that it
+        does universally put on all platform installs, but other
+        fonts in that list might be installed locally on your computer
+        only by other mods (like kOS itself, which loads all your
+        monospaced fonts for optional use as the terminal font).
+        Fonts that we know KSP itself tends to install are:
+        Arial, CALIBRI, HEADINGFONT, calibri, calibrib, calibriz, calibril, and dotty
 
     .. attribute:: FONTSIZE
 

--- a/src/kOS/Function/BuildList.cs
+++ b/src/kOS/Function/BuildList.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 using System.Linq;
 using kOS.Safe.Encapsulation;
 using kOS.Safe.Function;
 using kOS.Suffixed;
 using kOS.Utilities;
 using kOS.Suffixed.PartModuleField;
+using UnityEngine;
 
 namespace kOS.Function
 {
@@ -47,6 +48,12 @@ namespace kOS.Function
                     break;
                 case "processors":
                     list = ListValue.CreateList(shared.ProcessorMgr.processors.Values.ToList().Select(processor => PartModuleFieldsFactory.Construct(processor, shared)));
+                    break;
+                case "fonts":
+                    foreach(Font f in Resources.FindObjectsOfTypeAll<Font>())
+                    {
+                        list.Add(new StringValue(f.name));
+                    }
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();

--- a/src/kOS/Function/PrintList.cs
+++ b/src/kOS/Function/PrintList.cs
@@ -5,6 +5,7 @@ using kOS.Safe.Function;
 using kOS.Safe.Persistence;
 using kOS.Suffixed;
 using kOS.Suffixed.Part;
+using UnityEngine;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -67,6 +68,10 @@ namespace kOS.Function
 
                 case "config":
                     list = GetConfigList();
+                    break;
+
+                case "fonts":
+                    list = GetFontList();
                     break;
 
                 default:
@@ -155,6 +160,19 @@ namespace kOS.Function
             foreach (var body in FlightGlobals.fetch.bodies)
             {
                 list.AddItem(body.bodyName, Vector3d.Distance(body.position, shared.Vessel.CoMD));
+            }
+
+            return list;
+        }
+
+        private kList GetFontList()
+        {
+            var list = new kList();
+            list.AddColumn("Font Name", 15, ColumnAlignment.Left);
+
+            foreach (Font f in Resources.FindObjectsOfTypeAll<Font>())
+            {
+                list.AddItem(f.name);
             }
 
             return list;


### PR DESCRIPTION
Fixes #2461

Offers this new feature to print the font names installed in the game:

```
LIST FONTS.
// or this:
LIST FONTS IN FOO.
```

I originally wanted to put the font list on a suffix
of something and not add more to the old LIST blarg IN FOO
command, but there was nowhere to put it that was "static"
rather than "instance".  It didn't make sense to say something
like this to get at it, having to use a constructed instance
of something to get at the suffix:

```
local Gwin is GUI().
print Gwin:fontnames.
```

When the suffix is inherently a "static" thing.  kerboscript
sort of lacks the idea of "static" members of a Structure,
so I went with the old LIST blarg IN FOO syntax to offer
this feature.