### PR TITLE
Fixes #2491 with safe wrapper around GetTypes().

### DIFF
--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using System.Linq;
 using System.Collections.Generic;
@@ -310,7 +310,7 @@ namespace kOS.Safe.Compilation
             
             // List of all subclasses of Opcode:
             Type opcodeType = typeof(Opcode);
-            IEnumerable<Type> opcodeTypes = opcodeType.Assembly.GetTypes().Where( t => t.IsSubclassOf(opcodeType) );
+            IEnumerable<Type> opcodeTypes = ReflectUtil.GetLoadedTypes(opcodeType.Assembly).Where( t => t.IsSubclassOf(opcodeType) );
             foreach (Type opType in opcodeTypes)
             {
                 if (!opType.IsAbstract) // only the ones that can be instanced matter.

--- a/src/kOS.Safe/Serialization/SafeSerializationMgr.cs
+++ b/src/kOS.Safe/Serialization/SafeSerializationMgr.cs
@@ -182,7 +182,7 @@ namespace kOS.Safe.Serialization
 
             // All the classes in which the class is derived from IDumper, and instances of the class are
             // actually constructable because it isn't Abstract:
-            IEnumerable<Type> iDumperClasses = allKSPAssemblies.SelectMany(a => a.GetTypes()).Where(
+            IEnumerable<Type> iDumperClasses = allKSPAssemblies.SelectMany(a => ReflectUtil.GetLoadedTypes(a)).Where(
                 b => dumperInterface.IsAssignableFrom(b) && b.IsClass && !b.IsAbstract);
 
             List<string> offendingClasses = new List<string>();

--- a/src/kOS.Safe/Utilities/AssemblyWalkAttribute.cs
+++ b/src/kOS.Safe/Utilities/AssemblyWalkAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -115,7 +115,7 @@ namespace kOS.Safe.Utilities
 
         public static void LoadWalkAttribute(Assembly assembly)
         {
-            foreach (Type type in assembly.GetTypes())
+            foreach (Type type in ReflectUtil.GetLoadedTypes(assembly))
             {
                 var attr = type.GetCustomAttributes(typeof(AssemblyWalkAttribute), true).FirstOrDefault() as AssemblyWalkAttribute;
                 if (attr != null)
@@ -222,7 +222,7 @@ namespace kOS.Safe.Utilities
 
         public static void WalkAssembly(Assembly assembly)
         {
-            foreach (Type type in assembly.GetTypes())
+            foreach (Type type in ReflectUtil.GetLoadedTypes(assembly))
             {
                 foreach (AssemblyWalkAttribute walkAttribute in AllWalkAttributes.Keys)
                 {

--- a/src/kOS.Safe/Utilities/ReflectUtil.cs
+++ b/src/kOS.Safe/Utilities/ReflectUtil.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Reflection;
+
+namespace kOS.Safe.Utilities
+{
+    /// <summary>
+    /// kOS Utilities to help perform common Reflection operations
+    /// </summary>
+    public class ReflectUtil
+    {
+        /// <summary>
+        /// Avoid using System.Reflection.Assembly.GetTypes() in a KSP mod that
+        /// wants to walk over all the Assemblies getting all their Types, and instead call this.
+        ///  
+        /// Doing so fixes https://github.com/KSP-KOS/KOS/issues/2491.
+        /// 
+        /// If there was an exception during the loading of Assembly from its DLL, then the
+        /// types that failed to load will simply be culled from this list rather than the
+        /// default GetTypes() behavior of aborting with an exception.
+        /// (That may mean it's a list of zero length if the entire DLL failed to load.)
+        /// </summary>
+        /// <param name="assembly"></param>
+        public static Type[] GetLoadedTypes(Assembly assembly)
+        {
+            try
+            {
+                // If there are no Types that failed to load, then we can just return the normal result
+                // of GetTypes().
+                return assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException exception)
+            {
+                // If our DLLs *or any another mod's DLL outside our control* has enough of a
+                // version mismatch with KSP that it can't load, then calling that
+                // Assembly's GetTypes() throws this exception.
+
+                // But this exception doesn't actually abort GetTypes()' work.  It still
+                // does build the full list.  It just stores that list
+                // in the exception's 'Types' member instead of returning it.
+
+                // BUT, that list will contain some nulls in it - placeholders for where
+                // the missing Types would have appeared in the list had they been loaded.
+                // Getting rid of those nulls should result in just the types that actually
+                // are loaded, which is what we really want:
+                return exception.Types.Where(t => t != null).ToArray();
+
+                // There is no error message logged here because presumably failing to load
+                // one of the classes should have resulted in that mod failing to work, with
+                // plenty of other error messages that are "nearer to the cause" than this is.
+            }
+        }
+    }
+}

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -230,6 +230,7 @@
     <Compile Include="Utilities\KOSNomenclature.cs" />
     <Compile Include="Utilities\KOSNomenclatureAttribute.cs" />
     <Compile Include="Utilities\MovingAverage.cs" />
+    <Compile Include="Utilities\ReflectUtil.cs" />
     <Compile Include="Utilities\SafeHouse.cs" />
     <Compile Include="Utilities\Flushable.cs" />
     <Compile Include="Utilities\kOSKeys.cs" />

--- a/src/kOS/AddOns/RemoteTech/RemoteTechHook.cs
+++ b/src/kOS/AddOns/RemoteTech/RemoteTechHook.cs
@@ -63,8 +63,8 @@ namespace kOS.AddOns.RemoteTech
             if (loadedAssembly == null) return null;
             SafeHouse.Logger.Log(string.Format("Found RemoteTech! Version: {0}.{1}", loadedAssembly.versionMajor, loadedAssembly.versionMinor)); 
 
-            var type = loadedAssembly.assembly.GetTypes().FirstOrDefault(t => t.FullName.Equals(REMOTE_TECH_API)) ??
-                       loadedAssembly.assembly.GetTypes().FirstOrDefault(t => t.FullName.Equals(ALT_REMOTE_TECH_API));
+            var type = ReflectUtil.GetLoadedTypes(loadedAssembly.assembly).FirstOrDefault(t => t.FullName.Equals(REMOTE_TECH_API)) ??
+                       ReflectUtil.GetLoadedTypes(loadedAssembly.assembly).FirstOrDefault(t => t.FullName.Equals(ALT_REMOTE_TECH_API));
 
             if (type == null) return null;
 


### PR DESCRIPTION
Replace all calls to System.Reflection.Assembly.GetTypes() with this new wrapper, and it makes issue #2491 go away.