### PR TITLE
Support for parts with multiple engines which aren't multi-mode.

### DIFF
--- a/src/kOS/Suffixed/Part/EngineValue.cs
+++ b/src/kOS/Suffixed/Part/EngineValue.cs
@@ -146,13 +146,19 @@ namespace kOS.Suffixed.Part
         public void Activate()
         {
             ThrowIfNotCPUVessel();
-            FilteredEngineList.ForEach(e => e.Activate());
+            foreach (ModuleEngines e in FilteredEngineList)
+            {
+                e.Activate();
+            }
         }
 
         public void Shutdown()
         {
             ThrowIfNotCPUVessel();
-            FilteredEngineList.ForEach(e => e.Shutdown());
+            foreach (ModuleEngines e in FilteredEngineList)
+            {
+                e.Shutdown();
+            }
         }
 
         // The following functions calculate the correct Isp for multiple engines, regardless of individual performance.

--- a/src/kOS/Suffixed/Part/EngineValue.cs
+++ b/src/kOS/Suffixed/Part/EngineValue.cs
@@ -13,18 +13,18 @@ namespace kOS.Suffixed.Part
     [kOS.Safe.Utilities.KOSNomenclature("Engine")]
     public class EngineValue : PartValue
     {
-        public List<ModuleEngines> EngineList { get; private set; }
+        private List<ModuleEngines> RawEngineList { get; set; }
         public MultiModeEngine Multi { get; private set; }
         public GimbalFields Gimbal { get; private set; }
-        public IEnumerable<ModuleEngines> Engines {
+        public IEnumerable<ModuleEngines> FilteredEngineList {
             get {
-                if (EngineList.Count > 0 && Multi != null)
+                if (RawEngineList.Count > 0 && Multi != null)
                 {
-                    return EngineList.Count < 2 || Multi.runningPrimary ? EngineList.GetRange(0, 1) : EngineList.GetRange(1, 1);
+                    return RawEngineList.Count < 2 || Multi.runningPrimary ? RawEngineList.GetRange(0, 1) : RawEngineList.GetRange(1, 1);
                 }
                 else
                 {
-                    return EngineList;
+                    return RawEngineList;
                 }
             }
         }
@@ -37,7 +37,7 @@ namespace kOS.Suffixed.Part
         internal EngineValue(SharedObjects shared, global::Part part, PartValue parent, DecouplerValue decoupler)
             : base(shared, part, parent, decoupler)
         {
-            EngineList = new List<ModuleEngines>();
+            RawEngineList = new List<ModuleEngines>();
             foreach (var module in part.Modules)
             {
                 var mme = module as MultiModeEngine;
@@ -51,12 +51,12 @@ namespace kOS.Suffixed.Part
                 }
                 else if (e != null)
                 {
-                    EngineList.Add(e);
+                    RawEngineList.Add(e);
                 }
             }
-            if (EngineList.Count < 1)
+            if (RawEngineList.Count < 1)
                 throw new KOSException("Attempted to build an Engine from part with no ModuleEngines on {0}: {1}", part.name, part.partInfo.title);
-            if (EngineList.Count < 2)
+            if (RawEngineList.Count < 2)
             {
                 if (Multi != null)
                     SafeHouse.Logger.LogWarning("MultiModeEngine without second engine on {0}: {1}", part.name, part.partInfo.title);
@@ -65,16 +65,16 @@ namespace kOS.Suffixed.Part
             {
                 if (Multi != null)
                 {
-                    if (Multi.primaryEngineID == EngineList[1].engineID)
+                    if (Multi.primaryEngineID == RawEngineList[1].engineID)
                     {
-                        EngineList.Reverse();
+                        RawEngineList.Reverse();
                     }
-                    else if (Multi.primaryEngineID != EngineList[0].engineID)
+                    else if (Multi.primaryEngineID != RawEngineList[0].engineID)
                         SafeHouse.Logger.LogWarning("Primary engine ID={0} does not match multi.e1={1} on {2}: {3}",
-                            EngineList[0].engineID, Multi.primaryEngineID, part.name, part.partInfo.title);
-                    if (Multi.secondaryEngineID != EngineList[1].engineID)
+                            RawEngineList[0].engineID, Multi.primaryEngineID, part.name, part.partInfo.title);
+                    if (Multi.secondaryEngineID != RawEngineList[1].engineID)
                         SafeHouse.Logger.LogWarning("Secondary engine ID={0} does not match multi.e2={1} on {2}: {3}",
-                            EngineList[1].engineID, Multi.secondaryEngineID, part.name, part.partInfo.title);
+                            RawEngineList[1].engineID, Multi.secondaryEngineID, part.name, part.partInfo.title);
                 }
             }
 
@@ -89,29 +89,29 @@ namespace kOS.Suffixed.Part
         {
             AddSuffix("ACTIVATE", new NoArgsVoidSuffix(Activate));
             AddSuffix("SHUTDOWN", new NoArgsVoidSuffix(Shutdown));
-            AddSuffix("THRUSTLIMIT", new ClampSetSuffix<ScalarValue>(() => Engines.Average(e => e.thrustPercentage),
-                                                          value => EngineList.ForEach(e => e.thrustPercentage = value),
+            AddSuffix("THRUSTLIMIT", new ClampSetSuffix<ScalarValue>(() => FilteredEngineList.Average(e => e.thrustPercentage),
+                                                          value => RawEngineList.ForEach(e => e.thrustPercentage = value),
                                                           0f, 100f, 0f,
                                                           "thrust limit percentage for this engine"));
-            AddSuffix("MAXTHRUST", new Suffix<ScalarValue>(() => Engines.Sum(e => e.GetThrust())));
-            AddSuffix("THRUST", new Suffix<ScalarValue>(() => Engines.Sum(e => e.finalThrust)));
-            AddSuffix("FUELFLOW", new Suffix<ScalarValue>(() => Engines.Sum(e => e.fuelFlowGui)));
+            AddSuffix("MAXTHRUST", new Suffix<ScalarValue>(() => FilteredEngineList.Sum(e => e.GetThrust())));
+            AddSuffix("THRUST", new Suffix<ScalarValue>(() => FilteredEngineList.Sum(e => e.finalThrust)));
+            AddSuffix("FUELFLOW", new Suffix<ScalarValue>(() => FilteredEngineList.Sum(e => e.fuelFlowGui)));
             AddSuffix("ISP", new Suffix<ScalarValue>(GetIsp));
             AddSuffix(new[] { "VISP", "VACUUMISP" }, new Suffix<ScalarValue>(GetVacuumIsp));
             AddSuffix(new[] { "SLISP", "SEALEVELISP" }, new Suffix<ScalarValue>(GetSeaLevelIsp));
-            AddSuffix("FLAMEOUT", new Suffix<BooleanValue>(() => Engines.Any(e => e.flameout)));
-            AddSuffix("IGNITION", new Suffix<BooleanValue>(() => Engines.Any(e => e.getIgnitionState)));
-            AddSuffix("ALLOWRESTART", new Suffix<BooleanValue>(() => Engines.Any(e => e.allowRestart)));
-            AddSuffix("ALLOWSHUTDOWN", new Suffix<BooleanValue>(() => Engines.Any(e => e.allowShutdown)));
-            AddSuffix("THROTTLELOCK", new Suffix<BooleanValue>(() => Engines.All(e => e.throttleLocked)));
+            AddSuffix("FLAMEOUT", new Suffix<BooleanValue>(() => FilteredEngineList.Any(e => e.flameout)));
+            AddSuffix("IGNITION", new Suffix<BooleanValue>(() => FilteredEngineList.Any(e => e.getIgnitionState)));
+            AddSuffix("ALLOWRESTART", new Suffix<BooleanValue>(() => FilteredEngineList.Any(e => e.allowRestart)));
+            AddSuffix("ALLOWSHUTDOWN", new Suffix<BooleanValue>(() => FilteredEngineList.Any(e => e.allowShutdown)));
+            AddSuffix("THROTTLELOCK", new Suffix<BooleanValue>(() => FilteredEngineList.All(e => e.throttleLocked)));
             AddSuffix("ISPAT", new OneArgsSuffix<ScalarValue, ScalarValue>(GetIspAtAtm));
             AddSuffix("MAXTHRUSTAT", new OneArgsSuffix<ScalarValue, ScalarValue>(GetMaxThrustAtAtm));
-            AddSuffix("AVAILABLETHRUST", new Suffix<ScalarValue>(() => Engines.Sum(e => e.GetThrust(useThrustLimit: true))));
+            AddSuffix("AVAILABLETHRUST", new Suffix<ScalarValue>(() => FilteredEngineList.Sum(e => e.GetThrust(useThrustLimit: true))));
             AddSuffix("AVAILABLETHRUSTAT", new OneArgsSuffix<ScalarValue, ScalarValue>(GetAvailableThrustAtAtm));
-            AddSuffix("POSSIBLETHRUST", new Suffix<ScalarValue>(() => Engines.Sum(e => e.GetThrust(useThrustLimit: true, operational: false))));
+            AddSuffix("POSSIBLETHRUST", new Suffix<ScalarValue>(() => FilteredEngineList.Sum(e => e.GetThrust(useThrustLimit: true, operational: false))));
             AddSuffix("POSSIBLETHRUSTAT", new OneArgsSuffix<ScalarValue, ScalarValue>(GetPossibleThrustAtAtm));
-            AddSuffix("MAXPOSSIBLETHRUST", new Suffix<ScalarValue>(() => Engines.Sum(e => e.GetThrust(operational: false))));
-            AddSuffix("MAXPOSSIBLETHRUSTAT", new OneArgsSuffix<ScalarValue, ScalarValue>(atm => Engines.Sum(e => e.GetThrust(atm, operational: false))));
+            AddSuffix("MAXPOSSIBLETHRUST", new Suffix<ScalarValue>(() => FilteredEngineList.Sum(e => e.GetThrust(operational: false))));
+            AddSuffix("MAXPOSSIBLETHRUSTAT", new OneArgsSuffix<ScalarValue, ScalarValue>(atm => FilteredEngineList.Sum(e => e.GetThrust(atm, operational: false))));
             //MultiMode features
             AddSuffix("MULTIMODE", new Suffix<BooleanValue>(() => MultiMode));
             AddSuffix("MODES", new Suffix<ListValue>(GetAllModes, "A List of all modes of this engine"));
@@ -146,13 +146,13 @@ namespace kOS.Suffixed.Part
         public void Activate()
         {
             ThrowIfNotCPUVessel();
-            EngineList.ForEach(e => e.Activate());
+            FilteredEngineList.ForEach(e => e.Activate());
         }
 
         public void Shutdown()
         {
             ThrowIfNotCPUVessel();
-            EngineList.ForEach(e => e.Shutdown());
+            FilteredEngineList.ForEach(e => e.Shutdown());
         }
 
         // The following functions calculate the correct Isp for multiple engines, regardless of individual performance.
@@ -162,43 +162,43 @@ namespace kOS.Suffixed.Part
         public ScalarValue GetIsp()
         {
             // Get the combined flow rate of all engines
-            double flowRate = Engines.Sum(e => e.GetThrust(operational: false) / e.realIsp);
+            double flowRate = FilteredEngineList.Sum(e => e.GetThrust(operational: false) / e.realIsp);
             // Divide combined thrust by combined flow rate to get a correct Isp for all engines combined
-            return flowRate > 0 ? Engines.Sum(e => e.GetThrust(operational: false)) / flowRate : 0;
+            return flowRate > 0 ? FilteredEngineList.Sum(e => e.GetThrust(operational: false)) / flowRate : 0;
         }
         public ScalarValue GetVacuumIsp()
         {
             // Get the combined flow rate of all engines
-            double flowRate = Engines.Sum(e => e.GetThrust(0, operational: false) / e.atmosphereCurve.Evaluate(0));
+            double flowRate = FilteredEngineList.Sum(e => e.GetThrust(0, operational: false) / e.atmosphereCurve.Evaluate(0));
             // Divide combined thrust by combined flow rate to get a correct Isp for all engines combined
-            return flowRate > 0 ? Engines.Sum(e => e.GetThrust(0, operational: false)) / flowRate : 0;
+            return flowRate > 0 ? FilteredEngineList.Sum(e => e.GetThrust(0, operational: false)) / flowRate : 0;
         }
         public ScalarValue GetSeaLevelIsp()
         {
             // Get the combined flow rate of all engines
-            double flowRate = Engines.Sum(e => e.GetThrust(1, operational: false) / e.atmosphereCurve.Evaluate(1));
+            double flowRate = FilteredEngineList.Sum(e => e.GetThrust(1, operational: false) / e.atmosphereCurve.Evaluate(1));
             // Divide combined thrust by combined flow rate to get a correct Isp for all engines combined
-            return flowRate > 0 ? Engines.Sum(e => e.GetThrust(1, operational: false)) / flowRate : 0;
+            return flowRate > 0 ? FilteredEngineList.Sum(e => e.GetThrust(1, operational: false)) / flowRate : 0;
         }
         public ScalarValue GetIspAtAtm(ScalarValue atmPressure)
         {
             // Get the combined flow rate of all engines
-            double flowRate = Engines.Sum(e => e.GetThrust(atmPressure, operational: false) / e.GetIsp(atmPressure.GetDoubleValue()));
+            double flowRate = FilteredEngineList.Sum(e => e.GetThrust(atmPressure, operational: false) / e.GetIsp(atmPressure.GetDoubleValue()));
             // Divide combined thrust by combined flow rate to get a correct Isp for all engines combined
-            return flowRate > 0 ? Engines.Sum(e => e.GetThrust(atmPressure, operational: false)) / flowRate : 0;
+            return flowRate > 0 ? FilteredEngineList.Sum(e => e.GetThrust(atmPressure, operational: false)) / flowRate : 0;
         }
 
         public ScalarValue GetMaxThrustAtAtm(ScalarValue atmPressure)
         {
-            return Engines.Sum(e => e.GetThrust(atmPressure));
+            return FilteredEngineList.Sum(e => e.GetThrust(atmPressure));
         }
         public ScalarValue GetAvailableThrustAtAtm(ScalarValue atmPressure)
         {
-            return Engines.Sum(e => e.GetThrust(atmPressure, useThrustLimit: true));
+            return FilteredEngineList.Sum(e => e.GetThrust(atmPressure, useThrustLimit: true));
         }
         public ScalarValue GetPossibleThrustAtAtm(ScalarValue atmPressure)
         {
-            return Engines.Sum(e => e.GetThrust(atmPressure, useThrustLimit: true, operational: false));
+            return FilteredEngineList.Sum(e => e.GetThrust(atmPressure, useThrustLimit: true, operational: false));
         }
 
         public ListValue GetAllModes()

--- a/src/kOS/Suffixed/Part/EngineValue.cs
+++ b/src/kOS/Suffixed/Part/EngineValue.cs
@@ -99,10 +99,10 @@ namespace kOS.Suffixed.Part
             AddSuffix("ISP", new Suffix<ScalarValue>(GetIsp));
             AddSuffix(new[] { "VISP", "VACUUMISP" }, new Suffix<ScalarValue>(GetVacuumIsp));
             AddSuffix(new[] { "SLISP", "SEALEVELISP" }, new Suffix<ScalarValue>(GetSeaLevelIsp));
-            AddSuffix("FLAMEOUT", new Suffix<BooleanValue>(() => Engines.All(e => e.flameout)));
-            AddSuffix("IGNITION", new Suffix<BooleanValue>(() => Engines.All(e => e.getIgnitionState)));
-            AddSuffix("ALLOWRESTART", new Suffix<BooleanValue>(() => Engines.All(e => e.allowRestart)));
-            AddSuffix("ALLOWSHUTDOWN", new Suffix<BooleanValue>(() => Engines.All(e => e.allowShutdown)));
+            AddSuffix("FLAMEOUT", new Suffix<BooleanValue>(() => Engines.Any(e => e.flameout)));
+            AddSuffix("IGNITION", new Suffix<BooleanValue>(() => Engines.Any(e => e.getIgnitionState)));
+            AddSuffix("ALLOWRESTART", new Suffix<BooleanValue>(() => Engines.Any(e => e.allowRestart)));
+            AddSuffix("ALLOWSHUTDOWN", new Suffix<BooleanValue>(() => Engines.Any(e => e.allowShutdown)));
             AddSuffix("THROTTLELOCK", new Suffix<BooleanValue>(() => Engines.All(e => e.throttleLocked)));
             AddSuffix("ISPAT", new OneArgsSuffix<ScalarValue, ScalarValue>(GetIspAtAtm));
             AddSuffix("MAXTHRUSTAT", new OneArgsSuffix<ScalarValue, ScalarValue>(GetMaxThrustAtAtm));


### PR DESCRIPTION
This fixes an issue encountered with RO engines which have multiple engine modules in a single part (for main engine plus built-in verniers), but which aren't multi-mode engines.
Engine parts will support any number of engine modules, with aggregated values returned for the various suffixes.
Multi-mode engines continue to behave as before.