### PR TITLE
Fixes #2488 toggle panels logspam

### DIFF
--- a/doc/source/bindings.rst
+++ b/doc/source/bindings.rst
@@ -272,7 +272,7 @@ Variable Name                   Can Read     Can Set     Source    What it manag
 :global:`LEGS`                  yes          yes          kOS       The extended state of all landing legs
 :global:`CHUTES`                yes          yes          kOS       The armed state of all parachutes
 :global:`CHUTESSAFE`            yes          yes          kOS       The armed state of all "safe" parachutes
-:global:`PANELS`                yes          yes          kOS       The deployed state of solar panels
+:global:`PANELS`                yes          yes          kOS       The state of retractable solar panels
 :global:`RADIATORS`             yes          yes          kOS       The deployed state of radiators
 :global:`LADDERS`               yes          yes          kOS       The extended state of ladders
 :global:`BAYS`                  yes          yes          kOS       The opened state of payload/service bays

--- a/src/kOS/Utilities/VesselUtils.cs
+++ b/src/kOS/Utilities/VesselUtils.cs
@@ -405,10 +405,16 @@ namespace kOS.Utilities
                 {
                     atLeastOneSolarPanel = true;
 
-                    if (c.deployState == ModuleDeployablePart.DeployState.RETRACTED) // apparently this was "simplified"
+                    // To fix #2488 - KSP calls all solar panels "ModuleDeployableSolarPanel" even if
+                    // they aren't deployable.   The only way to tell if it's actually deployable
+                    // (versus fixed in place) is to see if it had an animation defined.
+                    if (c.useAnimation)
                     {
-                        // If just one panel is not deployed return false
-                        return false;
+                        if (c.deployState == ModuleDeployablePart.DeployState.RETRACTED) // apparently this was "simplified"
+                        {
+                            // If just one panel is not deployed return false
+                            return false;
+                        }
                     }
                 }
             }
@@ -422,8 +428,14 @@ namespace kOS.Utilities
             {
                 foreach (var c in p.FindModulesImplementing<ModuleDeployableSolarPanel>())
                 {
-                    if (state) { c.Extend(); }
-                    else { c.Retract(); }
+                    // To fix #2488 - KSP calls all solar panels "ModuleDeployableSolarPanel" even if
+                    // they aren't deployable.   The only way to tell if it's actually deployable
+                    // (versus fixed in place) is to see if it had an animation defined.
+                    if (c.useAnimation)
+                    {
+                        if (state) { c.Extend(); }
+                        else { c.Retract(); }
+                    }
                 }
             }
         }


### PR DESCRIPTION
To fix #2488 - KSP calls all solar panels "ModuleDeployableSolarPanel" even if
they aren't deployable.   The only way to tell if it's actually deployable
(versus fixed in place) is to see if it had an animation defined.

It seems the protection against calling Extend() or Retract() on
panels that aren't deployable only existed in the UI where
KSP disabled the gui fields if the animation isn't there.
That same protection didn't exist in the lower level API, so
I had to add the same protections in our code.