### PR TITLE
changed link to internal sphinx :ref: link

### DIFF
--- a/doc/source/general/cpu_hardware.rst
+++ b/doc/source/general/cpu_hardware.rst
@@ -172,8 +172,7 @@ Triggers for Cooked Steering
 
 *This is a kind of* :ref:`recurring trigger <recurring_trigger>`.
 
-The ``lock`` expressions associated with
-`Cooked Control <commands/flight/cooked.html>`__,
+The ``lock`` expressions associated with :ref:`Cooked Control <cooked>`,
 meaning ``STEERING``, ``THROTTLE``, ``WHEELSTEERING``, and
 ``WHEELTHROTTLE``, have triggers associated with them.
 kOS will keep calling these expressions repeatedly as frequently


### PR DESCRIPTION
Fixes #2496 by changing link to the more
reliable internal Sphinx :ref: link style.