### PR TITLE
Fixes #2499 disallow unset bindings, also document.

### DIFF
--- a/doc/source/commands/flight/systems.rst
+++ b/doc/source/commands/flight/systems.rst
@@ -59,7 +59,7 @@ RCS and SAS
 
         SET SASMODE TO value.
 
-    It is the equivalent to clicking on the buttons next to the nav ball while manually piloting the craft, and will respect the current mode of the nav ball (orbital, surface, or target velocity - use NAVMODE to read or set it).  Valid strings for ``value`` are ``"PROGRADE"``, ``"RETROGRADE"``, ``"NORMAL"``, ``"ANTINORMAL"``, ``"RADIALOUT"``, ``"RADIALIN"``, ``"TARGET"``, ``"ANTITARGET"``, ``"MANEUVER"``, ``"STABILITYASSIST"``, and ``"STABILITY"``.  A null or empty string will default to stability assist mode, however any other invalid string will throw an exception.  This feature will respect career mode limitations, and will throw an exception if the current vessel is not able to use the mode passed to the command.  An exception is also thrown if ``"TARGET"`` or ``"ANTITARGET"`` are used, but no target is selected.
+    It is the equivalent to clicking on the buttons next to the nav ball while manually piloting the craft, and will respect the current mode of the nav ball (orbital, surface, or target velocity - use NAVMODE to read or set it).  Valid strings for ``value`` are ``"PROGRADE"``, ``"RETROGRADE"``, ``"NORMAL"``, ``"ANTINORMAL"``, ``"RADIALOUT"``, ``"RADIALIN"``, ``"TARGET"``, ``"ANTITARGET"``, ``"MANEUVER"``, ``"STABILITYASSIST"``, and ``"STABILITY"``.  A null or empty string will default to stability assist mode, however any other invalid string will throw an exception.  This feature will respect career mode limitations, and will throw an exception if the current vessel is not able to use the mode passed to the command.  An exception is also thrown if ``"TARGET"`` or ``"ANTITARGET"`` are used when no target is set.
 
     .. note::
         SAS mode is reset to stability assist when toggling SAS on, however it doesn't happen immediately.
@@ -387,5 +387,14 @@ TARGET
         SET TARGET TO name.
 
     For more information see :ref:`bindings`.
+
+    NOTE, the way to de-select the target is to set it to an empty
+    string like this::
+
+        SET TARGET TO "". // de-selects the target, setting it to nothing.
+
+    (Trying to use :ref:`UNSET TARGET.<unset>` will have no effect because
+    ``UNSET`` means "get rid of the variable itself" which you're not
+    allowed to do with built-in bound variables like ``TARGET``.)
 
 Note that the above options also can refer to a different vessel besides the current ship, for example, ``TARGET:THROTTLE`` to read the target's throttle. But not all "set" or "lock" options will work with a different vessel other than the current one, because there's no authority to control a craft the current program is not attached to.

--- a/doc/source/language/variables.rst
+++ b/doc/source/language/variables.rst
@@ -290,7 +290,7 @@ example "TARGET", "GEAR", "THROTTLE", "STEERING", etc.  It only works
 variables that your script created.
 
 If ``UNSET`` does not find a variable to remove, or it fails to remove
-the variable becasue it is a built-in name as explained above, then
+the variable because it is a built-in name as explained above, then
 it will NOT generate an error.  It will simply quietly move on to the
 next statement, doing nothing.
 

--- a/doc/source/language/variables.rst
+++ b/doc/source/language/variables.rst
@@ -268,6 +268,32 @@ This follows the :ref:`scoping rules explained below <scope>`.  If the
 variable can be found in the current local scope, or any scope higher
 up, then it won't be created and instead the existing one will be used.
 
+.. _unset:
+
+``UNSET``
+---------
+
+Removes a user-defined variable, if one exists with the given name.
+
+    UNSET X.
+    UNSET myvariable.
+
+If there are two variables with the same name, one that is "more local"
+and one that is "more global", it will choose the "more local" one to
+be removed, according to the usual
+:ref:`scoping rules explained below <scope>`.
+
+After this is executed, the variable becomes undefined.
+
+``UNSET`` cannot be used on a kOS built-in bound variable name, for
+example "TARGET", "GEAR", "THROTTLE", "STEERING", etc.  It only works
+variables that your script created.
+
+If ``UNSET`` does not find a variable to remove, or it fails to remove
+the variable becasue it is a built-in name as explained above, then
+it will NOT generate an error.  It will simply quietly move on to the
+next statement, doing nothing.
+
 .. _defined:
 
 ``DEFINED``

--- a/doc/source/structures/misc/vecdraw.rst
+++ b/doc/source/structures/misc/vecdraw.rst
@@ -102,7 +102,7 @@ Drawing Vectors on the Screen
         // paramters LABEL, SCALE, SHOW, and WIDTH.
         SET vd TO VECDRAW(V(0,0,0), 5*north:vector, red).
 
-    To make a :struct:`VecDraw` disappear, you can either set its :attr:`VecDraw:SHOW` to false or just UNSET the variable, or re-assign it. An example using :struct:`VecDraw` can be seen in the documentation for :func:`POSITIONAT()`.
+    To make a :struct:`VecDraw` disappear, you can either set its :attr:`VecDraw:SHOW` to false or just :ref:`UNSET <unset>` the variable, or re-assign it. An example using :struct:`VecDraw` can be seen in the documentation for :func:`POSITIONAT()`.
 
 .. _clearvecdraws:
 

--- a/src/kOS.Safe/Execution/CPU.cs
+++ b/src/kOS.Safe/Execution/CPU.cs
@@ -785,7 +785,7 @@ namespace kOS.Safe.Execution
         public void RemoveVariable(string identifier)
         {
             VariableScope currentScope = GetCurrentScope();
-            Variable variable = currentScope.RemoveNested(identifier);
+            Variable variable = currentScope.RemoveNestedUserVar(identifier);
             if (variable != null)
             {
                 // Tell Variable to orphan its old value now.  Faster than relying

--- a/src/kOS.Safe/Execution/VariableScope.cs
+++ b/src/kOS.Safe/Execution/VariableScope.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using kOS.Safe.Binding;
+using System;
 using System.Collections.Generic;
 
 namespace kOS.Safe.Execution
@@ -97,19 +98,46 @@ namespace kOS.Safe.Execution
         /// Remove this variable from this local scope OR whichever
         /// VariableScope it is found in first when doing a scope walk
         /// up the parent chain to find the first hit.
+        /// <param name="name"/>identifier to remove</param>
+        /// <param name="removeBound">if true, allow bound variables to be removed, else do not.</param>
         /// </summary>
-        public Variable RemoveNested(string name)
+        private Variable RemoveNested(string name, bool removeBound)
         {
             Variable res = null;
 
             if (!Variables.TryGetValue(name, out res))
             {
-                return ParentScope.RemoveNested(name);
+                return ParentScope.RemoveNested(name, removeBound);
             }
+            if (res is BoundVariable && !removeBound)
+                return null; // If not allowed to remove this bound variable, pretend it wasn't found.
+
             Variables.Remove(name);
 
             return res;
         }
+
+        /// <summary>
+        /// Remove this variable from whichever scope it is "most locally"
+        /// found in, walking all the way up to the global scope.  It will
+        /// only remove USER-made variables, refusing to remove bound
+        /// variables.  It will act like it wasn't found if it finds
+        /// a bound variable.
+        /// </summary>
+        /// <param name="name">identifier of the variable to remove</param>
+        /// <returns>the variable that was removed, or null if not found (or a bound var found that doesn't count)</returns>
+        public Variable RemoveNestedUserVar(string name)
+        {
+            return RemoveNested(name, false);
+        }
+
+        // HINT: If there ever is a need for it, this is how we'd have an API to allow
+        // removing a bound variable.  This isn't enabled because it would currently
+        // be un-used and therefore un-tested.
+        // public Variable RemoveNestedAnyVar(string name)
+        // {
+        //     return RemoveNested(name, true);
+        // }
 
         /// <summary>
         /// True only if this variable name exists in THIS local scope.


### PR DESCRIPTION
Fixes #2499 by disallowing the UNSETing of things that were not created by the user.

In trying to document the changes to UNSET, I found out that UNSET was not even really documented at all prior to this, so I also added UNSET documentation.