### PR TITLE
Fixes 2532 throttle trigger priority

### DIFF
--- a/doc/source/commands/flight/cooked.rst
+++ b/doc/source/commands/flight/cooked.rst
@@ -184,17 +184,18 @@ Like all ``LOCK`` expressions, the steering and throttle continually update on t
     LOCK WHEELSTEERING.  See the note in the next section below.
 
 
-Don't 'WAIT' during cooked control calculation
-----------------------------------------------
+Don't 'WAIT' or run slow script code during cooked control calculation
+----------------------------------------------------------------------
 
 Be aware that because LOCK THROTTLE, LOCK STEERING, LOCK
-WHEELTHROTTLE, and LOCK WHEELSTEERING are actually
-:ref:`triggers <triggers>` that cause your expression
-to be calculated every single physics update tick behind
-the scenes, you should not execute a ``WAIT`` command
-in the code that performs the evaluation of the value
-used in them, as that will effectively cheat the entire
-script out of the full execution speed it deserves.
+WHEELTHROTTLE, and LOCK WHEELSTEERING are actually the
+highest priority types of :ref:`triggers <triggers>` that
+exist in kOS, they cause your expression to be calculated
+every single physics update tick behind the scenes.  So you
+should not execute a ``WAIT`` command in the code that
+performs the evaluation of the value used in them, as that
+will effectively cheat the entire script out of the full
+execution speed it deserves.
 
 For example, if you attempt this::
 
@@ -215,6 +216,13 @@ hits the wait inside the throttle expression, it will stop
 there, not resuming until the next update, effectively meaning
 it doesn't get around to running any of your main-line code
 until the next tick.)
+
+Again, note that the cooked steering LOCKS mentioned here are
+the *highest* priority triggers there are in kOS.  That means they
+can even interrupt other triggers like WHEN/THEN or GUI callbacks.
+Do not make them call complex functions that take a lot of instructions
+to return a value, or else you might find that there's not enough
+instructions per update left to run the rest of your program effectively.
 
 Normally when you use a LOCK command, the expression is only evaluated
 when it needs to be by some other part of the script that is trying

--- a/doc/source/structures/gui.rst
+++ b/doc/source/structures/gui.rst
@@ -38,7 +38,7 @@ this right now, but the effect of it is that by default one gui callback
 cannot trigger while another one is running.  There are ways to change this
 but they require a more in-depth discusion of how the kOS CPU works with
 triggers, and are thus :ref:`described elsewhere on the
-general CPU hardware description page<allowinterrupt>`.
+general CPU hardware description page<drop_priority>`.
 
 .. _gui_polling_technique:
 

--- a/doc/source/structures/gui.rst
+++ b/doc/source/structures/gui.rst
@@ -31,6 +31,15 @@ call whenever you notice this particular thing has happened."  For example::
 will interrupt whatever else you are doing and call a function you wrote
 called ``myClickFunction`` whenever that button is clicked.
 
+Note that gui callbacks that are triggered by user activity (rather than
+by your program changing a value) are a type of trigger, and thus run at a
+"higher priority" than normal code.  You don't need to think too hard about
+this right now, but the effect of it is that by default one gui callback
+cannot trigger while another one is running.  There are ways to change this
+but they require a more in-depth discusion of how the kOS CPU works with
+triggers, and are thus :ref:`described elsewhere on the
+general CPU hardware description page<allowinterrupt>`.
+
 .. _gui_polling_technique:
 
 The **polling technique** is when you actively keep checking the widget

--- a/src/kOS.Safe.Test/Opcode/FakeCpu.cs
+++ b/src/kOS.Safe.Test/Opcode/FakeCpu.cs
@@ -52,7 +52,7 @@ namespace kOS.Safe.Test.Opcode
             throw new NotImplementedException();
         }
 
-        public void SetLowerPriority(InterruptPriority newPriority)
+        public void DropBackPriority()
         {
             throw new NotImplementedException();
         }

--- a/src/kOS.Safe.Test/Opcode/FakeCpu.cs
+++ b/src/kOS.Safe.Test/Opcode/FakeCpu.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using kOS.Safe.Execution;
 using kOS.Safe.Encapsulation;
@@ -48,6 +48,11 @@ namespace kOS.Safe.Test.Opcode
         }
 
         public void PushNewScope(Int16 scopeId, Int16 parentScopeId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetLowerPriority(InterruptPriority newPriority)
         {
             throw new NotImplementedException();
         }

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -2509,7 +2509,7 @@ namespace kOS.Safe.Compilation.KS
                 {
                     Trigger triggerObject = context.Triggers.GetTrigger(triggerIdentifier);
                     AddOpcode(new OpcodePushRelocateLater(null), triggerObject.GetFunctionLabel());
-                    AddOpcode(new OpcodeAddTrigger(false));
+                    AddOpcode(new OpcodeAddTrigger(false, InterruptPriority.RecurringControl));
                 }
                     
                 // enable this FlyByWire parameter
@@ -2590,7 +2590,7 @@ namespace kOS.Safe.Compilation.KS
                 VisitNode(node.Nodes[1]); // the expression in the on statement.
                 AddOpcode(new OpcodeStore(triggerObject.OldValueIdentifier));
                 AddOpcode(new OpcodePushRelocateLater(null), triggerObject.GetFunctionLabel());
-                AddOpcode(new OpcodeAddTrigger());
+                AddOpcode(new OpcodeAddTrigger(InterruptPriority.Recurring));
             }
         }
 
@@ -2604,7 +2604,7 @@ namespace kOS.Safe.Compilation.KS
             if (triggerObject.IsInitialized())
             {
                 AddOpcode(new OpcodePushRelocateLater(null), triggerObject.GetFunctionLabel());
-                AddOpcode(new OpcodeAddTrigger());
+                AddOpcode(new OpcodeAddTrigger(InterruptPriority.Recurring));
             }
         }
 

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -2471,7 +2471,7 @@ namespace kOS.Safe.Compilation
         /// </summary>
         protected OpcodePushDelegateRelocateLater()
         {}
-        
+
         public override void PopulateFromMLFields(List<object> fields)
         {
             // Expect fields in the same order as the [MLField] properties of this class:
@@ -2489,14 +2489,17 @@ namespace kOS.Safe.Compilation
     /// <summary>
     /// <para>
     /// Pops a function pointer from the stack and adds a trigger that will be called each cycle.
-    /// These triggers get the priority InterruptPriority.Recurring
+    /// The argument (to the opcode, not on the stack) contains the Interrupt Priority level
+    /// of the trigger.  For one trigger to interrupt another, it needs a higher priority,
+    /// else it waits until the first trigger is completed before it will fire.
     /// </para>
     /// <para></para>
-    /// <para>addtrigger</para>
+    /// <para>addtrigger N</para>
     /// <para>... fp -- ...</para>
     /// </summary>
     public class OpcodeAddTrigger : Opcode
     {
+
         protected override string Name { get { return "addtrigger"; } }
         public override ByteCode Code { get { return ByteCode.ADDTRIGGER; } }
 
@@ -2505,17 +2508,42 @@ namespace kOS.Safe.Compilation
         /// that identifies this instance/entrypoint uniquely at runtime.
         /// (For example, ON triggers need this, but WHEN triggers do not).
         /// </summary>
-        [MLField(1,true)]
+        [MLField(1,false)]
         public bool Unique { get; set; }
+        /// <summary>
+        /// The interrupt priority level of the trigger.
+        /// (It's an Int32 type instead of InterruptPrioirity purely because MLFields
+        /// need to be one of the limited primitive types the system knows how to store.)
+        /// </summary>
+        [MLField(2, false)]
+        public Int32 Priority { get; set; }
 
-        public OpcodeAddTrigger(bool unique)
+        public OpcodeAddTrigger(bool unique, InterruptPriority priority)
         {
             Unique = unique;
+            Priority = (Int32)priority;
         }
 
-        public OpcodeAddTrigger() // Must have a defualt constructor for how KSM files work.
+        public OpcodeAddTrigger(InterruptPriority priority) // Must have a defualt constructor for how KSM files work.
         {
             Unique = true;
+            Priority = (Int32)priority;
+        }
+
+        /// <summary>Only here because the compile storage system requires a default constructor.
+        /// It's private because we want to force everyone ELSE to use one of the versions with args.
+        /// </summary>
+        private OpcodeAddTrigger()
+        {
+        }
+
+        public override void PopulateFromMLFields(List<object> fields)
+        {
+            // Expect fields in the same order as the [MLField] properties of this class:
+            if (fields == null || fields.Count < 2)
+                throw new Exception("Saved field in ML file for OpcodeAddTrigger seems to be missing.  Version mismatch?");
+            Unique = Convert.ToBoolean(fields[0]);
+            Priority = Convert.ToInt32(fields[1]);
         }
 
         public override void Execute(ICpu cpu)
@@ -2523,12 +2551,12 @@ namespace kOS.Safe.Compilation
             int functionPointer = Convert.ToInt32(cpu.PopValueArgument()); // in case it got wrapped in a ScalarIntValue
 
             List<Structure> args = new List<Structure>();
-            cpu.AddTrigger(functionPointer, InterruptPriority.Recurring, (Unique ? cpu.NextTriggerInstanceId : 0), false, cpu.GetCurrentClosure());
+            cpu.AddTrigger(functionPointer, (InterruptPriority) Priority, (Unique ? cpu.NextTriggerInstanceId : 0), false, cpu.GetCurrentClosure());
         }
 
         public override string ToString()
         {
-            return Name;
+            return string.Format("{0}{1}, Pri {2} ", Name, (Unique ? " unique" : ""), Priority );
         }
     }
 

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -2196,7 +2196,7 @@ namespace kOS.Safe.Compilation
             cpu.PushArgumentStack(new BooleanValue((sr == null ? false : sr.IsCancelled)));
         }
     }
-    
+
     /// <summary>
     /// <para>
     /// Push the thing atop the stack onto the stack again so there are now two of it atop the stack.

--- a/src/kOS.Safe/Execution/CPU.cs
+++ b/src/kOS.Safe/Execution/CPU.cs
@@ -465,7 +465,13 @@ namespace kOS.Safe.Execution
         public void BreakExecution(bool manual)
         {
             SafeHouse.Logger.Log(string.Format("Breaking Execution {0} Contexts: {1}", manual ? "Manually" : "Automatically", contexts.Count));
-            if (contexts.Count > 1)
+            if (contexts.Count == 0)
+            {
+                // Skip most of what this method does, since there's no execution to break.
+                // This case should only be posisble if BreakExecution() is called while the
+                // CPU is off or power starved, as can happen during OnLoad().
+            }
+            else if (contexts.Count > 1)
             {
                 AbortAllYields();
 
@@ -491,14 +497,15 @@ namespace kOS.Safe.Execution
                         stack.Clear();
                     }
                 }
+                CurrentPriority = InterruptPriority.Normal;
             }
             else
             {
                 if (manual)
                     currentContext.ClearTriggers(); // Removes the interpreter's triggers on Control-C and the like, but not on errors.
                 SkipCurrentInstructionId();
+                CurrentPriority = InterruptPriority.Normal;
             }
-            CurrentPriority = InterruptPriority.Normal;
             ResetStatistics();
         }
 

--- a/src/kOS.Safe/Execution/ICpu.cs
+++ b/src/kOS.Safe/Execution/ICpu.cs
@@ -35,7 +35,7 @@ namespace kOS.Safe.Execution
         string DumpStack();
         void RemoveVariable(string identifier);
         int InstructionPointer { get; set; }
-        void SetLowerPriority(InterruptPriority newPriority);
+        void DropBackPriority();
         double SessionTime { get; }
         List<string> ProfileResult { get; }
         int NextTriggerInstanceId {get; }

--- a/src/kOS.Safe/Execution/ICpu.cs
+++ b/src/kOS.Safe/Execution/ICpu.cs
@@ -35,6 +35,7 @@ namespace kOS.Safe.Execution
         string DumpStack();
         void RemoveVariable(string identifier);
         int InstructionPointer { get; set; }
+        void SetLowerPriority(InterruptPriority newPriority);
         double SessionTime { get; }
         List<string> ProfileResult { get; }
         int NextTriggerInstanceId {get; }

--- a/src/kOS.Safe/Execution/InterruptPriority.cs
+++ b/src/kOS.Safe/Execution/InterruptPriority.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace kOS.Safe.Execution
 {
@@ -23,9 +23,13 @@ namespace kOS.Safe.Execution
         Normal = 0,
         /// <summary>A one-shot callback such as is common with GUI code</summary>
         CallbackOnce = 10,
-        /// <summary>A trigger that tends to keep getting scheduled to happen
+        /// <summary>A user-made trigger that tends to keep getting scheduled to happen
         /// again as soon as the previous call to it is completed.</summary>
-        Recurring = 20
+        Recurring = 20,
+        /// <summary>These are recurring triggers too, but they absolutely MUST always fire
+        /// because they are used for the coooked controls like LOCK THROTTLLE and
+        /// LOCK STEERING</summary>
+        RecurringControl = 30
     }
 }
 

--- a/src/kOS.Safe/Execution/ProgramContext.cs
+++ b/src/kOS.Safe/Execution/ProgramContext.cs
@@ -252,13 +252,14 @@ namespace kOS.Safe.Execution
 
         /// <summary>
         /// Take only those pending triggers that AddPendingTrigger added who's
-        /// Priority is equal to or higher than the given value, and make them become active.
+        /// Priority is higher than the given value, and make them become active.
+        /// ("active" here means "called on the callstack like a subroutine.")
         /// </summary>
         /// <param name="aboveThis"></param>
-        public void ActivatePendingTriggersAtLeastPriority(InterruptPriority aboveThis)
+        public void ActivatePendingTriggersAbovePriority(InterruptPriority aboveThis)
         {
-            Triggers.AddRange(TriggersToInsert.FindAll(t => t.Priority >= aboveThis));
-            TriggersToInsert.RemoveAll(t => t.Priority >= aboveThis);
+            Triggers.AddRange(TriggersToInsert.FindAll(t => t.Priority > aboveThis));
+            TriggersToInsert.RemoveAll(t => t.Priority > aboveThis);
         }
 
         public bool HasActiveTriggersAtLeastPriority(InterruptPriority pri)

--- a/src/kOS.Safe/Execution/ProgramContext.cs
+++ b/src/kOS.Safe/Execution/ProgramContext.cs
@@ -251,15 +251,14 @@ namespace kOS.Safe.Execution
         }
 
         /// <summary>
-        /// Take all the pending triggers that have been added by AddPendingTrigger,
-        /// and finally make them become active.  To be called by the CPU when it
-        /// decides that enough mainline code has had a chance to happen that it's
-        /// okay to enable triggers again.
+        /// Take only those pending triggers that AddPendingTrigger added who's
+        /// Priority is equal to or higher than the given value, and make them become active.
         /// </summary>
-        public void ActivatePendingTriggers()
+        /// <param name="aboveThis"></param>
+        public void ActivatePendingTriggersAtLeastPriority(InterruptPriority aboveThis)
         {
-            Triggers.AddRange(TriggersToInsert);
-            TriggersToInsert.Clear();
+            Triggers.AddRange(TriggersToInsert.FindAll(t => t.Priority >= aboveThis));
+            TriggersToInsert.RemoveAll(t => t.Priority >= aboveThis);
         }
 
         public bool HasActiveTriggersAtLeastPriority(InterruptPriority pri)

--- a/src/kOS.Safe/Function/Misc.cs
+++ b/src/kOS.Safe/Function/Misc.cs
@@ -384,12 +384,12 @@ namespace kOS.Safe.Function
         }
     }
 
-    [Function("allowinterrupt")]
+    [Function("droppriority")]
     public class AllowInterrupt : SafeFunctionBase
     {
         public override void Execute(SafeSharedObjects shared)
         {
-            shared.Cpu.SetLowerPriority(InterruptPriority.Normal);
+            shared.Cpu.DropBackPriority();
         }
     }
 }

--- a/src/kOS.Safe/Function/Misc.cs
+++ b/src/kOS.Safe/Function/Misc.cs
@@ -383,4 +383,13 @@ namespace kOS.Safe.Function
             ReturnValue = new BuiltinDelegate(shared.Cpu, name);
         }
     }
+
+    [Function("allowinterrupt")]
+    public class AllowInterrupt : SafeFunctionBase
+    {
+        public override void Execute(SafeSharedObjects shared)
+        {
+            shared.Cpu.SetLowerPriority(InterruptPriority.Normal);
+        }
+    }
 }


### PR DESCRIPTION
Fixes #2532 

Essentially the earlier InterruptPriority system still wasn't fully implemented properly, and still had some messy unnecessarily clunky code in ContinueExecution() that was trying to handle the different types of trigger with special cases (instead of just using the priority level numerically and ignoring all else).

This fix does the following:

1 - Adds a new higher level priority - level 30 - for use with cooked control locks.   They now enjoy the highest priority and will interrupt *anything* other than another cooked control lock.

2 - Removes some ugly code from CPU.ContinueExecution() that pre-dated the concept of InterruptPriority.  (It tried to accomplish some of the same ideas but in a more complex special case kind of way).  That code was actually interfering with interrupt priorities working properly.  (It had to be removed in order to make priority level 30 actually succeed at interrupting level 20.)

3 - Some of the removed code mentioned above was present to attempt to support GUI callbacks interrupting other GUI callbacks just in case a GUI callback fired off something that lasts a long time so it would't freeze the rest of the GUI while it runs. (Normally a trigger doesn't interrupt a trigger of the same priority so this was meant to be a special case just for GUI callbacks).  In testing I found out that this had never been working anyway, and even with that messy code there, GUI callbacks still wouldn't interrupt other GUI callbacks so the reason for that was moot anyway.  From a backward-compatibilitly point of view it didn't have to be supported.

4 - Just in case someone *does* want to use a design pattern where one GUI callback lasts a long time and lets other GUI callbacks interrupt it, I provied a new built-in function, ``DROPPRIORITY`` that can be executed from inside a trigger to drop the priority back down to what it was prior to the interruption.  Thus the trigger can say "go ahead and re-enable interruptions and allow myself to get interrupted".

(The example program written in the docs shows a case of how things differ when DROPPRIORITY is present.)

I struggle with whether or not bullet point (4) should be described well in the docs, or should be hidden so only people who read the long CPU_hardware page see it.  (so it can't be used by someone who's never looked at the section on priorities and doesn't understand the consequences).