### PR TITLE
Fixes #2531 this is ugly

### DIFF
--- a/doc/source/structures/vessels/baseservo.rst
+++ b/doc/source/structures/vessels/baseservo.rst
@@ -1,0 +1,16 @@
+.. _baseservo:
+
+BaseServo
+=========
+
+This is a special type of :struct:`PartModule` used to handle the robotic
+servos that came with the Breaking Ground DLC.  If you examine a PartModule
+that controls such a part, it will be this type.
+
+This type has no extra suffixes (yet??) beyond those that come with every
+:struct:`PartModuile`.  The reason it has to be a separate type is that
+it needs to perform some strange work under the hood to mimic how normal
+PartModules work.  (The Breaking Ground DLC PartModules have some strange
+implementation changes about how their Part Action Window sliders work
+that required extra work for kOS to support.)
+

--- a/doc/source/structures/vessels/partmodule.rst
+++ b/doc/source/structures/vessels/partmodule.rst
@@ -47,6 +47,15 @@ Once you have a :struct:`PartModule`, you can use it to invoke the behaviors tha
         * - :meth:`GETFIELD(name)`
           -
           - Get value of a field by name
+        * - :meth:`GETFIELDMIN(name)`
+          -
+          - The field's minimum legal value, if scalar
+        * - :meth:`GETFIELDMAX(name)`
+          -
+          - The field's maximum legal value, if scalar
+        * - :meth:`GETFIELDSTEP(name)`
+          -
+          - The mandatory "rounding" increment, if scalar
         * - :meth:`SETFIELD(name,value)`
           -
           - Set value of a field by name
@@ -131,6 +140,44 @@ Once you have a :struct:`PartModule`, you can use it to invoke the behaviors tha
     :return: varies
 
     Get the value of one of the fields that this PartModule has placed onto the rightclick menu for the part. Note the Security comments below.
+
+.. method:: PartModule:GETFIELDMIN(name)
+
+    :parameter name: (string) Name of the field
+    :return: varies
+
+    Gets the minimum currently legal settable value for the field with
+    this name on the rightclick menu for the part, **assuming this field
+    is a :ref:`Scalar` slider** value.  (If this field is NOT a
+    :ref:`Scalar` slider, then the meaning of this suffix might be a
+    default bogus placeholder value that does not actually mean anything.)
+
+.. method:: PartModule:GETFIELDMAX(name)
+
+    :parameter name: (string) Name of the field
+    :return: varies
+
+    Gets the maximum currently legal settable value for the field with
+    this name on the rightclick menu for the part, **assuming this field
+    is a :ref:`Scalar` slider** value.  (If this field is NOT a
+    :ref:`Scalar` slider, then the meaning of this suffix might be a
+    default bogus placeholder value that does not actually mean anything.)
+
+.. method:: PartModule:GETFIELDSTEP(name)
+
+    :parameter name: (string) Name of the field
+    :return: varies
+
+    Gets the step increment value for the field with this name on the
+    rightclick menu for the part, **assuming this field is a
+    :ref:`Scalar` slider** value.  (If this field is NOT a
+    :ref:`Scalar` slider, then the meaning of this suffix might be a
+    default bogus placeholder value that does not actually mean anything.)
+
+    The step increment value determines how the scalar value will get rounded
+    when you set it.  For example, if the step increment is 0.5, and you
+    tried to set the value to 7.68, it would get rounded to the nearest 0.5,
+    so it would end up being 7.5 instead of 7.68.
 
 .. method:: PartModule:SETFIELD(name,value)
 

--- a/src/kOS.Safe/Execution/CPU.cs
+++ b/src/kOS.Safe/Execution/CPU.cs
@@ -465,7 +465,13 @@ namespace kOS.Safe.Execution
         public void BreakExecution(bool manual)
         {
             SafeHouse.Logger.Log(string.Format("Breaking Execution {0} Contexts: {1}", manual ? "Manually" : "Automatically", contexts.Count));
-            if (contexts.Count > 1)
+            if (contexts.Count == 0)
+            {
+                // Skip most of what this method does, since there's no execution to break.
+                // This case should only be posisble if BreakExecution() is called while the
+                // CPU is off or power starved, as can happen during OnLoad().
+            }
+            else if (contexts.Count > 1)
             {
                 AbortAllYields();
 
@@ -491,14 +497,15 @@ namespace kOS.Safe.Execution
                         stack.Clear();
                     }
                 }
+                CurrentPriority = InterruptPriority.Normal;
             }
             else
             {
                 if (manual)
                     currentContext.ClearTriggers(); // Removes the interpreter's triggers on Control-C and the like, but not on errors.
                 SkipCurrentInstructionId();
+                CurrentPriority = InterruptPriority.Normal;
             }
-            CurrentPriority = InterruptPriority.Normal;
             ResetStatistics();
         }
 

--- a/src/kOS.Safe/Utilities/kosMath.cs
+++ b/src/kOS.Safe/Utilities/kosMath.cs
@@ -1,4 +1,4 @@
-﻿namespace kOS.Safe.Utilities
+namespace kOS.Safe.Utilities
 {
     public static class KOSMath
     {
@@ -41,6 +41,10 @@
         /// <returns></returns>
         public static double ClampToIndent(double val, double min, double max, double increment)
         {
+            // The algorithm that follows breaks if increment is zero, so use the simpler clamp instead:
+            if (increment == 0f)
+                return Clamp(val, min, max);
+
             // First clamp the value to within min/max:
             double outVal = System.Math.Max(min, System.Math.Min(val, max));
             
@@ -72,6 +76,10 @@
         /// <returns></returns>
         public static float ClampToIndent(float val, float min, float max, float increment)
         {
+            // The algorithm that follows breaks if increment is zero, so use the simpler clamp instead:
+            if (increment == 0f)
+                return Clamp(val, min, max);
+
             // First clamp the value to within min/max:
             float outVal = System.Math.Max(min, System.Math.Min(val, max));
             

--- a/src/kOS/Suffixed/PartModuleField/BaseServoModuleFields.cs
+++ b/src/kOS/Suffixed/PartModuleField/BaseServoModuleFields.cs
@@ -39,51 +39,52 @@ namespace kOS.Suffixed.PartModuleField
         override protected List<UI_Control> GetFieldControls(BaseField field)
         {
             List<UI_Control> controls = base.GetFieldControls(field);
-
-            if (servo.useLimits)
+            Console.WriteLine("eraseme:   servo.useLimits = true.");
+            AxisFieldLimit limitOverride = servo.GetAxisFieldLimit(field.name);
+            if (limitOverride != null)
             {
-                AxisFieldLimit limitOverride = servo.GetAxisFieldLimit(field.name);
-                if (limitOverride != null)
-                {
-                    // This is the condition in which the DLC servo's KSPField's range values are
-                    // utter lies.  (Example: In a case like a Piston who's user interface lets
-                    // players pick any "Target Extension" values from 0 meters to 2.4 meters, down to
-                    // the exact centimeter, the UI_FloatRange control for "Target Extension" is lying,
-                    // reporting FloatRange values as if its valid values were actually 0 to 100 meters
-                    // and must be rounded to the nearest 1 meter.  That effectively meant kOS could only
-                    // set that slider to 3 distinct values: 0, 1, and 2.  Anything else got rounded to
-                    // one of those, making it impossible for kOS to let a script use that slider properly.)
-                    //
-                    // When this condition happens, we need to utterly ignore the
-                    // actual UI_Control values that the API claims are in use, and instead
-                    // replace it with this overridden version.
-                    //
-                    // If you are looking at this ugly code and want to judge me - remember I had to work this all
-                    // out from trial and error reverse engineering.  None of this was documented for modders.
-                    // There couild very well be a proper API call that does this cleanly, but I don't know what it is.
+                Console.WriteLine("eraseme:     limitOverride != null.");
+                // This is the condition in which the DLC servo's KSPField's range values are
+                // utter lies.  (Example: In a case like a Piston who's user interface lets
+                // players pick any "Target Extension" values from 0 meters to 2.4 meters, down to
+                // the exact centimeter, the UI_FloatRange control for "Target Extension" is lying,
+                // reporting FloatRange values as if its valid values were actually 0 to 100 meters
+                // and must be rounded to the nearest 1 meter.  That effectively meant kOS could only
+                // set that slider to 3 distinct values: 0, 1, and 2.  Anything else got rounded to
+                // one of those, making it impossible for kOS to let a script use that slider properly.)
+                //
+                // When this condition happens, we need to utterly ignore the
+                // actual UI_Control values that the API claims are in use, and instead
+                // replace it with this overridden version.
+                //
+                // If you are looking at this ugly code and want to judge me - remember I had to work this all
+                // out from trial and error reverse engineering.  None of this was documented for modders.
+                // There couild very well be a proper API call that does this cleanly, but I don't know what it is.
 
-                    for(int idx = 0; idx < controls.Count; ++idx)
+                for (int idx = 0; idx < controls.Count; ++idx)
+                {
+                    Console.WriteLine("eraseme:      index = " + idx);
+                    UI_Control control = controls[idx];
+                    if (control.controlEnabled && control is UI_FloatRange || control is UI_FieldFloatRange)
                     {
-                        UI_Control control = controls[idx];
-                        if (control.controlEnabled && control is UI_FloatRange || control is UI_FieldFloatRange)
-                        {
-                            // I do NOT want to overwrite the actual contents of the control that is
-                            // returned by the API, because I fear it's a reference to the one that is
-                            // really used by the rest of the game, and I don't know what I might break
-                            // by editing its values directly.  So instead I want to make a new one that
-                            // mimics the actual one, with the relevant range limit fields edited.
-                            // But there is no copy constructor or assignment operator for it, so
-                            // if I tried to copy all the fields I'd inevitably miss a few.  Instead I will
-                            // just only write to the few fields we actually use here in kOS.  This is not
-                            // a general all-purpose solution for every modder because many of these fields
-                            // are skipped in this copy:
-                            UI_FloatRange trueRange = new UI_FloatRange();
-                            trueRange.minValue = limitOverride.softLimits.x;
-                            trueRange.maxValue = limitOverride.softLimits.y;
-                            trueRange.stepIncrement = 0f;
-                            trueRange.controlEnabled = control.controlEnabled;
-                            controls[idx] = trueRange; // overwrite the bogus range info the API hands out by default.
-                        }
+                        Console.WriteLine("eraseme:        Doing the override to new limits.");
+                        // I do NOT want to overwrite the actual contents of the control that is
+                        // returned by the API, because I fear it's a reference to the one that is
+                        // really used by the rest of the game, and I don't know what I might break
+                        // by editing its values directly.  So instead I want to make a new one that
+                        // mimics the actual one, with the relevant range limit fields edited.
+                        // But there is no copy constructor or assignment operator for it, so
+                        // if I tried to copy all the fields I'd inevitably miss a few.  Instead I will
+                        // just only write to the few fields we actually use here in kOS.  This is not
+                        // a general all-purpose solution for every modder because many of these fields
+                        // are skipped in this copy:
+                        UI_FloatRange trueRange = new UI_FloatRange();
+                        trueRange.minValue = limitOverride.softLimits.x;
+                        trueRange.maxValue = limitOverride.softLimits.y;
+                        trueRange.stepIncrement = 0f;
+                        trueRange.controlEnabled = control.controlEnabled;
+                        controls[idx] = trueRange; // overwrite the bogus range info the API hands out by default.
+                        Console.WriteLine(string.Format("eraseme: just overwrote with min={0}, max={1}, step={2}", ((UI_FloatRange)controls[idx]).minValue, ((UI_FloatRange)controls[idx]).maxValue, ((UI_FloatRange)controls[idx]).stepIncrement));
                     }
                 }
             }

--- a/src/kOS/Suffixed/PartModuleField/BaseServoModuleFields.cs
+++ b/src/kOS/Suffixed/PartModuleField/BaseServoModuleFields.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using kOS.Safe.Utilities;
+
+// ABOUT THIS "using Expansions.Serenity;" LINE:
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// NOTE: "Serenity" means "Breaking Ground DLC", apparently.  It must have been
+// some internal name for the project.
+// Also, this namespace and its classes appear to ship with stock KSP 1.7.1's DLLs.
+// So it appears to be safe for us to have code that references the DLC's
+// namespace and its classes even though some users won't have the DLC.  Lacking
+// the DLC merely means you won't have any instances of these classes because none
+// of your parts use them, rather than lacking the class definitions themselves.)
+using Expansions.Serenity;
+using kOS.Safe.Encapsulation;
+using kOS.Safe.Exceptions;
+
+namespace kOS.Suffixed.PartModuleField
+{
+    [Safe.Utilities.KOSNomenclature("BaseServo")]
+    public class BaseServoModuleFields : PartModuleFields
+    {
+        private readonly BaseServo servo;
+        public BaseServoModuleFields(BaseServo servo, SharedObjects sharedObj) : base(servo, sharedObj)
+        {
+            this.servo = servo;
+        }
+
+        /// <summary>
+        /// Get the UI_Controls on a KSPField which are user editable.
+        /// BaseServo modules will sometimes use an alternative rule for
+        /// how their range limits work, and this checks to see if that
+        /// alternative is in play instead of the normal way.
+        /// </summary>
+        /// <param name="field"></param>
+        /// <returns></returns>
+        override protected List<UI_Control> GetFieldControls(BaseField field)
+        {
+            List<UI_Control> controls = base.GetFieldControls(field);
+
+            if (servo.useLimits)
+            {
+                AxisFieldLimit limitOverride = servo.GetAxisFieldLimit(field.name);
+                if (limitOverride != null)
+                {
+                    // This is the condition in which the DLC servo's KSPField's range values are
+                    // utter lies.  (Example: In a case like a Piston who's user interface lets
+                    // players pick any "Target Extension" values from 0 meters to 2.4 meters, down to
+                    // the exact centimeter, the UI_FloatRange control for "Target Extension" is lying,
+                    // reporting FloatRange values as if its valid values were actually 0 to 100 meters
+                    // and must be rounded to the nearest 1 meter.  That effectively meant kOS could only
+                    // set that slider to 3 distinct values: 0, 1, and 2.  Anything else got rounded to
+                    // one of those, making it impossible for kOS to let a script use that slider properly.)
+                    //
+                    // When this condition happens, we need to utterly ignore the
+                    // actual UI_Control values that the API claims are in use, and instead
+                    // replace it with this overridden version.
+                    //
+                    // If you are looking at this ugly code and want to judge me - remember I had to work this all
+                    // out from trial and error reverse engineering.  None of this was documented for modders.
+                    // There couild very well be a proper API call that does this cleanly, but I don't know what it is.
+
+                    for(int idx = 0; idx < controls.Count; ++idx)
+                    {
+                        UI_Control control = controls[idx];
+                        if (control.controlEnabled && control is UI_FloatRange || control is UI_FieldFloatRange)
+                        {
+                            // I do NOT want to overwrite the actual contents of the control that is
+                            // returned by the API, because I fear it's a reference to the one that is
+                            // really used by the rest of the game, and I don't know what I might break
+                            // by editing its values directly.  So instead I want to make a new one that
+                            // mimics the actual one, with the relevant range limit fields edited.
+                            // But there is no copy constructor or assignment operator for it, so
+                            // if I tried to copy all the fields I'd inevitably miss a few.  Instead I will
+                            // just only write to the few fields we actually use here in kOS.  This is not
+                            // a general all-purpose solution for every modder because many of these fields
+                            // are skipped in this copy:
+                            UI_FloatRange trueRange = new UI_FloatRange();
+                            trueRange.minValue = limitOverride.softLimits.x;
+                            trueRange.maxValue = limitOverride.softLimits.y;
+                            trueRange.stepIncrement = 0f;
+                            trueRange.controlEnabled = control.controlEnabled;
+                            controls[idx] = trueRange; // overwrite the bogus range info the API hands out by default.
+                        }
+                    }
+                }
+            }
+            return controls;
+        }
+    }
+}

--- a/src/kOS/Suffixed/PartModuleField/BaseServoModuleFields.cs
+++ b/src/kOS/Suffixed/PartModuleField/BaseServoModuleFields.cs
@@ -39,11 +39,9 @@ namespace kOS.Suffixed.PartModuleField
         override protected List<UI_Control> GetFieldControls(BaseField field)
         {
             List<UI_Control> controls = base.GetFieldControls(field);
-            Console.WriteLine("eraseme:   servo.useLimits = true.");
             AxisFieldLimit limitOverride = servo.GetAxisFieldLimit(field.name);
             if (limitOverride != null)
             {
-                Console.WriteLine("eraseme:     limitOverride != null.");
                 // This is the condition in which the DLC servo's KSPField's range values are
                 // utter lies.  (Example: In a case like a Piston who's user interface lets
                 // players pick any "Target Extension" values from 0 meters to 2.4 meters, down to
@@ -63,11 +61,9 @@ namespace kOS.Suffixed.PartModuleField
 
                 for (int idx = 0; idx < controls.Count; ++idx)
                 {
-                    Console.WriteLine("eraseme:      index = " + idx);
                     UI_Control control = controls[idx];
                     if (control.controlEnabled && control is UI_FloatRange || control is UI_FieldFloatRange)
                     {
-                        Console.WriteLine("eraseme:        Doing the override to new limits.");
                         // I do NOT want to overwrite the actual contents of the control that is
                         // returned by the API, because I fear it's a reference to the one that is
                         // really used by the rest of the game, and I don't know what I might break
@@ -84,7 +80,6 @@ namespace kOS.Suffixed.PartModuleField
                         trueRange.stepIncrement = 0f;
                         trueRange.controlEnabled = control.controlEnabled;
                         controls[idx] = trueRange; // overwrite the bogus range info the API hands out by default.
-                        Console.WriteLine(string.Format("eraseme: just overwrote with min={0}, max={1}, step={2}", ((UI_FloatRange)controls[idx]).minValue, ((UI_FloatRange)controls[idx]).maxValue, ((UI_FloatRange)controls[idx]).stepIncrement));
                     }
                 }
             }

--- a/src/kOS/Suffixed/PartModuleField/PartModuleFields.cs
+++ b/src/kOS/Suffixed/PartModuleField/PartModuleFields.cs
@@ -171,7 +171,6 @@ namespace kOS.Suffixed.PartModuleField
                 if (range != null)
                 {
                     float val = Convert.ToSingle(convertedVal);
-                    Console.WriteLine(string.Format("eraseme IsLegalValue: Clamping: {0}, {1}, {2}", range.minValue, range.maxValue, range.stepIncrement));
                     val = KOSMath.ClampToIndent(val, range.minValue, range.maxValue, range.stepIncrement);
                     convertedVal = Convert.ToDouble(val);
                 }

--- a/src/kOS/Suffixed/PartModuleField/PartModuleFields.cs
+++ b/src/kOS/Suffixed/PartModuleField/PartModuleFields.cs
@@ -79,7 +79,7 @@ namespace kOS.Suffixed.PartModuleField
         /// </summary>
         /// <param name="field"></param>
         /// <returns></returns>
-        private List<UI_Control> GetFieldControls(BaseField field)
+        virtual protected List<UI_Control> GetFieldControls(BaseField field)
         {
             var attribs = new List<object>();
             attribs.AddRange(field.FieldInfo.GetCustomAttributes(true));
@@ -177,6 +177,7 @@ namespace kOS.Suffixed.PartModuleField
                 if (!isLegal)
                     break;
             }
+
             newVal = FromPrimitiveWithAssert(convertedVal);
             return isLegal;
         }

--- a/src/kOS/Suffixed/PartModuleField/PartModuleFields.cs
+++ b/src/kOS/Suffixed/PartModuleField/PartModuleFields.cs
@@ -171,6 +171,7 @@ namespace kOS.Suffixed.PartModuleField
                 if (range != null)
                 {
                     float val = Convert.ToSingle(convertedVal);
+                    Console.WriteLine(string.Format("eraseme IsLegalValue: Clamping: {0}, {1}, {2}", range.minValue, range.maxValue, range.stepIncrement));
                     val = KOSMath.ClampToIndent(val, range.minValue, range.maxValue, range.stepIncrement);
                     convertedVal = Convert.ToDouble(val);
                 }
@@ -415,6 +416,9 @@ namespace kOS.Suffixed.PartModuleField
             AddSuffix("ALLACTIONNAMES", new Suffix<ListValue>(AllActionNames));
             AddSuffix("HASACTION", new OneArgsSuffix<BooleanValue, StringValue>(HasAction));
             AddSuffix("GETFIELD", new OneArgsSuffix<Structure, StringValue>(GetKSPFieldValue));
+            AddSuffix("GETFIELDMIN", new OneArgsSuffix<Structure, StringValue>(GetKSPFieldMin));
+            AddSuffix("GETFIELDMAX", new OneArgsSuffix<Structure, StringValue>(GetKSPFieldMax));
+            AddSuffix("GETFIELDSTEP", new OneArgsSuffix<Structure, StringValue>(GetKSPFieldStep));
             AddSuffix("SETFIELD", new TwoArgsSuffix<StringValue, Structure>(SetKSPFieldValue));
             AddSuffix("DOEVENT", new OneArgsSuffix<StringValue>(CallKSPEvent));
             AddSuffix("DOACTION", new TwoArgsSuffix<StringValue, BooleanValue>(CallKSPAction));
@@ -432,6 +436,65 @@ namespace kOS.Suffixed.PartModuleField
                 /* evt.externalToEVAOnly) && */ // this flag seems bugged.  It always returns true no matter what.
                 evt.active
                 );
+        }
+
+        protected Structure GetKSPFieldMin(StringValue fieldName)
+        {
+            BaseField field = GetField(fieldName);
+            if (field == null)
+                throw new KOSLookupFailException("FIELD", fieldName, this);
+
+            object min = -99999f;
+            List<UI_Control> controls = GetFieldControls(field);
+            foreach (UI_Control control in controls)
+            {
+                if (control is UI_FloatRange)
+                    min = ((UI_FloatRange)control).minValue;
+                else if (control is UI_Label)
+                    min = "";
+                else if (control is UI_Toggle)
+                    min = false;
+            }
+            Structure obj = FromPrimitiveWithAssert(min);
+            return obj;
+        }
+
+        protected Structure GetKSPFieldMax(StringValue fieldName)
+        {
+            BaseField field = GetField(fieldName);
+            if (field == null)
+                throw new KOSLookupFailException("FIELD", fieldName, this);
+
+            object max = 99999f;
+            List<UI_Control> controls = GetFieldControls(field);
+            foreach (UI_Control control in controls)
+            {
+                if (control is UI_FloatRange)
+                    max = ((UI_FloatRange)control).maxValue;
+                else if (control is UI_Label)
+                    max = "";
+                else if (control is UI_Toggle)
+                    max = false;
+            }
+            Structure obj = FromPrimitiveWithAssert(max);
+            return obj;
+        }
+
+        protected Structure GetKSPFieldStep(StringValue fieldName)
+        {
+            BaseField field = GetField(fieldName);
+            if (field == null)
+                throw new KOSLookupFailException("FIELD", fieldName, this);
+
+            object step = 0f;
+            List<UI_Control> controls = GetFieldControls(field);
+            foreach (UI_Control control in controls)
+            {
+                if (control is UI_FloatRange)
+                    step = ((UI_FloatRange)control).stepIncrement;
+            }
+            Structure obj = FromPrimitiveWithAssert(step);
+            return obj;
         }
 
         /// <summary>

--- a/src/kOS/Suffixed/PartModuleField/PartModuleFieldsFactory.cs
+++ b/src/kOS/Suffixed/PartModuleField/PartModuleFieldsFactory.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using kOS.Safe.Encapsulation;
 using kOS.AddOns.RemoteTech;
@@ -39,6 +39,10 @@ namespace kOS.Suffixed.PartModuleField
             {
                 return scienceExperimentFields;
             }
+
+            var baseServo = mod as Expansions.Serenity.BaseServo;
+            if (baseServo != null)
+                return new BaseServoModuleFields(baseServo, shared);
 
             return new PartModuleFields(mod, shared);
         }

--- a/src/kOS/kOS.csproj
+++ b/src/kOS/kOS.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Suffixed\CraftTemplate.cs" />
     <Compile Include="Suffixed\KUniverseValue.cs" />
     <Compile Include="Suffixed\LoadDistanceValue.cs" />
+    <Compile Include="Suffixed\PartModuleField\BaseServoModuleFields.cs" />
     <Compile Include="Suffixed\Part\DecouplerValue.cs" />
     <Compile Include="Suffixed\Part\LaunchClampValue.cs" />
     <Compile Include="Suffixed\ResourceTransferValue.cs" />


### PR DESCRIPTION
Fixes #2531 

I still believe proper support of the Breaking Ground DLC will require much more work than just this, using special case part abstractions similar to the engine part abstractions we have, but this at least fixes the problem with the slider range limits being reported wrong by the Breaking Ground DLC's UI sliders.

These new sliders have min/max values that can be different per part depending on what the limits were set to in the VAB.  That system seems to utterly bypass the usual field range values, rather than *setting and using* them as I'd prefer. 

EDIT: Also, this includes some new suffixes so a script can read the min/max values of a robot servo part module.

