### PR TITLE
Fixes #2545. Adds control locking from rp-1. 

### DIFF
--- a/src/kOS/Module/kOSVesselModule.cs
+++ b/src/kOS/Module/kOSVesselModule.cs
@@ -394,6 +394,11 @@ namespace kOS.Module
         /// <param name="c"></param>
         private void UpdateAutopilot(FlightCtrlState c)
         {
+            // Lock out controls if insufficient avionics in RP-0.
+            ControlTypes RP0Lock = InputLockManager.GetControlLock("RP0ControlLocker");
+            if (RP0Lock != 0)
+                return;
+
             if (Vessel != null)
             {
                 if (childParts.Count > 0)


### PR DESCRIPTION
Fixes #2545.
Adds a read of the rp-1 control locking mechanism so that craft with insufficient avionics are uncontrollable. No effect for non rp-1 games (as the lock will not exist). 