### PR TITLE
Fixes #2373 with new atmosphere data.

### DIFF
--- a/doc/source/math/basic.rst
+++ b/doc/source/math/basic.rst
@@ -39,6 +39,12 @@ constants about the universe that you may find handy in your math operations.  P
       - Conversion constant: Degrees to Radians.
     * - :global:`RadToDeg`
       - Conversion constant: Radians to Degrees.
+    * - :global:`Avogadro`
+      - Avogadro's Constant
+    * - :global:`Boltzmann`
+      - Boltzmann's Constant
+    * - :global:`IdealGas`
+      - The Ideal Gas Constant
 
 
 .. global:: Constant:G
@@ -56,7 +62,7 @@ constants about the universe that you may find handy in your math operations.  P
     within that game universe, and instead varies from one sphere
     of influence to the next.  Such a universe would be breaking
     some laws of physics by a lot, but it is technically possible
-    in the game's data model.  Due to this strange misfeature in
+    in the game's data model.  Due to this strange feature in
     the game's data model, it is probably safer to always have
     your scripts use the body's Mu in your formulas instead of
     explicitly doing mass*G to derive it.
@@ -85,19 +91,19 @@ constants about the universe that you may find handy in your math operations.  P
     contains an inherent conversion from mass to weight
     that basically means, "what would this mass of fuel
     have weighed at g0?".  Some kind of official standard
-    value of g0 is needed to use ISP to predict truly
-    accurately how much fuel will be burned in a scenario.
+    value of g0 is needed to use ISP properly to predict
+    how much fuel will be burned in a scenario.
 
-    In pretty much any other calculation other than using
-    ISP in the Rocketry Equation, you should probably
-    not use g0 and instead calculate your local gravity
-    more precisely based on your actual radius to the body
-    center.  Not only because this is more accurate, but
-    because the g0 you see here is NOT the g0 you would
-    actually have on Kerbin's sea level.  It's the g0 on
-    Earth, which is what the game's ISP numbers are using.
-    Kerbin's sea level g0 is ever so slightly different
-    from Earth's g0 (but not by much.)
+    In pretty much any other calculation you do in your kOS
+    scripts, other than when using ISP in the Rocketry Equation,
+    you should probably not use g0 and instead calculate your
+    local gravity more precisely based on your actual radius to
+    the body center.  Not only because this is more accurate, but
+    because the g0 you see here is NOT the g0 you would actually
+    have on Kerbin's sea level.  It's the g0 on Earth, which is
+    what the game's ISP numbers are using.  Kerbin's sea level
+    g0 is ever so slightly different from Earth's g0 (but not
+    by much.)
 
     ::
 
@@ -199,6 +205,31 @@ constants about the universe that you may find handy in your math operations.  P
         PRINT "A radian is:".
         PRINT 1 * constant:RadToDeg + " degrees".
 
+.. global:: Constant:Avogadro
+
+    Avogadro's Constant
+
+    This value can be used in calculating atmospheric properties for drag purposes,
+    which can be a rather advanced topic.
+    :ref:`(Wikipedia Page) <https://en.wikipedia.org/wiki/Avogadro_constant>`_.
+
+.. global:: Constant:Boltzmann
+
+    Boltzmann Constant
+
+    This value can be used in calculating atmospheric properties for drag purposes,
+    which can be a rather advanced topic.
+    :ref:`(Wikipedia Page) <https://en.wikipedia.org/wiki/Boltzmann_constant>`_.
+
+.. global:: Constant:IdealGas
+
+    Ideal Gas Constant
+
+    This value can be used in calculating atmospheric properties for drag purposes,
+    which can be a rather advanced topic.
+    :ref:`(Wikipedia Page) <https://en.wikipedia.org/wiki/Gas_constant>`_.
+
+
 .. _math functions:
 .. index:: Mathematical Functions
 
@@ -214,9 +245,9 @@ Mathematical Functions
  :func:`LN(a)`        natural log
  :func:`LOG10(a)`     log base 10
  :func:`MOD(a,b)`     modulus
- :func:`MIN(a,b)`     minimum
- :func:`MAX(a,b)`     maximum
- :func:`RANDOM()`     random number
+ :func:`MIN(a,b)`     return a or b, whichever is lesser.
+ :func:`MAX(a,b)`     return a or b, whichever is greater.
+ :func:`RANDOM()`     random fractional number between 0 and 1.
  :func:`ROUND(a)`     round to whole number
  :func:`ROUND(a,b)`   round to nearest place
  :func:`SQRT(a)`      square root
@@ -276,9 +307,18 @@ Mathematical Functions
 
 .. function:: RANDOM()
 
-    Returns a random floating point number in the range [0,1]::
+    Returns a random floating point number in the range [0..1]::
 
         PRINT RANDOM(). //prints a random number
+        PRINT "Let's roll a 6-sided die 10 times:".
+        FOR n in range(0,10) {
+
+          // To make RANDOM give you an integer in the range [0..n-1], you do this:
+          // floor(n*RANDOM()).
+
+          // So for example : a die giving values from 1 to 6 is like this:
+          print (1 + floor(6*RANDOM())).
+        }
 
 .. function:: ROUND(a)
 

--- a/doc/source/structures/celestial_bodies/atmosphere.rst
+++ b/doc/source/structures/celestial_bodies/atmosphere.rst
@@ -36,6 +36,21 @@ A Structure closely tied to :struct:`Body` A variable of type :struct:`Atmospher
         * - :attr:`HEIGHT`
           - :ref:`scalar <scalar>` (m)
           - advertised atmospheric height
+        * - :attr:`MOLARMASS`
+          - :ref:`scalar <scalar>` (kg/mol)
+          - The molecular mass of the atmosphere's gas
+        * - :attr:`ADIABATICINDEX`
+          - :ref:`scalar <scalar>`
+          - The Adiabatic index of the atmosphere's gas
+        * - :attr:`ADBIDX`
+          - :ref:`scalar <scalar>`
+          - Short alias for :attr:`ADIABATICINDEX`
+        * - :meth:`ALTITUDETEMPERATURE(altitude)`
+          - :ref:`scalar <scalar>`
+          - Estimate of temperature at the given altitude.
+        * - :meth:`ALTTEMP(altitude)`
+          - :ref:`scalar <scalar>`
+          - Short alias for :attr:`ALTITUDETEMPERATURE`
 
 
 .. attribute:: Atmosphere:BODY
@@ -97,6 +112,42 @@ A Structure closely tied to :struct:`Body` A variable of type :struct:`Atmospher
 
     The altitude at which the atmosphere is "officially" advertised as ending. (actual ending value differs, see below).
 
+.. attribute:: Atmosphere:MOLARMASS
+
+    :type: :ref:`scalar <scalar>`
+    :acces: Get only
+
+    The Molecular Mass of the gas the atmosphere is composed of.
+    Units are in kg/mol.
+    :ref:`Wikipedia Explanation <https://en.wikipedia.org/wiki/Molar_mass>`_.
+
+.. attribute:: Atmosphere:ADIABATICINDEX
+
+    :type: :ref:`scalar <scalar>`
+    :access: Get only
+
+    The Adiabatic index of the gas the atmosphere is composed of.
+    :ref:`Wikipedia Explanation <https://en.wikipedia.org/wiki/Heat_capacity_ratio>`_.
+
+.. attribute:: Atmosphere:ADBIDX
+
+    :type: :ref:`scalar <scalar>`
+    :access: Get only
+
+    A shorthand alias for :attr:ADIABATICINDEX.
+
+.. method:: Atmosphere:ALTITUDETEMPERATURE(altitude)
+
+    :parameter: altitude (:ref:`scalar <scalar>`) the altitude to query temperature at.
+    :access: Get only
+
+    Returns an approximate atmosphere temperature on this world at the given altitude.
+    Note that this is only approximate because the temperature will vary depending
+    on the sun position in the sky (i.e. your latitude and what time of day it is).
+
+.. method:: Atmosphere:ALTTEMP(altitude)
+
+   A shorthand alias for :meth:ALTITUDETEMPERATURE(altitude).
 
 Deprecated Suffix
 -----------------

--- a/src/kOS.Safe/Encapsulation/ConstantValue.cs
+++ b/src/kOS.Safe/Encapsulation/ConstantValue.cs
@@ -26,7 +26,46 @@ namespace kOS.Safe.Encapsulation
             get { return gravConstBeingUsed; }
             set { gravConstBeingUsed = value; }
         }
-        
+
+        private static double avogadroFromWIKI = 6.02214076 * Math.Pow(10, 23);
+        private static double avogadroBeingUsed = avogadroFromWIKI;
+
+        /// <summary>
+        /// This is a public property so that it can be overridden by KSP-aware code elsewhere:
+        /// (ConstantValue is in kOS.Safe, so we can't see KSP's G value from here.)
+        /// </summary>
+        public static double AvogadroConst
+        {
+            get { return avogadroBeingUsed; }
+            set { avogadroBeingUsed = value; }
+        }
+
+        private static double boltzmannFromWiki = 1.380649 * Math.Pow(10, -23);
+        private static double boltzmannBeingUsed = boltzmannFromWiki;
+
+        /// <summary>
+        /// This is a public property so that it can be overridden by KSP-aware code elsewhere:
+        /// (ConstantValue is in kOS.Safe, so we can't see KSP's G value from here.)
+        /// </summary>
+        public static double BoltzmannConst
+        {
+            get { return boltzmannBeingUsed; }
+            set { boltzmannBeingUsed = value; }
+        }
+
+        private static double idealGasFromWiki = 8.31446215324;
+        private static double idealGasBeingUsed = idealGasFromWiki;
+
+        /// <summary>
+        /// This is a public property so that it can be overridden by KSP-aware code elsewhere:
+        /// (ConstantValue is in kOS.Safe, so we can't see KSP's G value from here.)
+        /// </summary>
+        public static double IdealGasConst
+        {
+            get { return idealGasBeingUsed; }
+            set { idealGasBeingUsed = value; }
+        }
+
         private static double g0 = 9.80665; // Typically accepted Earth value. Will override with KSP game value.
         public static double G0
         {
@@ -49,6 +88,10 @@ namespace kOS.Safe.Encapsulation
             
             // 180/pi :
             AddGlobalSuffix<ConstantValue>("RADTODEG", new StaticSuffix<ScalarValue>(() => 57.295779513082320876798154814105, "radians to degrees"));
+
+            AddGlobalSuffix<ConstantValue>("AVOGADRO", new StaticSuffix<ScalarValue>(() => AvogadroConst));
+            AddGlobalSuffix<ConstantValue>("BOLTZMANN", new StaticSuffix<ScalarValue>(() => BoltzmannConst));
+            AddGlobalSuffix<ConstantValue>("IDEALGAS", new StaticSuffix<ScalarValue>(() => IdealGasConst));
         }
 
         public override string ToString()

--- a/src/kOS/Function/Suffixed.cs
+++ b/src/kOS/Function/Suffixed.cs
@@ -164,7 +164,7 @@ namespace kOS.Function
         {
             string bodyName = PopValueAssert(shared).ToString();
             AssertArgBottomAndConsume(shared);
-            var result = new BodyAtmosphere(VesselUtils.GetBodyByName(bodyName));
+            var result = new BodyAtmosphere(VesselUtils.GetBodyByName(bodyName), shared);
             ReturnValue = result;
         }
     }

--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -548,6 +548,10 @@ namespace kOS.Module
                 SafeHouse.Logger.LogError("kOSProcessor: This game installation is badly broken.  It appears to have no planets in it.");
             else
                 ConstantValue.GravConst = anyBody.gravParameter / anyBody.Mass;
+
+            ConstantValue.AvogadroConst = PhysicsGlobals.AvogadroConstant;
+            ConstantValue.BoltzmannConst = PhysicsGlobals.BoltzmannConstant;
+            ConstantValue.IdealGasConst = PhysicsGlobals.IdealGasConstant;
         }
 
         private void InitProcessorTracking()

--- a/src/kOS/Suffixed/BodyAtmosphere.cs
+++ b/src/kOS/Suffixed/BodyAtmosphere.cs
@@ -21,7 +21,7 @@ namespace kOS.Suffixed
             AddSuffix("SEALEVELPRESSURE", new Suffix<ScalarValue>(()=> celestialBody.atmosphere ? celestialBody.atmospherePressureSeaLevel * ConstantValue.KpaToAtm : 0));
             AddSuffix("HEIGHT", new Suffix<ScalarValue>(()=> celestialBody.atmosphere ? celestialBody.atmosphereDepth : 0));
             AddSuffix("ALTITUDEPRESSURE", new OneArgsSuffix<ScalarValue, ScalarValue>((alt)=> celestialBody.GetPressure(alt) * ConstantValue.KpaToAtm));
-            AddSuffix(new string[] { "MOLECULARMASS", "MOLMASS" }, new Suffix<ScalarValue>(() => celestialBody.atmosphereMolarMass));
+            AddSuffix("MOLARMASS", new Suffix<ScalarValue>(() => celestialBody.atmosphereMolarMass));
             AddSuffix(new string[] { "ADIABATICINDEX", "ADBIDX" }, new Suffix<ScalarValue>(() => celestialBody.atmosphereAdiabaticIndex));
             AddSuffix(new string[] { "ALTITUDETEMPERATURE", "ALTTEMP" }, new OneArgsSuffix<ScalarValue, ScalarValue>((alt) => celestialBody.GetTemperature(alt)));
         }

--- a/src/kOS/Suffixed/BodyAtmosphere.cs
+++ b/src/kOS/Suffixed/BodyAtmosphere.cs
@@ -1,4 +1,4 @@
-﻿using kOS.Safe.Encapsulation;
+using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Exceptions;
 
@@ -8,10 +8,12 @@ namespace kOS.Suffixed
     public class BodyAtmosphere : Structure
     {
         private readonly CelestialBody celestialBody;
+        private readonly SharedObjects shared;
 
-        public BodyAtmosphere(CelestialBody celestialBody)
+        public BodyAtmosphere(CelestialBody celestialBody, SharedObjects shared)
         {
             this.celestialBody = celestialBody;
+            this.shared = shared;
 
             AddSuffix("BODY", new Suffix<StringValue>(()=> celestialBody.bodyName));
             AddSuffix("EXISTS", new Suffix<BooleanValue>(()=> celestialBody.atmosphere));
@@ -19,8 +21,9 @@ namespace kOS.Suffixed
             AddSuffix("SEALEVELPRESSURE", new Suffix<ScalarValue>(()=> celestialBody.atmosphere ? celestialBody.atmospherePressureSeaLevel * ConstantValue.KpaToAtm : 0));
             AddSuffix("HEIGHT", new Suffix<ScalarValue>(()=> celestialBody.atmosphere ? celestialBody.atmosphereDepth : 0));
             AddSuffix("ALTITUDEPRESSURE", new OneArgsSuffix<ScalarValue, ScalarValue>((alt)=> celestialBody.GetPressure(alt) * ConstantValue.KpaToAtm));
-
-            AddSuffix("SCALE", new Suffix<ScalarValue>(() => { throw new KOSAtmosphereObsoletionException("0.17.2","SCALE","<None>",string.Empty); }));
+            AddSuffix(new string[] { "MOLECULARMASS", "MOLMASS" }, new Suffix<ScalarValue>(() => celestialBody.atmosphereMolarMass));
+            AddSuffix(new string[] { "ADIABATICINDEX", "ADBIDX" }, new Suffix<ScalarValue>(() => celestialBody.atmosphereAdiabaticIndex));
+            AddSuffix(new string[] { "ALTITUDETEMPERATURE", "ALTTEMP" }, new OneArgsSuffix<ScalarValue, ScalarValue>((alt) => celestialBody.GetTemperature(alt)));
         }
 
         public override string ToString()

--- a/src/kOS/Suffixed/BodyTarget.cs
+++ b/src/kOS/Suffixed/BodyTarget.cs
@@ -103,7 +103,7 @@ namespace kOS.Suffixed
             AddSuffix("RADIUS", new Suffix<ScalarValue>(() => Body.Radius));
             AddSuffix("MU", new Suffix<ScalarValue>(() => Body.gravParameter));
             AddSuffix("ROTATIONPERIOD", new Suffix<ScalarValue>(() => Body.rotationPeriod));
-            AddSuffix("ATM", new Suffix<BodyAtmosphere>(() => new BodyAtmosphere(Body)));
+            AddSuffix("ATM", new Suffix<BodyAtmosphere>(() => new BodyAtmosphere(Body, Shared)));
             AddSuffix("ANGULARVEL", new Suffix<Vector>(() => RawAngularVelFromRelative(Body.angularVelocity)));
             AddSuffix("SOIRADIUS", new Suffix<ScalarValue>(() => Body.sphereOfInfluence));
             AddSuffix("ROTATIONANGLE", new Suffix<ScalarValue>(() => Body.rotationAngle));


### PR DESCRIPTION
Fixes #2373 

While I was at it, I also edited a few lines in the
constant documentation that needed cleaning up,
since I was in there an noticed them.

There is an API call from KSP called
CelestialBody.GetFullTemperature(Vector3d position),
but as far as I can tell it seems totally broken, or
at least is in a weird reference frame I don't know about.
So I gave up on supporting that, since I don't seem
to be able to make it work (also, other KSP mods seem
to have written their own replacement for this call as
well, indicating that they found it didn't work for them
either.)