### PR TITLE
Fixes #2568 - Unity's IMGUI works better without KSP locking.

### DIFF
--- a/src/kOS/Screen/GUIWindow.cs
+++ b/src/kOS/Screen/GUIWindow.cs
@@ -41,6 +41,7 @@ namespace kOS.Screen
 
         public void Awake()
         {
+
             // Transparent - leave the widget inside it to draw background if it wants to.
             style = new GUIStyle(HighLogic.Skin.window);
             style.normal.background = null;
@@ -66,6 +67,10 @@ namespace kOS.Screen
 
             GameEvents.onHideUI.Add (OnHideUI);
 			GameEvents.onShowUI.Add (OnShowUI);
+
+            // Fixes #2568 - Unity IMGUI does its own individual input locking per field that needs it,
+            // so don't use KSP's more high-level control locking:
+            OptOutOfControlLocking = true;
         }
 
         public void OnDestroy()

--- a/src/kOS/Screen/KOSManagedWindow.cs
+++ b/src/kOS/Screen/KOSManagedWindow.cs
@@ -54,7 +54,7 @@ namespace kOS.Screen
         public bool OptOutOfControlLocking
         {
             get { return optOutOfControlLocking; }
-            set { optOutOfControlLocking = value; if (value) InputLockManager.RemoveControlLock(lockIdName); }
+            set { if (value) InputLockManager.RemoveControlLock(lockIdName); optOutOfControlLocking = value; }
         }
 
         protected KOSManagedWindow(string lockIdName = "")

--- a/src/kOS/Screen/KOSManagedWindow.cs
+++ b/src/kOS/Screen/KOSManagedWindow.cs
@@ -45,6 +45,18 @@ namespace kOS.Screen
 
         private string lockIdName;
 
+        private bool optOutOfControlLocking;
+        /// <summary>
+        /// Fixes #2568 - If the window is one where Unity can handle doing the keyboard focus
+        /// properly itself, like a Unity IMGUI window, then it should set this to true so it
+        /// will avoid using KSP's more high level control locking scheme whcih is a bit flaky at times:
+        /// </summary>
+        public bool OptOutOfControlLocking
+        {
+            get { return optOutOfControlLocking; }
+            set { optOutOfControlLocking = value; if (value) InputLockManager.RemoveControlLock(lockIdName); }
+        }
+
         protected KOSManagedWindow(string lockIdName = "")
         {
             // multiply by 50 so there's a range for future expansion for other GUI objects inside the window:
@@ -144,6 +156,8 @@ namespace kOS.Screen
         /// </summary>
         public virtual void GetFocus()
         {
+            if (OptOutOfControlLocking)
+                return;
             if (HighLogic.LoadedSceneIsFlight || HighLogic.LoadedSceneHasPlanetarium)
                 InputLockManager.SetControlLock(ControlTypes.ALLBUTCAMERAS, lockIdName);
         }
@@ -156,6 +170,8 @@ namespace kOS.Screen
         /// </summary>
         public virtual void LoseFocus()
         {
+            if (OptOutOfControlLocking)
+                return;
             InputLockManager.RemoveControlLock(lockIdName);
         }
         


### PR DESCRIPTION
KSP's control locking as a way to disable keypresses from
doing things to the game isn't needed when the window is a
Unity IMGUI window that handles keyboard focus itself
anyway, so this gives an option for it to disable that part of
KOSManagedWindow.