### PR TITLE
Protections against waypoints with bogus body names.

### DIFF
--- a/src/kOS/Function/Suffixed.cs
+++ b/src/kOS/Function/Suffixed.cs
@@ -164,7 +164,10 @@ namespace kOS.Function
         {
             string bodyName = PopValueAssert(shared).ToString();
             AssertArgBottomAndConsume(shared);
-            var result = new BodyAtmosphere(VesselUtils.GetBodyByName(bodyName), shared);
+            var bod = VesselUtils.GetBodyByName(bodyName);
+            if (bod == null)
+                throw new KOSInvalidArgumentException(GetFuncName(), bodyName, "Body not found in this solar system");
+            var result = new BodyAtmosphere(bod, shared);
             ReturnValue = result;
         }
     }
@@ -591,7 +594,11 @@ namespace kOS.Function
             // But for now, this is the only place it's done:
 
             foreach (Waypoint point in points)
-                returnList.Add(new WaypointValue(point, shared));
+            {
+                WaypointValue wp = WaypointValue.CreateWaypointValueWithCheck(point, shared, true);
+                if (wp != null)
+                    returnList.Add(wp);
+            }
             ReturnValue = returnList;
         }
     }
@@ -639,7 +646,7 @@ namespace kOS.Function
             if (point == null)
                 throw new KOSInvalidArgumentException("waypoint", "\""+pointName+"\"", "no such waypoint");
 
-            ReturnValue = new WaypointValue(point, shared);
+        ReturnValue = WaypointValue.CreateWaypointValueWithCheck(point, shared, false);
         }
     }
 

--- a/src/kOS/Suffixed/BodyTarget.cs
+++ b/src/kOS/Suffixed/BodyTarget.cs
@@ -88,7 +88,11 @@ namespace kOS.Suffixed
 
         public static BodyTarget CreateOrGetExisting(string bodyName, SharedObjects shared)
         {
-            return CreateOrGetExisting(VesselUtils.GetBodyByName(bodyName), shared);
+            var bod = VesselUtils.GetBodyByName(bodyName);
+            if (bod == null)
+                throw new KOSInvalidArgumentException("BODY() constructor", bodyName, "Body not found in this solar system");
+
+            return CreateOrGetExisting(bod, shared);
         }
 
         private void BodyInitializeSuffixes()

--- a/src/kOS/Suffixed/WaypointValue.cs
+++ b/src/kOS/Suffixed/WaypointValue.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using kOS.Utilities;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Encapsulation;
+using kOS.Safe.Exceptions;
 using FinePrint; // This is part of KSP's own DLL now.  The Waypoint info is in here.
 
 namespace kOS.Suffixed
@@ -15,11 +16,27 @@ namespace kOS.Suffixed
         protected SharedObjects Shared { get; set; }
         private static Dictionary<string,int> greekMap;
         
-        public WaypointValue(Waypoint wayPoint, SharedObjects shared)
+        private WaypointValue(Waypoint wayPoint, SharedObjects shared)
         {
             WrappedWaypoint = wayPoint;
             Shared = shared;
             InitializeSuffixes();
+        }
+
+        public static WaypointValue CreateWaypointValueWithCheck(Waypoint wayPoint, SharedObjects shared, bool failOkay)
+        {
+            string bodyName = wayPoint.celestialName;
+            CelestialBody bod = VesselUtils.GetBodyByName(bodyName);
+            if (bod == null)
+            {
+                if (failOkay)
+                    return null;
+                else
+                    throw new KOSInvalidArgumentException("WAYPOINT constructor", bodyName, "Body not found in this solar system");
+            }
+            WaypointValue wp = new WaypointValue(wayPoint, shared);
+            wp.CachedBody = bod;
+            return wp;
         }
 
         private void InitializeSuffixes()


### PR DESCRIPTION
With Kopernicus, it's possible to have waypoints
in the game that refer to bodies that are missing.
This commit allows kOS to operate anyway, by
pretending such waypoints do not exist.