### PR TITLE
Fixes #2598 - implements forced sort order.

### DIFF
--- a/src/kOS/Screen/KOSToolbarWindow.cs
+++ b/src/kOS/Screen/KOSToolbarWindow.cs
@@ -78,6 +78,7 @@ namespace kOS.Screen
         private bool alreadyAwake;
         private bool firstTime = true;
         private bool isOpen;
+        private bool wasOpenLastPaint;
         private kOS.Screen.ListPickerDialog fontPicker;
         private kOS.Screen.ListPickerDialog ipAddrPicker;
 
@@ -427,7 +428,16 @@ namespace kOS.Screen
             horizontalSectionCount = 0;
             verticalSectionCount = 0;
 
-            if (!isOpen) return;
+            if (!isOpen)
+            {
+                wasOpenLastPaint = false;
+                return;
+            }
+
+            // Sorting the list is expensive.  Only do it when the window is first re-opened, not on every single repaint:
+            if (!wasOpenLastPaint)
+                kOSProcessor.SortAllInstances();
+            wasOpenLastPaint = true;
 
             if (uiGloballyHidden && kOS.Safe.Utilities.SafeHouse.Config.ObeyHideUI) return;
 

--- a/src/kOS/UserIO/TelnetWelcomeMenu.cs
+++ b/src/kOS/UserIO/TelnetWelcomeMenu.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Collections.Generic;
 using System.Text;
@@ -168,6 +168,10 @@ namespace kOS.UserIO
         {
             localMenuBuffer.Remove(0,localMenuBuffer.Length); // Any time the menu is reprinted, clear out any previous buffer text.
             telnetServer.ReadAll(); // Consume and throw away any readahead typing that preceeded the printing of this menu.
+
+            kOSProcessor.SortAllInstances();
+            CPUListChanged();
+
 
             forceMenuReprint = false;
 


### PR DESCRIPTION
The idea of the decoupler count was not implemented.
It just does a parent part count instead.  Trying to
decide what counts as a decoupler is messy, and it
wasn't easy to borrow the PART:DECOUPLER logic,
because that's too tied to our PartValue wrapper
around the part, and this is happening at a more
low-level than that.