### PR TITLE
Fixes #2611 bypass some repaint just after resize

### DIFF
--- a/src/kOS.Safe/Screen/ScreenBuffer.cs
+++ b/src/kOS.Safe/Screen/ScreenBuffer.cs
@@ -271,8 +271,11 @@ namespace kOS.Safe.Screen
                         if ((mergeRow + rowsToMerge) > RowCount) rowsToMerge = (RowCount - mergeRow);
                         List<IScreenBufferLine> bufferRange = subBuffer.Buffer.GetRange(startRow, rowsToMerge);
 
-                        // remove the replaced rows
-                        mergedBuffer.RemoveRange(mergeRow, rowsToMerge);
+                        // Remove the replaced rows, but protect against the case where they didn't exist in
+                        // the first place because sizes just got changed in a window drag during the GUI pass:
+                        int mergeRowClamped = Math.Min(Math.Max(mergeRow, 0), mergedBuffer.Count - 1);
+                        int rowsToMergeClamped = Math.Min(Math.Max(rowsToMerge, 0), (mergedBuffer.Count - mergeRowClamped));
+                        mergedBuffer.RemoveRange(mergeRowClamped, rowsToMergeClamped);
                         // Replace them:
                         mergedBuffer.InsertRange(mergeRow, bufferRange);
                     }


### PR DESCRIPTION
fixes #2611 

Just after a GUI pass notices the terminal got resized,
the screen buffers are temporarily the wrong size for
the next GUI repaint pass.  They will get corrected
later, but for a brief moment they're wrong, and that
was causing the exception.  When the exception got
thrown, it aborted the GUI pass before the code that
recalculates the buffer size gets reached, so the same
exception happens again the next pass, and so on.

The fix was to just let the repaint pass work with
the wrong buffer size (protecting against the things
being out of bounds, and just painting the subset of the
buffer that fits). On the next repaint pass after that
it should have the right buffer sizes recalced by then and
be able to paint it right.