### PR TITLE
Fix for changes to part configs breaking ships

### DIFF
--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -267,7 +267,8 @@ namespace kOS.Module
 
         private void UpdateCostAndMass()
         {
-            float spaceDelta = diskSpace - baseDiskSpace;
+            // Clamp this to prevent negative cost and mass.
+            float spaceDelta = Mathf.Max(diskSpace - baseDiskSpace, 0.0f);
             additionalCost = (float)System.Math.Round(spaceDelta * diskSpaceCostFactor, 0);
             AdditionalMass = spaceDelta * diskSpaceMassFactor;
             additionalMassGui = AdditionalMass * 1000;


### PR DESCRIPTION
Fixes #2660, whereby if the underlying part values change then saved ships can end up with negative mass and cost on their kOSProcessor parts.