### PR TITLE
Engine Value improvements

### DIFF
--- a/doc/source/structures/vessels/aggregateresource.rst
+++ b/doc/source/structures/vessels/aggregateresource.rst
@@ -50,6 +50,9 @@ This is also the type returned by STAGE:RESOURCES ::
         * - :attr:`CAPACITY`
           - :ref:`scalar <scalar>`
           - Total amount when full
+        * - :attr:`DENSITY`
+          - :ref:`scalar <scalar>`
+          - Density of this resource
         * - :attr:`PARTS`
           - List
           - Parts containing this resource
@@ -75,6 +78,16 @@ This is also the type returned by STAGE:RESOURCES ::
     :type: :ref:`scalar <scalar>`
 
     What AMOUNT would be if the resource was filled to the top.
+
+.. attribute:: AggregateResource:DENSITY
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+
+    The density value of this resource, expressed in Megagrams f mass
+    per Unit of resource.  (i.e. a value of 0.005 would mean that each
+    unit of this resource is 5 kilograms.  Megagrams [metric tonnes] is
+    the usual unit that most mass in the game is represented in.)
 
 .. attribute:: AggregateResource:PARTS
 

--- a/doc/source/structures/vessels/consumedresource.rst
+++ b/doc/source/structures/vessels/consumedresource.rst
@@ -1,0 +1,123 @@
+.. _consumedresource:
+
+ConsumedResource
+=================
+
+A single resource value an engine consumes (i.e. fuel, oxidizer, etc). This is the type returned by the :struct:`Engine`:CONSUMEDRESOURCES suffix
+
+.. structure:: ConsumedResource
+
+    .. list-table::
+        :header-rows: 1
+        :widths: 2 1 4
+
+        * - Suffix
+          - Type
+          - Description
+
+        * - :attr:`NAME`
+          - :ref:`string <string>`
+          - Resource name
+        * - :attr:`AMOUNT`
+          - :ref:`scalar <scalar>`
+          - Total amount remaining (only valid while engine is running)
+        * - :attr:`CAPACITY`
+          - :ref:`scalar <scalar>`
+          - Total amount when full (only valid while engine is running)
+        * - :attr:`DENSITY`
+          - :ref:`scalar <scalar>`
+          - Density of this resource
+        * - :attr:`FUELFLOW`
+          - :ref:`scalar <scalar>`
+          - Current volumetric flow rate of fuel
+        * - :attr:`MAXFUELFLOW`
+          - :ref:`scalar <scalar>`
+          - Untweaked maximum volumetric flow rate of fuel
+        * - :attr:`REQUIREDFLOW`
+          - :ref:`scalar <scalar>`
+          - Required volumetric flow rate of fuel for current throttle
+        * - :attr:`MASSFLOW`
+          - :ref:`scalar <scalar>`
+          - Current mass flow rate of fuel
+        * - :attr:`MAXMASSFLOW`
+          - :ref:`scalar <scalar>`
+          - Untweaked maximum mass flow rate of fuel
+        * - :attr:`RATIO`
+          - :ref:`scalar <scalar>`
+          - Volumetric flow ratio of this resource
+
+
+.. attribute:: ConsumedResource:NAME
+
+    :access: Get only
+    :type: :ref:`string <string>`
+
+    The name of the resource, i.e. "LIQUIDFUEL", "ELECTRICCHARGE", "MONOPROP".
+
+.. attribute:: ConsumedResource:AMOUNT
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+
+    The value of how much resource is left and accessible to this engine. Only valid while the engine is running.
+
+.. attribute:: ConsumedResource:CAPACITY
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+
+    What AMOUNT would be if the resource was filled to the top. Only valid while the engine is running.
+
+.. attribute:: ConsumedResource:DENSITY
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+
+    The density value of this resource, expressed in Megagrams f mass
+    per Unit of resource.  (i.e. a value of 0.005 would mean that each
+    unit of this resource is 5 kilograms.  Megagrams [metric tonnes] is
+    the usual unit that most mass in the game is represented in.)
+
+.. attribute:: ConsumedResource:FUELFLOW
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+
+    How much volume of this fuel is this engine consuming at this very moment.
+
+.. attribute:: ConsumedResource:MAXFUELFLOW
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+
+    How much volume of this fuel would this engine consume at standard pressure and velocity if the throttle was max at 1.0, and the thrust limiter was max at 100%.
+    
+.. attribute:: ConsumedResource:REQUIREDFLOW
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+
+    How much volume of this fuel does this require at this very moment for the current throttle setting.
+    This will usually equal FUELFLOW but may be higher for INTAKEAIR for instance.
+
+.. attribute:: ConsumedResource:MASSFLOW
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+
+    How much mass of this fuel is this engine consuming at this very moment.
+
+.. attribute:: ConsumedResource:MAXMASSFLOW
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+
+    How much mass of this fuel would this engine consume at standard pressure and velocity if the throttle was max at 1.0, and the thrust limiter was max at 100%.
+    
+.. attribute:: ConsumedResource:RATIO
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+
+    What is the volumetric ratio of this fuel as a proportion of the overall fuel mixture, e.g. if this is 0.5 then this fuel is half the required fuel for the engine.
+

--- a/doc/source/structures/vessels/engine.rst
+++ b/doc/source/structures/vessels/engine.rst
@@ -54,8 +54,17 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
           - :ref:`scalar <scalar>` (kN)
           - Possible thrust at the specified pressure (in standard Kerbin atmospheres), when the engine is enabled.
         * - :attr:`FUELFLOW`
-          - :ref:`scalar <scalar>` (l/s maybe)
-          - Rate of fuel burn
+          - :ref:`scalar <scalar>` (unit/s)
+          - Current volumetric flow rate of fuel.
+        * - :attr:`MAXFUELFLOW`
+          - :ref:`scalar <scalar>` (unit/s)
+          - Untweaked maximum volumetric flow rate of fuel at full throttle.
+        * - :attr:`MASSFLOW`
+          - :ref:`scalar <scalar>` (Mg/s)
+          - Current mass flow rate of fuel.
+        * - :attr:`MAXMASSFLOW`
+          - :ref:`scalar <scalar>` (Mg/s)
+          - Untweaked maximum mass flow rate of fuel at full throttle.
         * - :attr:`ISP`
           - :ref:`scalar <scalar>`
           - `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_
@@ -113,6 +122,24 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
         * - :attr:`GIMBAL`
           - :struct:`Gimbal`
           - Gimbal of this engine (only if available)
+        * - :attr:`ULLAGE`
+          - :ref:`Boolean <boolean>`
+          - Does this engine need ullage (for RealFuels)
+        * - :attr:`FUELSTABILITY`
+          - :ref:`scalar <scalar>`
+          - How stable is the fuel for this engine (for RealFuels)
+        * - :attr:`PRESSUREFED`
+          - :ref:`Boolean <boolean>`
+          - Is this engine pressure fed? (for RealFuels)
+        * - :attr:`IGNITIONS`
+          - :ref:`scalar <scalar>`
+          - Number of ignitions remaining for this engine (for RealFuels)
+        * - :attr:`MINTHROTTLE`
+          - :ref:`scalar <scalar>`
+          - The minimum throttle setting for this engine (for RealFuels)
+        * - :attr:`CONFIG`
+          - :struct:`String`
+          - Engine configuration name (for RealFuels)
 
 
 .. note::
@@ -218,13 +245,34 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
     Taking into account the thrust limiter tweakable setting, how much thrust would this engine give if the throttle was max at its current thrust limit setting and velocity, but at a different atmospheric pressure you pass into it.  The pressure is measured in ATM's, meaning 0.0 is a vacuum, 1.0 is sea level at Kerbin.  This will give the correct value even if the engine is currently disabled.
     (Pressure must be greater than or equal to zero.  If you pass in a
     negative value, it will be treated as if you had given a zero instead.)
-    
+
 .. attribute:: Engine:FUELFLOW
 
     :access: Get only
-    :type: :ref:`scalar <scalar>` (Liters/s? maybe)
+    :type: :ref:`scalar <scalar>` (units/s)
 
-    Rate at which fuel is being burned. Not sure what the units are.
+    How much fuel volume is this engine consuming at this very moment.
+
+.. attribute:: Engine:MAXFUELFLOW
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>` (units/s)
+
+    How much fuel volume would this engine consume at standard pressure and velocity if the throttle was max at 1.0, and the thrust limiter was max at 100%.  Note this might not be the engine's actual max fuel flow it could have under other air pressure conditions.  Some jet engines have a very different fuel consumption depending on how fast they are currently being rammed through the air.
+    
+.. attribute:: Engine:MASSFLOW
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>` (Mg/s)
+
+    How much fuel mass is this engine consuming at this very moment.
+
+.. attribute:: Engine:MAXMASSFLOW
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>` (Mg/s)
+
+    How much fuel mass would this engine consume at standard pressure and velocity if the throttle was max at 1.0, and the thrust limiter was max at 100%.  Note this might not be the engine's actual max fuel flow it could have under other air pressure conditions.  Some jet engines have a very different fuel consumption depending on how fast they are currently being rammed through the air.
 
 .. attribute:: Engine:ISP
 
@@ -357,5 +405,47 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
     :type: :struct:`Gimbal`
 
     Returns the :struct:`Gimbal` attached to this engine. Only accessible if the gimbal is present (Use :attr:`Engine:HASGIMBAL` to check if available).
+    
+.. attribute:: Engine:ULLAGE
+
+    :access: Get only
+    :type: :ref:`Boolean <boolean>`
+    
+    If RealFuels is installed, returns true if this engine needs ullage, otherwise returns false.
+
+.. attribute:: Engine:FUELSTABILITY`
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+    
+    If RealFuels is installed, returns the fuel stability of this engines as a value between 0 and 1 (where 1 is fullly stable), otherwsie returns 1.
+
+.. attribute:: Engine:PRESSUREFED`
+
+    :access: Get only
+    :type: :ref:`Boolean <boolean>`
+    
+    If RealFuels is installed, returns true if this engine is pressure fed, otherwise returns false.
+
+.. attribute:: Engine:IGNITIONS`
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+    
+    If RealFuels is installed, returns the number of ignitions remaining, or -1 if it is unlimited, otherwise returns -1.
+
+.. attribute:: Engine:MINTHROTTLE`
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+    
+    If RealFuels is installed, returns the minimum throttle setting as a value between 0 and 1, otherwise returns 0.
+
+.. attribute:: Engine:CONFIG`
+
+    :access: Get only
+    :type: :struct:`String`
+    
+    If RealFuels is installed, returns the configuration name of this engine if applicable, otherwise returns the part title.
 
 .. _isp: http://en.wikipedia.org/wiki/Specific_impulse

--- a/doc/source/structures/vessels/engine.rst
+++ b/doc/source/structures/vessels/engine.rst
@@ -411,14 +411,16 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
     :access: Get only
     :type: :ref:`Boolean <boolean>`
     
-    If RealFuels is installed, returns true if this engine needs ullage, otherwise returns false.
+    If RealFuels is installed, returns true if this engine is a type of engine that requires ullage, otherwise returns false.
+    Note: this is a static property of the engine, for current fuel status, check `FUELSTABILITY`.
 
 .. attribute:: Engine:FUELSTABILITY`
 
     :access: Get only
     :type: :ref:`scalar <scalar>`
     
-    If RealFuels is installed, returns the fuel stability of this engines as a value between 0 and 1 (where 1 is fullly stable), otherwsie returns 1.
+    If RealFuels is installed, returns the fuel stability of this engine as a value between 0 and 1 (where 1 is fullly stable), otherwise returns 1.
+    Engines that don't require ullage will always return 1, unelss they are pressure fed and the feed pressure is too low.
 
 .. attribute:: Engine:PRESSUREFED`
 

--- a/src/kOS/Suffixed/ConsumedResourceValue.cs
+++ b/src/kOS/Suffixed/ConsumedResourceValue.cs
@@ -1,0 +1,45 @@
+using kOS.Safe.Encapsulation;
+using kOS.Safe.Encapsulation.Suffixes;
+using UnityEngine;
+
+namespace kOS.Suffixed
+{
+    [kOS.Safe.Utilities.KOSNomenclature("ConsumedResource")]
+    public class ConsumedResourceValue : Structure
+    {
+        private readonly string name;
+        protected readonly SharedObjects shared;
+        private readonly float density;
+        private readonly ModuleEngines engine;
+        private readonly Propellant propellant;
+
+        public ConsumedResourceValue(ModuleEngines engine, Propellant prop, SharedObjects shared)
+        {
+            this.shared = shared;
+            name = prop.displayName;
+            density = prop.resourceDef.density;
+            this.engine = engine;
+            propellant = prop;
+            InitializeConsumedResourceSuffixes();
+        }
+
+        private void InitializeConsumedResourceSuffixes()
+        {
+            AddSuffix("NAME", new Suffix<StringValue>(() => name, "The name of the resource (eg LiguidFuel, ElectricCharge)"));
+            AddSuffix("DENSITY", new Suffix<ScalarValue>(() => density, "The density of the resource"));
+            AddSuffix("FUELFLOW", new Suffix<ScalarValue>(() => (engine != null && engine.fuelFlowGui > 0) ? propellant.currentAmount / Time.fixedDeltaTime : 0, "The current volumetric flow rate of the resource"));
+            AddSuffix("MAXFUELFLOW", new Suffix<ScalarValue>(() => engine ? engine.getMaxFuelFlow(propellant) : 0, "The maximum volumetric flow rate of the resource"));
+            AddSuffix("REQUIREDFLOW", new Suffix<ScalarValue>(() => (engine != null && engine.fuelFlowGui > 0) ? propellant.currentRequirement / Time.fixedDeltaTime : 0, "The required volumetric flow rate of the resource"));
+            AddSuffix("MASSFLOW", new Suffix<ScalarValue>(() => (engine != null && engine.fuelFlowGui > 0) ? propellant.currentAmount * density / Time.fixedDeltaTime : 0, "The current mass flow rate of the resource"));
+            AddSuffix("MAXMASSFLOW", new Suffix<ScalarValue>(() => engine ? engine.getMaxFuelFlow(propellant) * density : 0, "The maximum mass flow rate of the resource"));
+            AddSuffix("RATIO", new Suffix<ScalarValue>(() => propellant.ratio, "The volumetric flow ratio of the resource"));
+            AddSuffix("AMOUNT", new Suffix<ScalarValue>(() => propellant.actualTotalAvailable, "The resources currently available"));
+            AddSuffix("CAPACITY", new Suffix<ScalarValue>(() => propellant.totalResourceCapacity, "The total storage capacity currently available"));
+        }
+
+        public override string ToString()
+        {
+            return string.Format("CONSUMEDRESOURCE({0})", name);
+        }
+    }
+}

--- a/src/kOS/Suffixed/Part/EngineValue.cs
+++ b/src/kOS/Suffixed/Part/EngineValue.cs
@@ -6,6 +6,7 @@ using kOS.Safe.Utilities;
 using kOS.Suffixed.PartModuleField;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using UnityEngine;
 
 namespace kOS.Suffixed.Part
@@ -19,6 +20,10 @@ namespace kOS.Suffixed.Part
         private List<ModuleEngines> RawEngineList { get; set; }
         public MultiModeEngine Multi { get; private set; }
         public GimbalFields Gimbal { get; private set; }
+        // +For RealFuels
+        private readonly bool HasRealFuels;
+        private readonly PartModule EngineConfig;
+        // -For RealFuels
         /// <summary>Only those Engine Modules that the part's current engine mode allows to work.
         /// (i.e. if an engine has a wet mode and a dry mode, then you should see either the wet module
         /// or the dry module in this list, but not both at once.)</summary>
@@ -59,6 +64,22 @@ namespace kOS.Suffixed.Part
                 {
                     RawEngineList.Add(e);
                 }
+
+                if (e != null)
+                {
+                    HasRealFuels = false;
+                    for (System.Type t = module.GetType(); t != null; t = t.BaseType)
+                    {
+                        if (t.Name.Contains("ModuleEnginesRF"))
+                        {
+                            HasRealFuels = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (module.GetType().Name.Contains("ModuleEngineConfigs"))
+                    EngineConfig = module;
             }
             if (RawEngineList.Count < 1)
                 throw new KOSException("Attempted to build an Engine from part with no ModuleEngines on {0}: {1}", part.name, part.partInfo.title);
@@ -101,7 +122,10 @@ namespace kOS.Suffixed.Part
                                                           "thrust limit percentage for this engine"));
             AddSuffix("MAXTHRUST", new Suffix<ScalarValue>(() => FilteredEngineList.Sum(e => e.GetThrust())));
             AddSuffix("THRUST", new Suffix<ScalarValue>(() => FilteredEngineList.Sum(e => e.finalThrust)));
-            AddSuffix("FUELFLOW", new Suffix<ScalarValue>(() => FilteredEngineList.Sum(e => e.fuelFlowGui)));
+            AddSuffix("FUELFLOW", new Suffix<ScalarValue>(GetFuelFlow));
+            AddSuffix("MAXFUELFLOW", new Suffix<ScalarValue>(GetMaxFuelFlow));
+            AddSuffix("MASSFLOW", new Suffix<ScalarValue>(GetMassFlow));
+            AddSuffix("MAXMASSFLOW", new Suffix<ScalarValue>(() => FilteredEngineList.Sum(e => e.maxFuelFlow)));
             AddSuffix("ISP", new Suffix<ScalarValue>(GetIsp));
             AddSuffix(new[] { "VISP", "VACUUMISP" }, new Suffix<ScalarValue>(GetVacuumIsp));
             AddSuffix(new[] { "SLISP", "SEALEVELISP" }, new Suffix<ScalarValue>(GetSeaLevelIsp));
@@ -118,6 +142,7 @@ namespace kOS.Suffixed.Part
             AddSuffix("POSSIBLETHRUSTAT", new OneArgsSuffix<ScalarValue, ScalarValue>(GetPossibleThrustAtAtm));
             AddSuffix("MAXPOSSIBLETHRUST", new Suffix<ScalarValue>(() => FilteredEngineList.Sum(e => e.GetThrust(operational: false))));
             AddSuffix("MAXPOSSIBLETHRUSTAT", new OneArgsSuffix<ScalarValue, ScalarValue>(atm => FilteredEngineList.Sum(e => e.GetThrust(atm, operational: false))));
+            AddSuffix("CONSUMEDRESOURCES", new Suffix<Lexicon>(GetConsumedResources, "A List of all resources consumed by this engine"));
             //MultiMode features
             AddSuffix("MULTIMODE", new Suffix<BooleanValue>(() => MultiMode));
             AddSuffix("MODES", new Suffix<ListValue>(GetAllModes, "A List of all modes of this engine"));
@@ -128,6 +153,14 @@ namespace kOS.Suffixed.Part
             //gimbal interface
             AddSuffix("HASGIMBAL", new Suffix<BooleanValue>(() => HasGimbal));
             AddSuffix("GIMBAL", new Suffix<GimbalFields>(GetGimbal));
+
+            // RealFuels stuff
+            AddSuffix("ULLAGE", new Suffix<BooleanValue>(GetUllage));
+            AddSuffix("FUELSTABILITY", new Suffix<ScalarValue>(GetFuelStability));
+            AddSuffix("PRESSUREFED", new Suffix<BooleanValue>(GetPressureFed));
+            AddSuffix("IGNITIONS", new Suffix<ScalarValue>(GetIgnitions));
+            AddSuffix("MINTHROTTLE", new Suffix<ScalarValue>(GetMinThrottle));
+            AddSuffix("CONFIG", new Suffix<StringValue>(GetEngineConfig));
         }
 
         public static ListValue PartsToList(IEnumerable<global::Part> parts, SharedObjects sharedObj)
@@ -211,6 +244,215 @@ namespace kOS.Suffixed.Part
         public ScalarValue GetPossibleThrustAtAtm(ScalarValue atmPressure)
         {
             return FilteredEngineList.Sum(e => e.GetThrust(atmPressure, useThrustLimit: true, operational: false));
+        }
+
+        public Lexicon GetConsumedResources()
+        {
+            var resources = new Lexicon();
+
+            foreach (ModuleEngines e in FilteredEngineList)
+            {
+                foreach (Propellant p in e.propellants)
+                {
+                    resources.Add(new StringValue(p.displayName), new ConsumedResourceValue(e, p, Shared));
+                }
+            }
+
+            return resources;
+        }
+
+        public StringValue GetEngineConfig()
+        {
+            if (EngineConfig != null)
+            {
+                var configField = EngineConfig.GetType().GetField("configuration");
+                if (configField != null)
+                    return (string)configField.GetValue(EngineConfig);
+            }
+
+            return Part.partInfo.title;
+        }
+
+        public ScalarValue GetFuelFlow()
+        {
+            // fuelFlowGui is overidden by RealFuels to display massflow, so work around it.
+            if (HasRealFuels)
+            {
+                double fuelFlow = 0;
+
+                foreach (ModuleEngines e in FilteredEngineList)
+                {
+                    // currentAmount does not update when there is no fuel flow, so only update when fuel is flowing.
+                    if (e.fuelFlowGui > 0.0f)
+                    {
+                        foreach (Propellant p in e.propellants)
+                        {
+                            fuelFlow += p.currentAmount / Time.fixedDeltaTime;
+                        }
+                    }
+                }
+
+                return fuelFlow;
+            }
+            else
+            {
+                // Stock just shows flow.
+                return FilteredEngineList.Sum(e => e.fuelFlowGui);
+            }
+        }
+
+        // Unfortunately mixtureDensity is unreliable so there isn't a quick way to get this.
+        public ScalarValue GetMaxFuelFlow()
+        {
+            double maxFuelFlow = 0;
+
+            foreach (ModuleEngines e in FilteredEngineList)
+            {
+                foreach (Propellant p in e.propellants)
+                {
+                    maxFuelFlow += e.getMaxFuelFlow(p);
+                }
+            }
+
+            return maxFuelFlow;
+        }
+
+        public ScalarValue GetMassFlow()
+        {
+            double massFlow = 0;
+
+            foreach (ModuleEngines e in FilteredEngineList)
+            {
+                // currentAmount does not update when there is no fuel flow, so only update when fuel is flowing.
+                if (e.fuelFlowGui > 0.0f)
+                {
+                    foreach (Propellant p in e.propellants)
+                    {
+                        massFlow += p.currentAmount * p.resourceDef.density / Time.fixedDeltaTime;
+                    }
+                }
+            }
+
+            return massFlow;
+        }
+
+        public BooleanValue GetUllage()
+        {
+            bool ullage = false;
+
+            if (HasRealFuels)
+            {
+                foreach (ModuleEngines e in FilteredEngineList)
+                {
+                    var ullageField = e.GetType().GetField("ullage");
+                    if (ullageField != null)
+                    {
+                        ullage |= (bool)ullageField.GetValue(e);
+                    }
+                }
+            }
+
+            return ullage;
+        }
+
+        public ScalarValue GetFuelStability()
+        {
+            // Default to full stability
+            float stability = 1.0f;
+
+            if (HasRealFuels)
+            {
+                foreach (ModuleEngines e in FilteredEngineList)
+                {
+                    var ullageField = e.GetType().GetField("ullage");
+                    var pressureFedField = e.GetType().GetField("pressureFed");
+                    var ullageSetField = e.GetType().GetField("ullageSet");
+
+                    if (ullageField != null && pressureFedField != null && ullageSetField != null)
+                    {
+                        bool pressureOK = !(bool)pressureFedField.GetValue(e);
+                        if (!pressureOK)
+                        {
+                            var pressureOKMethod = ullageSetField.GetType().GetMethod("PressureOK", BindingFlags.Public | BindingFlags.Instance);
+                            pressureOK = pressureOKMethod != null ? (bool)pressureOKMethod.Invoke(ullageSetField.GetValue(e), new object[] { }) : true;
+                        }
+
+                        if (!pressureOK)
+                        {
+                            // No feed pressure
+                            stability = 0;
+                        }
+                        else if ((bool)ullageField.GetValue(e))
+                        {
+                            // Use minimum value if multiple engines
+                            var ullageStabilityMethod = ullageSetField.GetType().GetMethod("GetUllageStability", BindingFlags.Public | BindingFlags.Instance);
+                            stability = Mathf.Min(stability, ullageStabilityMethod != null ? (float)ullageStabilityMethod.Invoke(ullageSetField.GetValue(e), new object[] { }) : 1.0f);
+                        }
+                    }
+                }
+            }
+
+            return stability;
+        }
+
+        public BooleanValue GetPressureFed()
+        {
+            bool pressureFed = false;
+
+            if (HasRealFuels)
+            {
+                foreach (ModuleEngines e in FilteredEngineList)
+                {
+                    var pressureFedField = e.GetType().GetField("pressureFed");
+                    if (pressureFedField != null)
+                    {
+                        pressureFed |= (bool)pressureFedField.GetValue(e);
+                    }
+                }
+            }
+
+            return pressureFed;
+        }
+
+        public ScalarValue GetIgnitions()
+        {
+            int ignitions = -1;
+
+            if (HasRealFuels)
+            {
+                foreach (ModuleEngines e in FilteredEngineList)
+                {
+                    var ignitionsField = e.GetType().GetField("ignitions");
+                    if (ignitionsField != null)
+                    {
+                        int engIngitions = (int)ignitionsField.GetValue(e);
+                        if (engIngitions >= 0)
+                        {
+                            if (ignitions < 0)
+                                ignitions = engIngitions;
+                            else
+                                ignitions = Mathf.Min(ignitions, engIngitions);
+                        }
+                    }
+                }
+            }
+
+            return ignitions;
+        }
+
+        public ScalarValue GetMinThrottle()
+        {
+            float minThrottle = 0;
+
+            if (HasRealFuels)
+            {
+                foreach (ModuleEngines e in FilteredEngineList)
+                {
+                    minThrottle = Mathf.Max(minThrottle, e.minFuelFlow / e.maxFuelFlow);
+                }
+            }
+
+            return minThrottle;
         }
 
         public ListValue GetAllModes()

--- a/src/kOS/Suffixed/Part/EngineValue.cs
+++ b/src/kOS/Suffixed/Part/EngineValue.cs
@@ -338,8 +338,6 @@ namespace kOS.Suffixed.Part
 
         public BooleanValue GetUllage()
         {
-            bool ullage = false;
-
             if (HasRealFuels)
             {
                 foreach (ModuleEngines e in FilteredEngineList)
@@ -347,12 +345,14 @@ namespace kOS.Suffixed.Part
                     var ullageField = e.GetType().GetField("ullage");
                     if (ullageField != null)
                     {
-                        ullage |= (bool)ullageField.GetValue(e);
+                        // Return immediately if the module has ullage.
+                        if ((bool)ullageField.GetValue(e))
+                            return true;
                     }
                 }
             }
 
-            return ullage;
+            return false;
         }
 
         public ScalarValue GetFuelStability()
@@ -397,8 +397,6 @@ namespace kOS.Suffixed.Part
 
         public BooleanValue GetPressureFed()
         {
-            bool pressureFed = false;
-
             if (HasRealFuels)
             {
                 foreach (ModuleEngines e in FilteredEngineList)
@@ -406,12 +404,14 @@ namespace kOS.Suffixed.Part
                     var pressureFedField = e.GetType().GetField("pressureFed");
                     if (pressureFedField != null)
                     {
-                        pressureFed |= (bool)pressureFedField.GetValue(e);
+                        // Return immediately if the module is pressure fed.
+                        if ((bool)pressureFedField.GetValue(e))
+                            return true;
                     }
                 }
             }
 
-            return pressureFed;
+            return false;
         }
 
         public ScalarValue GetIgnitions()

--- a/src/kOS/kOS.csproj
+++ b/src/kOS/kOS.csproj
@@ -158,6 +158,7 @@
     <Compile Include="Sound\Voice.cs" />
     <Compile Include="Sound\VoiceValue.cs" />
     <Compile Include="Suffixed\BoundsValue.cs" />
+    <Compile Include="Suffixed\ConsumedResourceValue.cs" />
     <Compile Include="Suffixed\CraftTemplate.cs" />
     <Compile Include="Suffixed\KUniverseValue.cs" />
     <Compile Include="Suffixed\LoadDistanceValue.cs" />


### PR DESCRIPTION
Fixes #2658, see also #2075.

Adds suffix to provide consumed fuel information to `ENGINE`.
Adds suffixes for `MASSFLOW`, `MAXFUELFLOW`, and `MAXMASSFLOW` to `ENGINE`.
Adds a number of RealFuels informational suffixes (these return sensible defaults for Stock configs).
Adds documentation for the above.

Documentation fix for `AggregateResource`.

Tested on Stock and RealFuels builds - should return consistent numbers for both configurations now.