### PR TITLE
RCS module interface

### DIFF
--- a/doc/source/commands/list.rst
+++ b/doc/source/commands/list.rst
@@ -61,6 +61,8 @@ These generate :struct:`lists <List>` of items on the :struct:`Vessel`:
     :struct:`List` of :struct:`Parts <Part>`
 ``Engines``
     :struct:`List` of :struct:`Engines <Engine>`
+``RCS``
+    :struct:`List` of :struct:`RCS <RCS>`
 ``Sensors``
     :struct:`List` of :struct:`Sensors <Sensor>`
 ``Elements``

--- a/doc/source/structures/vessels/consumedresourcercs.rst
+++ b/doc/source/structures/vessels/consumedresourcercs.rst
@@ -1,0 +1,72 @@
+.. _consumedresourcercs:
+
+ConsumedResourceRCS
+================
+
+A single resource value an rcs thruster consumes (i.e. monopropellant, etc). This is the type returned by the :struct:`RCS`:CONSUMEDRESOURCES suffix
+
+.. structure:: ConsumedResourceRCS
+
+    .. list-table::
+        :header-rows: 1
+        :widths: 2 1 4
+
+        * - Suffix
+          - Type
+          - Description
+
+        * - :attr:`NAME`
+          - :ref:`string <string>`
+          - Resource name
+        * - :attr:`AMOUNT`
+          - :ref:`scalar <scalar>`
+          - Total amount remaining (only valid while engine is running)
+        * - :attr:`CAPACITY`
+          - :ref:`scalar <scalar>`
+          - Total amount when full (only valid while engine is running)
+        * - :attr:`DENSITY`
+          - :ref:`scalar <scalar>`
+          - Density of this resource
+        * - :attr:`RATIO`
+          - :ref:`scalar <scalar>`
+          - Volumetric flow ratio of this resource
+
+
+.. attribute:: ConsumedResource:NAME
+
+    :access: Get only
+    :type: :ref:`string <string>`
+
+    The name of the resource, i.e. "LIQUIDFUEL", "ELECTRICCHARGE", "MONOPROP".
+
+.. attribute:: ConsumedResource:AMOUNT
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+
+    The value of how much resource is left and accessible to this thruster. Only valid while the thruster is running.
+
+.. attribute:: ConsumedResource:CAPACITY
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+
+    What AMOUNT would be if the resource was filled to the top. Only valid while the thruster is running.
+
+.. attribute:: ConsumedResource:DENSITY
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+
+    The density value of this resource, expressed in Megagrams f mass
+    per Unit of resource.  (i.e. a value of 0.005 would mean that each
+    unit of this resource is 5 kilograms.  Megagrams [metric tonnes] is
+    the usual unit that most mass in the game is represented in.)
+
+.. attribute:: ConsumedResource:RATIO
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+
+    What is the volumetric ratio of this fuel as a proportion of the overall fuel mixture, e.g. if this is 0.5 then this fuel is half the required fuel for the thruster.
+

--- a/doc/source/structures/vessels/rcs.rst
+++ b/doc/source/structures/vessels/rcs.rst
@@ -1,0 +1,320 @@
+.. _rcs:
+
+RCS
+======
+
+Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type RCS. It is also possible to get just the RCS parts by executing ``LIST RCS``, for example::
+
+    LIST RCS IN myVariable.
+    FOR rcs IN myVariable {
+        print "An rcs thruster exists with ISP = " + rcs:ISP.
+    }.
+
+.. structure:: RCS
+
+    .. list-table::
+        :header-rows: 1
+        :widths: 1 1 2
+
+        * - Suffix
+          - Type (units)
+          - Description
+
+        * - All suffixes of :struct:`Part`
+          -
+          - :struct:`RCS` objects are a type of :struct:`Part`
+
+
+        * - :meth:`ENABLED`
+          -
+          - Is this thruster enabled.
+        * - :meth:`YAWENABLED`
+          -
+          - Is yaw control enabled for this thruster.
+        * - :meth:`PITCHENABLED`
+          -
+          - Is pitch control enabled for this thruster.
+        * - :meth:`ROLLENABLED`
+          -
+          - Is roll control enabled for this thruster.
+        * - :meth:`FOREENABLED`
+          -
+          - Is fore/aft control enabled for this thruster.
+        * - :meth:`STARBOARDENABLED`
+          -
+          - Is port/starboard control enabled for this thruster.
+        * - :meth:`TOPENABLED`
+          -
+          - Is dorsal/ventral control enabled for this thruster.
+        * - :meth:`FOREBYTHROTTLE`
+          -
+          - Does this thruster apply fore thrust when the ship throttled up.
+        * - :meth:`FULLTHRUST`
+          -
+          - Does this thruster always apply full thrust.
+        * - :attr:`THRUSTLIMIT`
+          - :ref:`scalar <scalar>` (%)
+          - Tweaked thrust limit.
+        * - :attr:`MAXTHRUST`
+          - :ref:`scalar <scalar>` (kN)
+          - Untweaked thrust limit.
+        * - :meth:`MAXTHRUSTAT(pressure)`
+          - :ref:`scalar <scalar>` (kN)
+          - Max thrust at the specified pressure (in standard Kerbin atmospheres).
+        * - :attr:`AVAILABLETHRUST`
+          - :ref:`scalar <scalar>` (kN)
+          - Available thrust at full throttle accounting for thrust limiter.
+        * - :meth:`AVAILABLETHRUSTAT(pressure)`
+          - :ref:`scalar <scalar>` (kN)
+          - Available thrust at the specified pressure (in standard Kerbin atmospheres).
+        * - :attr:`MAXFUELFLOW`
+          - :ref:`scalar <scalar>` (unit/s)
+          - Untweaked maximum volumetric flow rate of fuel at full throttle.
+        * - :attr:`MAXMASSFLOW`
+          - :ref:`scalar <scalar>` (Mg/s)
+          - Untweaked maximum mass flow rate of fuel at full throttle.
+        * - :attr:`ISP`
+          - :ref:`scalar <scalar>`
+          - `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_
+        * - :meth:`ISPAT(pressure)`
+          - :ref:`scalar <scalar>`
+          - `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_ at the given pressure (in standard Kerbin atmospheres).
+        * - :attr:`VACUUMISP`
+          - :ref:`scalar <scalar>`
+          - Vacuum `specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_
+        * - :attr:`VISP`
+          - :ref:`scalar <scalar>`
+          - Synonym for VACUUMISP
+        * - :attr:`SEALEVELISP`
+          - :ref:`scalar <scalar>`
+          - `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_ at Kerbin sealevel
+        * - :attr:`SLISP`
+          - :ref:`scalar <scalar>`
+          - Synonym for SEALEVELISP
+        * - :attr:`FLAMEOUT`
+          - :ref:`Boolean <boolean>`
+          - Check if no more fuel.
+        * - :attr:`THRUSTVECTORS`
+          - :struct:`List`
+          - List of thrust :struct:`Vectors <Vector>` for this RCS module.
+        * - :attr:`CONSUMEDRESOURCES`
+          - :struct:`Lexicon`
+          - Lexicon of resources consumed by this thruster, keyed by resource name.
+
+
+.. note::
+
+    A :struct:`RCS` is a type of :struct:`Part`, and therefore can use all the suffixes of :struct:`Part`.
+
+.. attribute:: RCS:ENABLED
+
+    :access: Get/Set
+    :type: :ref:`Boolean <boolean>`
+    
+    Is this rcs thruster enabled.
+    
+.. attribute:: RCS:ENABLEYAW
+
+    :access: Get/Set
+    :type: :ref:`Boolean <boolean>`
+        
+    Is yaw control enabled for this rcs thruster.
+    
+.. attribute:: RCS:ENABLEPITCH
+
+    :access: Get/Set
+    :type: :ref:`Boolean <boolean>`
+        
+    Is pitch control enabled for this rcs thruster.
+    
+.. attribute:: RCS:ENABLEROLL
+
+    :access: Get/Set
+    :type: :ref:`Boolean <boolean>`
+        
+    Is roll control enabled for this rcs thruster.
+    
+.. attribute:: RCS:ENABLEFORE
+
+    :access: Get/Set
+    :type: :ref:`Boolean <boolean>`
+        
+    Is fore/aft control enabled for this rcs thruster.
+    
+.. attribute:: RCS:ENABLESTARBOARD
+
+    :access: Get/Set
+    :type: :ref:`Boolean <boolean>`
+        
+    Is port/starboard control enabled for this rcs thruster.
+    
+.. attribute:: RCS:ENABLETOP
+
+    :access: Get/Set
+    :type: :ref:`Boolean <boolean>`
+        
+    Is dorsal/ventral control enabled for this rcs thruster.
+    
+.. attribute:: RCS:FOREBYTHROTTLE
+
+    :access: Get/Set
+    :type: :ref:`Boolean <boolean>`
+        
+    Does this thruster apply fore thrust when the ship throttled up.
+    
+.. attribute:: RCS:FULLTHRUST
+
+    :access: Get/Set
+    :type: :ref:`Boolean <boolean>`
+        
+    Does this thruster always apply full thrust.
+    
+.. attribute:: RCS:THRUSTLIMIT
+
+    :access: Get/Set
+    :type: :ref:`scalar <scalar>` (%)
+
+    If this is a thruster with a thrust limiter (tweakable) enabled, what
+    percentage is it limited to?  Note that this is expressed as a
+    percentage, not a simple 0..1 coefficient.  e.g. To set thrustlimit
+    to half, you use a value of 50.0, not 0.5.
+
+    This value is not allowed to go outside the range [0..100].  If you
+    attempt to do so, it will be clamped down into the allowed range.
+
+    Note that although a kerboscript is allowed to set the value to a
+    very precise number (for example 10.5123), the stock in-game display
+    widget that pops up when you right-click the rcs will automatically
+    round it to the nearest 0.5 whenever you open the panel.  So if you
+    do something like ``set ship:part[20]:thrustlimit to 10.5123.`` in
+    your script, then look at the rightclick menu for the rcs, the very
+    act of just looking at the menu will cause it to become 10.5 instead
+    of 10.5123.  There isn't much that kOS can do to change this.  It's a
+    user interface decision baked into the stock game.
+
+.. _rcs_MAXTHRUST:
+
+.. attribute:: RCS:MAXTHRUST
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>` (kN)
+
+    How much thrust would this rcs thruster give at its current atmospheric pressure if the throttle was max at 1.0, and the thrust limiter was max at 100%.  Note this might not be the thruster's actual max thrust it could have under other air pressure conditions.  Some thrusters have a very different value for MAXTHRUST in vacuum as opposed to at sea level pressure.
+
+.. _rcs_MAXTHRUSTAT:
+
+.. method:: RCS:MAXTHRUSTAT(pressure)
+
+    :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
+    :type: :ref:`scalar <scalar>` (kN)
+
+    How much thrust would this rcs thruster give if both the throttle and thrust limtier was max at the given atmospheric pressure.  Use a pressure of 0.0 for vacuum, and 1.0 for sea level (on Kerbin) (or more than 1 for thicker atmospheres like on Eve).
+    (Pressure must be greater than or equal to zero.  If you pass in a
+    negative value, it will be treated as if you had given a zero instead.)
+
+.. attribute:: RCS:THRUST
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>` (kN)
+
+    How much thrust is this rcs thruster is giving at this very moment.
+
+.. _rcs_AVAILABLETHRUST:
+
+.. attribute:: RCS:AVAILABLETHRUST
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>` (kN)
+
+    Taking into account the thrust limiter tweakable setting, how much thrust would this rcs thruster give if the throttle was max at its current thrust limit setting and atmospheric pressure conditions.
+
+.. _rcs_AVAILABLETHRUSTAT:
+
+.. method:: RCS:AVAILABLETHRUSTAT(pressure)
+
+    :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
+    :type: :ref:`scalar <scalar>` (kN)
+
+    Taking into account the thrust limiter tweakable setting, how much thrust would this rcs thruster give if the throttle was max at its current thrust limit setting, but at a different atmospheric pressure you pass into it.  The pressure is measured in ATMs, meaning 0.0 is a vacuum, 1.0 is sea level at Kerbin.
+    (Pressure must be greater than or equal to zero.  If you pass in a
+    negative value, it will be treated as if you had given a zero instead.)
+
+.. attribute:: RCS:MAXFUELFLOW
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>` (units/s)
+
+    How much fuel volume would this rcs thruster consume at standard pressure and velocity if the throttle was max at 1.0, and the thrust limiter was max at 100%.  Note this might not be the engine's actual max fuel flow it could have under other air pressure conditions.
+
+.. attribute:: RCS:MAXMASSFLOW
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>` (Mg/s)
+
+    How much fuel mass would this rcs thruster consume at standard pressure and velocity if the throttle was max at 1.0, and the thrust limiter was max at 100%.  Note this might not be the engine's actual max fuel flow it could have under other air pressure conditions.
+
+.. attribute:: RCS:ISP
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+
+    `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_
+
+.. method:: RCS:ISPAT(pressure)
+
+    :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
+    :type: :ref:`scalar <scalar>`
+
+    `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_ at the given atmospheric pressure.  Use a pressure of 0 for vacuum, and 1 for sea level (on Kerbin).
+    (Pressure must be greater than or equal to zero.  If you pass in a
+    negative value, it will be treated as if you had given a zero instead.)
+
+.. attribute:: RCS:VACUUMISP
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+
+    Vacuum `specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_
+
+.. attribute:: RCS:VISP
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+
+    Synonym for :VACUUMISP
+
+.. attribute:: RCS:SEALEVELISP
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+
+    `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_ at Kerbin sealevel.
+
+.. attribute:: RCS:SLISP
+
+    :access: Get only
+    :type: :ref:`scalar <scalar>`
+
+    Synonym for :SEALEVELISP
+
+.. attribute:: RCS:FLAMEOUT
+
+    :access: Get only
+    :type: :ref:`Boolean <boolean>`
+
+    Is this rcs thruster failed because it is starved of a resource (monopropellant)?
+
+.. attribute:: RCS:THRUSTVECTORS
+
+    :access: Get only
+    :type: :struct:`List` of :struct:`Vectors <Vector>`
+
+    This gives a list of all the vectors that this RCS module can thrust along. Vectors returns are of unit length.
+
+.. attribute:: RCS:CONSUMEDRESOURCES
+
+    :access: Get only
+    :type: :struct:`Lexicon` of :struct:`CONSUMEDRESOURCERCS`
+
+    This gives a lexicon of all the resources this rcs thruster consumes, keyed by resource name.
+

--- a/src/kOS/Function/BuildList.cs
+++ b/src/kOS/Function/BuildList.cs
@@ -35,6 +35,7 @@ namespace kOS.Function
                 case "resources":
                 case "parts":
                 case "engines":
+                case "rcs":
                 case "sensors":
                 case "elements":
                 case "dockingports":

--- a/src/kOS/Function/PrintList.cs
+++ b/src/kOS/Function/PrintList.cs
@@ -62,6 +62,10 @@ namespace kOS.Function
                     list = GetEngineList(shared);
                     break;
 
+                case "rcs":
+                    list = GetRCSList(shared);
+                    break;
+
                 case "sensors":
                     list = GetSensorList(shared);
                     break;
@@ -262,6 +266,27 @@ namespace kOS.Function
             {
                 var part = (PartValue) structure;
                 list.AddItem(part.Part.uid(), part.Part.inverseStage, part.Part.partInfo.name);
+            }
+
+            return list;
+        }
+
+        private kList GetRCSList(SharedObjects shared)
+        {
+            var list = new kList();
+            list.AddColumn("ID", 12, ColumnAlignment.Left);
+            list.AddColumn("Name", 28, ColumnAlignment.Left);
+
+            foreach (Part part in shared.Vessel.Parts)
+            {
+                foreach (PartModule module in part.Modules)
+                {
+                    var rcs = module as ModuleRCS;
+                    if (rcs != null)
+                    {
+                        list.AddItem(part.ConstructID(), part.partInfo.name);
+                    }
+                }
             }
 
             return list;

--- a/src/kOS/Suffixed/ConsumedResourceValueRCS.cs
+++ b/src/kOS/Suffixed/ConsumedResourceValueRCS.cs
@@ -1,0 +1,39 @@
+using kOS.Safe.Encapsulation;
+using kOS.Safe.Encapsulation.Suffixes;
+using UnityEngine;
+
+namespace kOS.Suffixed
+{
+    [kOS.Safe.Utilities.KOSNomenclature("ConsumedResourceRCS")]
+    public class ConsumedResourceValueRCS : Structure
+    {
+        private readonly string name;
+        protected readonly SharedObjects shared;
+        private readonly float density;
+        private readonly ModuleEngines engine;
+        private readonly Propellant propellant;
+
+        public ConsumedResourceValueRCS(Propellant prop, SharedObjects shared)
+        {
+            this.shared = shared;
+            name = prop.displayName;
+            density = prop.resourceDef.density;
+            propellant = prop;
+            InitializeConsumedResourceRCSSuffixes();
+        }
+
+        private void InitializeConsumedResourceRCSSuffixes()
+        {
+            AddSuffix("NAME", new Suffix<StringValue>(() => name, "The name of the resource (eg LiguidFuel, ElectricCharge)"));
+            AddSuffix("DENSITY", new Suffix<ScalarValue>(() => density, "The density of the resource"));
+            AddSuffix("RATIO", new Suffix<ScalarValue>(() => propellant.ratio, "The volumetric flow ratio of the resource"));
+            AddSuffix("AMOUNT", new Suffix<ScalarValue>(() => propellant.actualTotalAvailable, "The resources currently available"));
+            AddSuffix("CAPACITY", new Suffix<ScalarValue>(() => propellant.totalResourceCapacity, "The total storage capacity currently available"));
+        }
+
+        public override string ToString()
+        {
+            return string.Format("CONSUMEDRESOURCERCS({0})", name);
+        }
+    }
+}

--- a/src/kOS/Suffixed/Part/RCSValue.cs
+++ b/src/kOS/Suffixed/Part/RCSValue.cs
@@ -1,0 +1,145 @@
+using kOS.Safe;
+using kOS.Safe.Encapsulation;
+using kOS.Safe.Encapsulation.Suffixes;
+using kOS.Safe.Exceptions;
+using kOS.Safe.Utilities;
+using kOS.Suffixed.PartModuleField;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace kOS.Suffixed.Part
+{
+    [kOS.Safe.Utilities.KOSNomenclature("RCS")]
+    public class RCSValue : PartValue
+    {
+        private readonly ModuleRCS module;
+
+        /// <summary>
+        /// Do not call! VesselTarget.ConstructPart uses this, would use `friend VesselTarget` if this was C++!
+        /// </summary>
+        internal RCSValue(SharedObjects shared, global::Part part, PartValue parent, DecouplerValue decoupler, ModuleRCS module)
+            : base(shared, part, parent, decoupler)
+        {
+            this.module = module;
+            RegisterInitializer(RCSInitializeSuffixes);
+        }
+        private void RCSInitializeSuffixes()
+        {
+            // Tweakables
+            AddSuffix("ENABLED", new SetSuffix<BooleanValue>(() => module.rcsEnabled, value => module.rcsEnabled = value));
+            AddSuffix("YAWENABLED", new SetSuffix<BooleanValue>(() => module.enableYaw, value => module.enableYaw = value));
+            AddSuffix("PITCHENABLED", new SetSuffix<BooleanValue>(() => module.enablePitch, value => module.enablePitch = value));
+            AddSuffix("ROLLENABLED", new SetSuffix<BooleanValue>(() => module.enableRoll, value => module.enableRoll = value));
+            AddSuffix("STARBOARDENABLED", new SetSuffix<BooleanValue>(() => module.enableX, value => module.enableX = value));
+            AddSuffix("TOPENABLED", new SetSuffix<BooleanValue>(() => module.enableY, value => module.enableY = value));
+            AddSuffix("FOREENABLED", new SetSuffix<BooleanValue>(() => module.enableZ, value => module.enableZ = value));
+            AddSuffix("FOREBYTHROTTLE", new SetSuffix<BooleanValue>(() => module.useThrottle, value => module.useThrottle = value));
+            AddSuffix("FULLTHRUST", new SetSuffix<BooleanValue>(() => module.fullThrust, value => module.fullThrust = value));
+            AddSuffix("THRUSTLIMIT", new ClampSetSuffix<ScalarValue>(() => module.thrustPercentage, value => module.thrustPercentage = value, 0f, 100f, 0f, "thrust limit percentage for this rcs thruster"));
+            // Performance metrics
+            AddSuffix("AVAILABLETHRUST", new Suffix<ScalarValue>(() => module.GetThrust(useThrustLimit: true)));
+            AddSuffix("AVAILABLETHRUSTAT",  new OneArgsSuffix<ScalarValue, ScalarValue>((ScalarValue atmPressure) => module.GetThrust(atmPressure, useThrustLimit: true)));
+            AddSuffix("MAXTHRUST", new Suffix<ScalarValue>(() => module.GetThrust()));
+            AddSuffix("MAXFUELFLOW", new Suffix<ScalarValue>(GetMaxFuelFlow));
+            AddSuffix("MAXMASSFLOW", new Suffix<ScalarValue>(() => module.maxFuelFlow));
+            AddSuffix("ISP", new Suffix<ScalarValue>(() => module.realISP));
+            AddSuffix(new[] { "VISP", "VACUUMISP" }, new Suffix<ScalarValue>(() => module.GetIsp(0)));
+            AddSuffix(new[] { "SLISP", "SEALEVELISP" }, new Suffix<ScalarValue>(() => module.GetIsp(1)));
+            AddSuffix("FLAMEOUT", new Suffix<BooleanValue>(() => module.flameout));
+            AddSuffix("ISPAT", new OneArgsSuffix<ScalarValue, ScalarValue>((ScalarValue atmPressure) => module.GetIsp(atmPressure)));
+            AddSuffix("MAXTHRUSTAT", new OneArgsSuffix<ScalarValue, ScalarValue>((ScalarValue atmPressure) => module.GetThrust(atmPressure)));
+            AddSuffix("THRUSTVECTORS", new Suffix<ListValue>(GetThrustVectors));
+            AddSuffix("CONSUMEDRESOURCES", new Suffix<Lexicon>(GetConsumedResources, "A Lexicon of all resources consumed by this rcs thruster"));
+        }
+
+        public static ListValue PartsToList(IEnumerable<global::Part> parts, SharedObjects sharedObj)
+        {
+            var toReturn = new ListValue();
+            var vessel = VesselTarget.CreateOrGetExisting(sharedObj);
+            foreach (var part in parts)
+            {
+                foreach (var module in part.Modules)
+                {
+                    if (module is ModuleRCS)
+                    {
+                        toReturn.Add(vessel[part]);
+                        // Only add each part once
+                        break;
+                    }
+                }
+            }
+            return toReturn;
+        }
+        
+        // Unfortunately mixtureDensity is unreliable so there isn't a quick way to get this.
+        public ScalarValue GetMaxFuelFlow()
+        {
+            double mixtureDensity = 0;
+            foreach (Propellant p in module.propellants)
+            {
+                mixtureDensity += p.resourceDef.density * p.ratio;
+            }
+            SafeHouse.Logger.Log(string.Format("Calculated density: {0} reported: {1} [{2}]", mixtureDensity, module.mixtureDensity, 1.0 / module.mixtureDensityRecip));
+
+            return module.maxFuelFlow / mixtureDensity;
+        }
+
+        public ListValue GetThrustVectors()
+        {
+            var toReturn = new ListValue();
+            foreach (Transform t in module.thrusterTransforms)
+            {
+                // RCS thrusts along up. Possibly useZAxis property means it thrusts along forward?
+                toReturn.Add(new Vector(t.up));
+            }
+            return toReturn;
+        }
+
+        public Lexicon GetConsumedResources()
+        {
+            var resources = new Lexicon();
+            foreach (Propellant p in module.propellants)
+            {
+                resources.Add(new StringValue(p.displayName), new ConsumedResourceValueRCS(p, Shared));
+            }
+
+            return resources;
+        }
+    }
+
+    public static class ModuleRCSExtensions
+    {
+        /// <summary>
+        /// Get engine thrust
+        /// </summary>
+        /// <param name="rcs">The rcs thruster (can be null - returns zero in that case)</param>
+        /// <param name="atmPressure">
+        ///   Atmospheric pressure (defaults to pressure at current location if omitted/null,
+        ///   1.0 means Earth/Kerbin sea level, 0.0 is vacuum)</param>
+        /// <returns>The thrust</returns>
+        public static float GetThrust(this ModuleRCS rcs, double? atmPressure = null, bool useThrustLimit = false)
+        {
+            if (rcs == null)
+                return 0f;
+            float throttle = 1.0f;
+            if (useThrustLimit)
+                throttle = throttle * rcs.thrustPercentage / 100.0f;
+            // thrust is fuel flow rate times isp times g
+            // Assume min fuel flow is 0 as it's not exposed.
+            return (float)(rcs.maxFuelFlow * throttle * GetIsp(rcs, atmPressure) * rcs.G);
+        }
+        /// <summary>
+        /// Get engine ISP
+        /// </summary>
+        /// <param name="rcs">The rcs thruster (can be null - returns zero in that case)</param>
+        /// <param name="atmPressure">
+        ///   Atmospheric pressure (defaults to pressure at current location if omitted/null,
+        ///   1.0 means Earth/Kerbin sea level, 0.0 is vacuum)</param>
+        /// <returns></returns>
+        public static float GetIsp(this ModuleRCS rcs, double? atmPressure = null)
+        {
+            return rcs == null ? 0f : rcs.atmosphereCurve.Evaluate(Mathf.Max(0f, (float)(atmPressure ?? rcs.part.staticPressureAtm)));
+        }
+    }
+}

--- a/src/kOS/Suffixed/VesselTarget.Parts.cs
+++ b/src/kOS/Suffixed/VesselTarget.Parts.cs
@@ -123,6 +123,12 @@ namespace kOS.Suffixed
                     self = new EngineValue(Shared, part, parent, decoupler);
                     break;
                 }
+                var rcs = module as ModuleRCS;
+                if (rcs != null)
+                {
+                    self = new RCSValue(Shared, part, parent, decoupler, rcs);
+                    break;
+                }
                 if (module is IStageSeparator)
                 {
                     var dock = module as ModuleDockingNode;

--- a/src/kOS/Utilities/VesselUtils.cs
+++ b/src/kOS/Utilities/VesselUtils.cs
@@ -82,6 +82,10 @@ namespace kOS.Utilities
                     list = EngineValue.PartsToList(partList, sharedObj);
                     break;
 
+                case "RCS":
+                    list = RCSValue.PartsToList(partList, sharedObj);
+                    break;
+
                 case "SENSORS":
                     list = SensorValue.PartsToList(partList, sharedObj);
                     break;

--- a/src/kOS/kOS.csproj
+++ b/src/kOS/kOS.csproj
@@ -159,11 +159,13 @@
     <Compile Include="Sound\VoiceValue.cs" />
     <Compile Include="Suffixed\BoundsValue.cs" />
     <Compile Include="Suffixed\ConsumedResourceValue.cs" />
+    <Compile Include="Suffixed\ConsumedResourceValueRCS.cs" />
     <Compile Include="Suffixed\CraftTemplate.cs" />
     <Compile Include="Suffixed\KUniverseValue.cs" />
     <Compile Include="Suffixed\LoadDistanceValue.cs" />
     <Compile Include="Suffixed\Part\DecouplerValue.cs" />
     <Compile Include="Suffixed\Part\LaunchClampValue.cs" />
+    <Compile Include="Suffixed\Part\RCSValue.cs" />
     <Compile Include="Suffixed\ResourceTransferValue.cs" />
     <Compile Include="Screen\DelegateDialog.cs" />
     <Compile Include="Screen\KOSManagedWindow.cs" />


### PR DESCRIPTION
Fixes #2657.

This PR adds an RCS structure type which allows querying of various properties of RCS thrusters.