### PR TITLE
Make createorbit() take mean anomaly at epoch in degrees

### DIFF
--- a/src/kOS/Function/Suffixed.cs
+++ b/src/kOS/Function/Suffixed.cs
@@ -110,7 +110,7 @@ namespace kOS.Function
             } else 
             {
                 double t = GetDouble(PopValueAssert(shared));
-                double mEp = GetDouble(PopValueAssert(shared));
+                double mEp = DegreesToRadians(GetDouble(PopValueAssert(shared)));
                 double argPe = GetDouble(PopValueAssert(shared));
                 double lan = GetDouble(PopValueAssert(shared));
                 double sma = GetDouble(PopValueAssert(shared));


### PR DESCRIPTION
This fixes issue #2681. I ran into this issue myself while testing a fix for #2687, so I fixed it and then found this earlier report.

In particular, with this patch, the following function now successfully clones an orbit:

```
function cloneorbit {
	parameter o is orbit.
	return createorbit(
		o:inclination,
		o:eccentricity,
		o:semimajoraxis,
		o:lan,
		o:argumentofperiapsis,
		o:meananomalyatepoch,
		o:epoch,
		o:body
	).
}
```