### PR TITLE
New maxTemp for parts .cfg

### DIFF
--- a/Resources/GameData/kOS/Parts/KOSCherryLight/part.cfg
+++ b/Resources/GameData/kOS/Parts/KOSCherryLight/part.cfg
@@ -25,7 +25,7 @@ PART
     minimum_drag = .002
     angularDrag = 2
     crashTolerance = 9
-    maxTemp = 2400
+    maxTemp = 2000
     MODULE
     {
         name = ModuleLight

--- a/Resources/GameData/kOS/Parts/kOSMachine0m/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSMachine0m/part.cfg
@@ -39,7 +39,7 @@ maximum_drag = 0.2
 minimum_drag = 0.2
 angularDrag = 2
 crashTolerance = 9
-maxTemp = 3400
+maxTemp = 1200
 
 MODULE
 {

--- a/Resources/GameData/kOS/Parts/kOSMachine0mLegacy/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSMachine0mLegacy/part.cfg
@@ -45,7 +45,7 @@ PART
 	minimum_drag = 0.2
 	angularDrag = 2
 	crashTolerance = 9
-	maxTemp = 3400
+	maxTemp = 1200
 
 	MODULE
 	{

--- a/Resources/GameData/kOS/Parts/kOSMachine1m/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSMachine1m/part.cfg
@@ -39,7 +39,7 @@ maximum_drag = 0.2
 minimum_drag = 0.2
 angularDrag = 2
 crashTolerance = 9
-maxTemp = 3400
+maxTemp = 1200
 
 MODULE
 {

--- a/Resources/GameData/kOS/Parts/kOSMachineRad/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSMachineRad/part.cfg
@@ -37,7 +37,7 @@ maximum_drag = 0.0
 minimum_drag = 0.0
 angularDrag = 0
 crashTolerance = 6
-maxTemp = 3400
+maxTemp = 1200
 
 
 MODULE

--- a/Resources/GameData/kOS/Parts/kOSkal9000/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSkal9000/part.cfg
@@ -36,7 +36,7 @@ maximum_drag = 0
 minimum_drag = 0
 angularDrag = 0
 crashTolerance = 9
-maxTemp = 2000
+maxTemp = 1200
 
 MODULE
 {

--- a/Resources/GameData/kOS/Parts/kOSkal9000/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSkal9000/part.cfg
@@ -36,7 +36,7 @@ maximum_drag = 0
 minimum_drag = 0
 angularDrag = 0
 crashTolerance = 9
-maxTemp = 3400
+maxTemp = 2000
 
 MODULE
 {


### PR DESCRIPTION
This is about this issue #2698 

I not 100% that "Resources/GameData/kOS/Parts/kOSMachine0mLegacy/part.cfg" should be changed but other `maxTemp` should works good.