### PR TITLE
Fix forum link

### DIFF
--- a/doc/source/downloads_links.rst
+++ b/doc/source/downloads_links.rst
@@ -42,7 +42,7 @@ There are two good places to go for help and sharing of ideas with other
 users of kOS, and the developers of the mod frequent those locations too:
 
 - `/r/kos on reddit <https://www.reddit.com/r/kos>`__
-- `On Kerbal Space Program's forum <https://forum.kerbalspaceprogram.com/index.php?/topic/165628/>`__
+- `On Kerbal Space Program's forum <https://forum.kerbalspaceprogram.com/index.php?/topic/165628-*>`__
 
 Of these two locations, the Reddit one tends to be more active because it
 allows multiple sub-threads about kOS.  On the Kerbal Space Program


### PR DESCRIPTION
The KSP forum is weird. This link doesn't work (it goes to the main forum home page, included here for clicking convenience):

- https://forum.kerbalspaceprogram.com/index.php?/topic/165628/

... but this one does (opens the kOS thread):

- [https://forum.kerbalspaceprogram.com/index.php?/topic/165628-*](https://forum.kerbalspaceprogram.com/index.php?/topic/165628-*)

This pull request will make the link from kOS's documentation work.

Tagging @Dunbaratu since not everyone has GitHub notifications enabled for pull requests.