### PR TITLE
Fixes 2716. Moves sounds outside the kOS game object

### DIFF
--- a/src/kOS/Function/Suffixed.cs
+++ b/src/kOS/Function/Suffixed.cs
@@ -334,7 +334,7 @@ namespace kOS.Function
 
             VoiceValue val;
 
-            if (shared.AllVoiceValues.TryGetValue(voiceNum, out val))
+            if (shared.AllVoiceValues.TryGetValue(voiceNum,out val))
                 ReturnValue = val;
             else
             {

--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -102,7 +102,6 @@ namespace kOS.Screen
         private Texture2D networkZigZagImage;
         private Texture2D brightnessButtonImage;
         private Texture2D fontHeightButtonImage;
-        private AudioSource beepSource;
         private int guiTerminalBeepsPending;
 
         private SharedObjects shared;
@@ -164,8 +163,6 @@ namespace kOS.Screen
             terminalFrameStyle = Create9SliceStyle(terminalFrameImage);
             terminalFrameActiveStyle = Create9SliceStyle(terminalFrameActiveImage);
 
-            LoadAudio();
-            
             tinyToggleStyle = new GUIStyle(HighLogic.Skin.toggle)
             {
                 fontSize = 10
@@ -216,21 +213,6 @@ namespace kOS.Screen
         public kOS.Safe.Sound.ISoundMaker GetSoundMaker()
         {
             return soundMaker;
-        }
-
-        private void LoadAudio()
-        {
-            // Deliberately not fixing the following deprecation warning for using WWW, because I want this
-            // codebase to be back-portable to older KSP versions for RO/RP-1 without too much hassle.  Eventually
-            // it might not work and we may be forced to change this, but the KSP1 lifecycle may be done
-            // by then, so I don't want to make the effort prematurely.  Fixing this requires a very ugly
-            // coroutine mess to load URLs the new way Unity wants you to do it.
-#pragma warning disable CS0618 // ^^^ see above comment about why this is disabled.
-            WWW beepURL = new WWW("file://" + root + "GameData/kOS/GFX/terminal-beep.wav");
-#pragma warning enable CS0618
-            AudioClip beepClip = beepURL.GetAudioClip();
-            beepSource = gameObject.AddComponent<AudioSource>();
-            beepSource.clip = beepClip;
         }
 
         public void OpenPopupEditor(Volume v, GlobalPath path)

--- a/src/kOS/Sound/ProceduralSoundWave.cs
+++ b/src/kOS/Sound/ProceduralSoundWave.cs
@@ -1,4 +1,4 @@
-﻿using kOS.Safe.Sound;
+using kOS.Safe.Sound;
 using UnityEngine;
 
 namespace kOS.Sound

--- a/src/kOS/Sound/SoundMaker.cs
+++ b/src/kOS/Sound/SoundMaker.cs
@@ -19,6 +19,12 @@ namespace kOS.Sound
         private SharedObjects shared;
 
         /// <summary>
+        /// This top-level game object holds the AudioSources the kOS PartModule will use.
+        /// See the initialization comment in SoundMaker.Awake() for why.
+        /// </summary>
+        private GameObject soundObject;
+
+        /// <summary>
         /// Our pretend hardware limit on a "SKID" chip's number of voices
         /// </summary>
         private int hardwareMaxVoices = 10;
@@ -32,6 +38,18 @@ namespace kOS.Sound
         void Awake()
         {
             kspDirectory = KSPUtil.ApplicationRootPath.Replace("\\", "/");
+
+            // To get AudioMufflerRedux to stop quashing kOS sound effects, we had
+            // to put the AudioSource components into a GameObject that was NOT part of the
+            // kOS PartModule.  As long as it was in the kOS PartModule, AudioMufflerRedux would
+            // mistake the sounds for 3D sound effects coming from the part that need silencing
+            // in a vacuum.  (It seems to ignore AudioSource.spatialBlend being set to zero, which
+            // is supposed to tell Unity3d the sound is explicitly NOT coming from a position in 3D
+            // space.  AudioMufflerRedux muffles it anyway.)  The only fix that seems to work
+            // is to remove the sound from the PartModule's GameObject and make a global GameObject
+            // to hold it instead:
+            soundObject = new GameObject();
+            soundObject.name = "kOS.SoundMaker sound library";
 
             sounds = new Dictionary<string, AudioSource>();
             waveGenerators = new Dictionary<string, ProceduralSoundWave>();
@@ -64,6 +82,7 @@ namespace kOS.Sound
                 shared.AllVoiceValues.Clear();
                 shared = null;
             }
+            soundObject.DestroyGameObject();
         }
 
         /// <summary>
@@ -82,7 +101,7 @@ namespace kOS.Sound
             WWW fileGetter = new WWW(url);
 #pragma warning restore CS0618
             AudioClip clip = fileGetter.GetAudioClip();
-            AudioSource source = gameObject.AddComponent<AudioSource>();
+            AudioSource source = soundObject.AddComponent<AudioSource>();
             source.clip = clip;
             Console.Out.WriteLine("eraseme: PROOF I AM NEW!.  LOADFILESOUND!!");
             source.spatialBlend = 0; // Makes it ignore spatial position for calculating sound.
@@ -146,7 +165,7 @@ namespace kOS.Sound
             voices = new Voice[howMany];
             for (int i = 0; i < howMany ; ++i)
             {
-                Voice voice = gameObject.AddComponent<Voice>();
+                Voice voice = soundObject.AddComponent<Voice>();
                 voices[i] = voice;
             }
         }

--- a/src/kOS/Sound/SoundMaker.cs
+++ b/src/kOS/Sound/SoundMaker.cs
@@ -84,6 +84,8 @@ namespace kOS.Sound
             AudioClip clip = fileGetter.GetAudioClip();
             AudioSource source = gameObject.AddComponent<AudioSource>();
             source.clip = clip;
+            Console.Out.WriteLine("eraseme: PROOF I AM NEW!.  LOADFILESOUND!!");
+            source.spatialBlend = 0; // Makes it ignore spatial position for calculating sound.
             sounds[name] = source;
         }
 

--- a/src/kOS/Sound/Voice.cs
+++ b/src/kOS/Sound/Voice.cs
@@ -1,4 +1,4 @@
-﻿using kOS.Safe.Sound;
+using kOS.Safe.Sound;
 using UnityEngine;
 
 namespace kOS.Sound
@@ -76,6 +76,7 @@ namespace kOS.Sound
         {
             source = gameObject.AddComponent<AudioSource>();
             source.loop = true;
+            source.spatialBlend = 0; // Makes it ignore spatial position for calculating sound.
 
             // Dummy test stupid values:
             Attack = 0f;


### PR DESCRIPTION
By moving the AudioSource GameComponent to a global new GameObject instead of adding it to the tree of components under the PartModule game object, AudioMufflerRedux will stop trying to suppress it, because it no longer thinks of it as coming from a Part on the ship.