### PR TITLE
Vessel delta-v suffixes

### DIFF
--- a/doc/source/structures/vessels/vessel.rst
+++ b/doc/source/structures/vessels/vessel.rst
@@ -79,6 +79,10 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
     :meth:`CREW()`                           :struct:`List`                  all :struct:`CrewMembers <CrewMember>`
     :attr:`CONNECTION`                       :struct:`Connection`            Returns your connection to this vessel
     :attr:`MESSAGES`                         :struct:`MessageQueue`          This vessel's message queue
+    :attr:`DELTAV`                           :struct:`scalar`                The total delta-v of this vessel in its current situation
+    :attr:`DELTAVASL`                        :struct:`scalar`                The total delta-v of this vessel if it were at sea level
+    :attr:`DELTAVVACUUM`                     :struct:`scalar`                The total delta-v of this vessel if it were in a vacuum
+    :attr:`BURNTIME`                         :struct:`scalar`                The total burn time, in seconds, of this vessel (or 5 if the vessel has 0 delta/v).
     ======================================== =============================== =============
 
 .. note::
@@ -550,6 +554,30 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
     :return: :struct:`MessageQueue`
 
     Returns this vessel's message queue. You can only access this attribute for your current vessel (using for example `SHIP:MESSAGES`).
+
+.. attribute:: Vessel:`DELTAV`
+
+    :return: :struct:`scalar`
+
+    The total delta-v of this vessel in its current situation.
+
+.. attribute:: Vessel:`DELTAVASL`
+
+    :return: :struct:`scalar`
+
+    The total delta-v of this vessel if it were at sea level.
+
+.. attribute:: Vessel:`DELTAVVACUUM`
+
+    :return: :struct:`scalar`
+
+    The total delta-v of this vessel if it were at sea vacuum.
+
+.. attribute:: Vessel:`BURNTIME`
+
+    :return: :struct:`scalar`
+
+    The total burn time, in seconds, of this vessel (or 5 if the vessel has 0 delta/v). Burn time is not affected by atmosphere.
 
 
 Deprecated Suffix

--- a/doc/source/structures/vessels/vessel.rst
+++ b/doc/source/structures/vessels/vessel.rst
@@ -79,10 +79,10 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
     :meth:`CREW()`                           :struct:`List`                  all :struct:`CrewMembers <CrewMember>`
     :attr:`CONNECTION`                       :struct:`Connection`            Returns your connection to this vessel
     :attr:`MESSAGES`                         :struct:`MessageQueue`          This vessel's message queue
-    :attr:`DELTAV`                           :struct:`scalar`                The total delta-v of this vessel in its current situation
-    :attr:`DELTAVASL`                        :struct:`scalar`                The total delta-v of this vessel if it were at sea level
-    :attr:`DELTAVVACUUM`                     :struct:`scalar`                The total delta-v of this vessel if it were in a vacuum
-    :attr:`BURNTIME`                         :struct:`scalar`                The total burn time, in seconds, of this vessel (or 5 if the vessel has 0 delta/v).
+    :attr:`DELTAV`                           :struct:`scalar` (m/s)          The total delta-v of this vessel in its current situation
+    :attr:`DELTAVASL`                        :struct:`scalar` (m/s)          The total delta-v of this vessel if it were at sea level
+    :attr:`DELTAVVACUUM`                     :struct:`scalar` (m/s)          The total delta-v of this vessel if it were in a vacuum
+    :attr:`BURNTIME`                         :struct:`scalar` (s)            The total burn time of this vessel (or 5 if the vessel has 0 delta/v).
     ======================================== =============================== =============
 
 .. note::

--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -262,6 +262,11 @@ namespace kOS.Suffixed
             AddSuffix("ISDEAD", new NoArgsSuffix<BooleanValue>(() => (Vessel == null || Vessel.state == Vessel.State.DEAD)));
             AddSuffix("STATUS", new Suffix<StringValue>(() => Vessel.situation.ToString()));
 
+            AddSuffix("DELTAV", new Suffix<ScalarValue>(() => Vessel.VesselDeltaV.TotalDeltaVActual));
+            AddSuffix("DELTAVASL", new Suffix<ScalarValue>(() => Vessel.VesselDeltaV.TotalDeltaVASL));
+            AddSuffix("DELTAVVACUUM", new Suffix<ScalarValue>(() => Vessel.VesselDeltaV.TotalDeltaVVac));
+            AddSuffix("BURNTIME", new Suffix<ScalarValue>(() => Vessel.VesselDeltaV.TotalBurnTime));
+
             //// Although there is an implementation of lat/long/alt in Orbitible,
             //// it's better to use the methods for vessels that are faster if they're
             //// available:


### PR DESCRIPTION
Added DELTAV, DELTAVATASL, DELTAVVACUUM, and BURNTIME suffixes to Vessel.
Resolves #2655
Resolves #2674

There are a lot of other useful things in Vessel.VesselDeltaV that we should consider adding bindings for.