### PR TITLE
Update the documented keywords+symbols to match the tinypg grammar

### DIFF
--- a/doc/source/language/syntax.rst
+++ b/doc/source/language/syntax.rst
@@ -25,23 +25,23 @@ operator symbols:
 
 **Arithmetic Operators**::
 
-    +  -  *  /  ^  e  (  )
+    +  -  *  /  ^  e
 
 **Logic Operators**::
 
     not  and  or  true  false  <>  >=  <=  =  >  <
 
-**Instructions and keywords**::
+**Instructions and Keywords**::
 
-    add all at batch break clearscreen compile copy declare delete
-    deploy do do edit else file for from from function global if
-    in list local lock log off on once parameter preserve print reboot
-    remove rename run set shutdown stage step switch then to toggle
-    unlock unset until volume wait when
+    add all at break choose clearscreen compile copy declare defined
+    delete do edit else file for from function global if in is list
+    local lock log off on once parameter preserve print reboot remove
+    rename return run runoncepath runpath set shutdown stage step
+    switch then to toggle unlock unset until volume wait when
 
-**Other symbols**::
+**Other Symbols**::
 
-    {  }  [  ]  ,  :  //
+    ( )  {  }  [  ]  ,  :  #  @  //
 
 .. highlight:: kerboscript
 

--- a/src/kOS.Safe/Compilation/KS/kRISC.tpg
+++ b/src/kOS.Safe/Compilation/KS/kRISC.tpg
@@ -2,6 +2,10 @@
 
 // Terminals
 // ===================================================
+
+// When these change, please also update the list of keywords and
+// operators in the documentation: doc/source/language/syntax.rst
+
 //Math
 PLUSMINUS    -> @"(\+|-)";
 MULT         -> @"\*";


### PR DESCRIPTION
Every KerboScript major mode I could find had an out-of-date list of
keywords for syntax highlighting. While trying to fix the issue I also
discovered that the documentation's list of keywords and operators
didn't match the list of keywords I was using in my code.

I also added a comment to the grammar file asking people who change it
to keep the documentation in sync. Hopefully it helps.

Fixes #2723 