### PR TITLE
Added gui fields to a gui group

### DIFF
--- a/src/kOS/Module/KOSNameTag.cs
+++ b/src/kOS/Module/KOSNameTag.cs
@@ -1,4 +1,4 @@
-﻿using kOS.Screen;
+using kOS.Screen;
 using kOS.Suffixed;
 using UnityEngine;
 
@@ -6,17 +6,23 @@ namespace kOS.Module
 {
     public class KOSNameTag : PartModule
     {
+        private const string PAWGroup = "kOS";
+		
         private KOSNameTagWindow typingWindow;
 
         [KSPField(isPersistant = true,
                   guiActive = true,
                   guiActiveEditor = true,
-                  guiName = "name tag")]
+                  guiName = "name tag",
+                  groupName = PAWGroup,
+                  groupDisplayName = PAWGroup)]
         public string nameTag = "";
 
         [KSPEvent(guiActive = true,
                   guiActiveEditor = true,
-                  guiName = "Change Name Tag")]
+                  guiName = "Change Name Tag",
+                  groupName = PAWGroup,
+                  groupDisplayName = PAWGroup)]
         public void PopupNameTagChanger()
         {
             if (typingWindow != null)

--- a/src/kOS/Module/kOSLightModule.cs
+++ b/src/kOS/Module/kOSLightModule.cs
@@ -5,25 +5,27 @@ namespace kOS.Module
 {
     internal class kOSLightModule : PartModule
     {
-        [KSPField(isPersistant = true, guiName = "Required Power for Lights", guiActive = true)]
+        private const string PAWGroup = "kOS";
+		
+        [KSPField(isPersistant = true, guiName = "Required Power for Lights", guiActive = true, groupName = PAWGroup, groupDisplayName = PAWGroup)]
         public float resourceAmount = 0.001f;
 
-        [KSPField(isPersistant = true, guiActive = true, guiName = "Light R")]
+        [KSPField(isPersistant = true, guiActive = true, guiName = "Light R", groupName = PAWGroup, groupDisplayName = PAWGroup)]
         [UI_FloatRange(maxValue = 1, minValue = 0, scene = UI_Scene.Flight, stepIncrement = 0.01f)]
         protected float red = 1;
 
-        [KSPField(isPersistant = true, guiActive = true, guiName = "Light G")]
+        [KSPField(isPersistant = true, guiActive = true, guiName = "Light G", groupName = PAWGroup, groupDisplayName = PAWGroup)]
         [UI_FloatRange(maxValue = 1, minValue = 0, scene = UI_Scene.Flight, stepIncrement = 0.01f)]
         protected float green = 1;
 
-        [KSPField(isPersistant = true, guiActive = true, guiName = "Light B")]
+        [KSPField(isPersistant = true, guiActive = true, guiName = "Light B", groupName = PAWGroup, groupDisplayName = PAWGroup)]
         [UI_FloatRange(maxValue = 1, minValue = 0, scene = UI_Scene.Flight, stepIncrement = 0.01f)]
         protected float blue = 1;
 
-        [KSPField(isPersistant = true, guiActive = true, guiName = "Power Starved")]
+        [KSPField(isPersistant = true, guiActive = true, guiName = "Power Starved", groupName = PAWGroup, groupDisplayName = PAWGroup)]
         private bool powerStarved = false;
 
-        [KSPField(isPersistant = false, guiName = "Last requested power", guiActive = true)]
+        [KSPField(isPersistant = false, guiName = "Last requested power", guiActive = true, groupName = PAWGroup, groupDisplayName = PAWGroup)]
         public float lastResource = 0.2f;
 
         [KSPField(isPersistant = false, guiActive = false)]

--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -28,6 +28,8 @@ namespace kOS.Module
 {
     public class kOSProcessor : PartModule, IProcessor, IPartCostModifier, IPartMassModifier
     {
+        private const string PAWGroup = "kOS";
+
         public ProcessorModes ProcessorMode { get; private set; }
 
         public Harddisk HardDisk { get; private set; }
@@ -78,28 +80,28 @@ namespace kOS.Module
 
         private const string BootDirectoryName = "boot";
 
-        [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "Boot File"), UI_ChooseOption(scene = UI_Scene.Editor)]
+        [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "Boot File", groupName = PAWGroup, groupDisplayName = PAWGroup), UI_ChooseOption(scene = UI_Scene.Editor)]
         public string bootFile = "None";
 
-        [KSPField(isPersistant = true, guiName = "kOS Disk Space", guiActive = true)]
+        [KSPField(isPersistant = true, guiName = "kOS Disk Space", guiActive = true, groupName = PAWGroup, groupDisplayName = PAWGroup)]
         public int diskSpace = 1024;
 
-        [KSPField(isPersistant = true, guiName = "kOS Base Disk Space", guiActive = false)]
+        [KSPField(isPersistant = true, guiName = "kOS Base Disk Space", guiActive = false, groupName = PAWGroup, groupDisplayName = PAWGroup)]
         public int baseDiskSpace = 0;
 
-        [KSPField(isPersistant = false, guiName = "kOS Base Module Cost", guiActive = false)]
+        [KSPField(isPersistant = false, guiName = "kOS Base Module Cost", guiActive = false, groupName = PAWGroup, groupDisplayName = PAWGroup)]
         public float baseModuleCost = 0F;  // this is the base cost added to a part for including the kOSProcessor, default to 0.
 
-        [KSPField(isPersistant = true, guiName = "kOS Base Module Mass", guiActive = false)]
+        [KSPField(isPersistant = true, guiName = "kOS Base Module Mass", guiActive = false, groupName = PAWGroup, groupDisplayName = PAWGroup)]
         public float baseModuleMass = 0F;  // this is the base mass added to a part for including the kOSProcessor, default to 0.
 
-        [KSPField(isPersistant = false, guiName = "kOS Disk Space", guiActive = false, guiActiveEditor = true), UI_ChooseOption(scene = UI_Scene.Editor)]
+        [KSPField(isPersistant = false, guiName = "kOS Disk Space", guiActive = false, guiActiveEditor = true, groupName = PAWGroup, groupDisplayName = PAWGroup), UI_ChooseOption(scene = UI_Scene.Editor)]
         public string diskSpaceUI = "1024";
 
-        [KSPField(isPersistant = true, guiName = "CPU/Disk Upgrade Cost", guiActive = false, guiActiveEditor = true)]
+        [KSPField(isPersistant = true, guiName = "CPU/Disk Upgrade Cost", guiActive = false, guiActiveEditor = true, groupName = PAWGroup, groupDisplayName = PAWGroup)]
         public float additionalCost = 0F;
 
-        [KSPField(isPersistant = false, guiName = "CPU/Disk Upgrade Mass", guiActive = false, guiActiveEditor = true, guiUnits = "Kg", guiFormat = "0.00")]
+        [KSPField(isPersistant = false, guiName = "CPU/Disk Upgrade Mass", guiActive = false, guiActiveEditor = true, guiUnits = "Kg", guiFormat = "0.00", groupName = PAWGroup, groupDisplayName = PAWGroup)]
         public float additionalMassGui = 0F;
 
         [KSPField(isPersistant = false, guiActive = false, guiActiveEditor = false)]
@@ -143,24 +145,24 @@ namespace kOS.Module
             }
         }
 
-        [KSPEvent(guiActive = true, guiName = "Open Terminal", category = "skip_delay;")]
+        [KSPEvent(guiActive = true, guiName = "Open Terminal", category = "skip_delay;", groupName = PAWGroup, groupDisplayName = PAWGroup)]
         public void Activate()
         {
             SafeHouse.Logger.Log("Open Window by event");
             OpenWindow();
         }
 
-        [KSPEvent(guiActive = true, guiName = "Close Terminal", category = "skip_delay;")]
+        [KSPEvent(guiActive = true, guiName = "Close Terminal", category = "skip_delay;", groupName = PAWGroup, groupDisplayName = PAWGroup)]
         public void Deactivate()
         {
             SafeHouse.Logger.Log("Close Window by event");
             CloseWindow();
         }
 
-        [KSPField(isPersistant = true, guiName = "kOS Average Power", guiActive = true, guiActiveEditor = true, guiUnits = "EC/s", guiFormat = "0.000")]
+        [KSPField(isPersistant = true, guiName = "kOS Average Power", guiActive = true, guiActiveEditor = true, guiUnits = "EC/s", guiFormat = "0.000", groupName = PAWGroup, groupDisplayName = PAWGroup)]
         public float RequiredPower = 0;
 
-        [KSPEvent(guiActive = true, guiName = "Toggle Power")]
+        [KSPEvent(guiActive = true, guiName = "Toggle Power", groupName = PAWGroup, groupDisplayName = PAWGroup)]
         public void TogglePower()
         {
             SafeHouse.Logger.Log("Toggle Power");
@@ -267,12 +269,8 @@ namespace kOS.Module
 
         private void UpdateCostAndMass()
         {
-            // Clamp this to prevent negative cost and mass.  Antimatter
-            // parts can explode the ship since their response to forces
-            // is all backward.  (That problem only happens if people
-            // edit the part.cfg numbers, but people do sometimes do that.)
+            // Clamp this to prevent negative cost and mass.
             float spaceDelta = Mathf.Max(diskSpace - baseDiskSpace, 0.0f);
-
             additionalCost = (float)System.Math.Round(spaceDelta * diskSpaceCostFactor, 0);
             AdditionalMass = spaceDelta * diskSpaceMassFactor;
             additionalMassGui = AdditionalMass * 1000;


### PR DESCRIPTION
Places all kOS fields into a group in the PAW.
In Edtior:
![image](https://user-images.githubusercontent.com/40358880/88924020-894b4800-d26a-11ea-84d1-b814dff755ed.png)
In Flight:
![image](https://user-images.githubusercontent.com/40358880/88924053-99fbbe00-d26a-11ea-89ce-bf65757d8423.png)