### PR TITLE
Fixes issue 2697 clickthrublocker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,7 +213,14 @@ Setting Up Your Environment
                * Click on the resulting link to go to that class's documentation page.
                * The Unity documentation for that class will start with some faint grey text at the top of the page that says, "Implemented in:", which tells you which DLL you need to reference to get code using that class to compile properly.
 
-	3. If you do not have a copy of KSP locally, you may
+        3. Make sure your installation of KSP has LinuxGuruGamer's ClivkThroughBlocker
+           mod installed.  kOS now needs it in order to compile.  After it is
+           installed, create a reference for it in your kOS project's References
+           like so:
+
+               * $KSP_INSTALL_DIR/GameData/00_ClickThroughBlocker/Plugins/ClickThroughBlocker.dll
+
+	4. If you do not have a copy of KSP locally, you may
 	  download dummy assemblies at https://github.com/KSP-KOS/KSP_LIB
 
 3. Make sure you are targeting this version of .Net:  ".Net 4.0 Framework".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,10 +215,19 @@ Setting Up Your Environment
 
         3. Make sure your installation of KSP has LinuxGuruGamer's ClivkThroughBlocker
            mod installed.  kOS now needs it in order to compile.  After it is
-           installed, create a reference for it in your kOS project's References
-           like so:
+           installed, copy its DLL file into Resources/ from your GameData folder.
+
+           Copy This file:
 
                * $KSP/GameData/00_ClickThroughBlocker/Plugins/ClickThroughBlocker.dll
+
+           To here:
+
+               * Resources/
+
+           Then *make a Reference to Resoruces/ClickThroughBlocker.dll in your kOS project
+           file*.  This is needed for it to let you compile parts of kOS that use classes
+           from ClickThroughBlocker.
 
 	4. If you do not have a copy of KSP locally, you may
 	  download dummy assemblies at https://github.com/KSP-KOS/KSP_LIB

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,7 +218,7 @@ Setting Up Your Environment
            installed, create a reference for it in your kOS project's References
            like so:
 
-               * $KSP_INSTALL_DIR/GameData/00_ClickThroughBlocker/Plugins/ClickThroughBlocker.dll
+               * $KSP/GameData/00_ClickThroughBlocker/Plugins/ClickThroughBlocker.dll
 
 	4. If you do not have a copy of KSP locally, you may
 	  download dummy assemblies at https://github.com/KSP-KOS/KSP_LIB

--- a/kOS.netkan
+++ b/kOS.netkan
@@ -19,6 +19,7 @@
     "depends"        : [
         {
             "name" : ClickThroughBlocker",
+            "min_version" : "0.10.0",
             "comment" : "For better cooperation with the many other mods that use it, kOS now also uses ClickThroughBlocker to open its GUI windows.  But this means kOS won't work if ClickThroughBlocker is missing. <br/> (Geek technical note: Any implementation that tried to make this dependency optional would have involved too much expensive Reflection.)"
         }
     ],

--- a/kOS.netkan
+++ b/kOS.netkan
@@ -16,13 +16,6 @@
         "repository" : "https://github.com/KSP-KOS/KOS"
     },
     "conflicts"      :   [ { "name" : "kOS-Classic" } ],
-    "depends"        : [
-        {
-            "name" : "ClickThroughBlocker",
-            "min_version" : "0.10.0",
-            "comment" : "For better cooperation with the many other mods that use it, kOS now also uses ClickThroughBlocker to open its GUI windows.  But this means kOS won't work if ClickThroughBlocker is missing. <br/> (Geek technical note: Any implementation that tried to make this dependency optional would have involved too much expensive Reflection.)"
-        }
-    ],
     "recommends"     : [
         {
             "name": "ModuleManager",

--- a/kOS.netkan
+++ b/kOS.netkan
@@ -16,6 +16,12 @@
         "repository" : "https://github.com/KSP-KOS/KOS"
     },
     "conflicts"      :   [ { "name" : "kOS-Classic" } ],
+    "depends"        : [
+        {
+            "name" : ClickThroughBlocker",
+            "comment" : "For better cooperation with the many other mods that use it, kOS now also uses ClickThroughBlocker to open its GUI windows.  But this means kOS won't work if ClickThroughBlocker is missing. <br/> (Geek technical note: Any implementation that tried to make this dependency optional would have involved too much expensive Reflection.)"
+        }
+    ],
     "recommends"     : [
         {
             "name": "ModuleManager",

--- a/kOS.netkan
+++ b/kOS.netkan
@@ -18,7 +18,7 @@
     "conflicts"      :   [ { "name" : "kOS-Classic" } ],
     "depends"        : [
         {
-            "name" : ClickThroughBlocker",
+            "name" : "ClickThroughBlocker",
             "min_version" : "0.10.0",
             "comment" : "For better cooperation with the many other mods that use it, kOS now also uses ClickThroughBlocker to open its GUI windows.  But this means kOS won't work if ClickThroughBlocker is missing. <br/> (Geek technical note: Any implementation that tried to make this dependency optional would have involved too much expensive Reflection.)"
         }

--- a/src/kOS/Module/kOSSettingsChecker.cs
+++ b/src/kOS/Module/kOSSettingsChecker.cs
@@ -22,6 +22,7 @@ namespace kOS.Module
             SafeHouse.Logger.SuperVerbose("kOSSettingsChecker.CheckSettings()");
             HighLogic.CurrentGame.Parameters.CustomParams<kOSCustomParameters>().CheckMigrateSettings();
             HighLogic.CurrentGame.Parameters.CustomParams<kOSConnectivityParameters>().CheckNewManagers();
+            HighLogic.CurrentGame.Parameters.CustomParams<kOSCustomParameters>().CheckClickThroughBlockerExists();
         }
 
         // Because rapidly showing dialogs can prevent some from being shown, we can just queue up

--- a/src/kOS/Properties/AssemblyInfo.cs
+++ b/src/kOS/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("1.2.1.0")]
 [assembly: AssemblyVersion("1.2.1.0")]
 [assembly: KSPAssembly("kOS", 1, 7)]
+[assembly: KSPAssemblyDependency("ClickThroughBlocker", 1, 0)]

--- a/src/kOS/Properties/AssemblyInfo.cs
+++ b/src/kOS/Properties/AssemblyInfo.cs
@@ -34,4 +34,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("1.2.1.0")]
 [assembly: AssemblyVersion("1.2.1.0")]
 [assembly: KSPAssembly("kOS", 1, 7)]
-[assembly: KSPAssemblyDependency("ClickThroughBlocker", 1, 0)]
+
+// No longer a hard dependancy, because we want to tell the user why kOS isn't working
+// if ClickThroughBlocker is not there, rather than just have it silently refuse to
+// load kOS with no explanation as would happen if this line was enabled:
+// [assembly: KSPAssemblyDependency("ClickThroughBlocker", 1, 0)]

--- a/src/kOS/Screen/DelegateDialog.cs
+++ b/src/kOS/Screen/DelegateDialog.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using ClickThroughFix; // Needs ClickThroughBlocker DLL to be in the Reference directory.
 using UnityEngine;
 
 namespace kOS.Screen
@@ -38,7 +39,7 @@ namespace kOS.Screen
             if (invoked)
             {
                 float guessWidth = GUI.skin.label.CalcSize( new GUIContent(message) ).x;
-                GUILayout.Window( parent.GetUniqueId()+1, new Rect( parent.GetRect().xMin+200,
+                ClickThruBlocker.GUILayoutWindow( parent.GetUniqueId()+1, new Rect( parent.GetRect().xMin+200,
                                                  parent.GetRect().yMin+10,
                                                  guessWidth,
                                                  0) , DrawConfirm, "Confirm", GUILayout.ExpandWidth(true) );

--- a/src/kOS/Screen/GUIWindow.cs
+++ b/src/kOS/Screen/GUIWindow.cs
@@ -14,6 +14,7 @@ using kOS.Suffixed.Widget;
 using kOS.Utilities;
 using kOS.Communication;
 using kOS.Safe;
+using ClickThroughFix; // Needs ClickThroughBlocker DLL to be in the Reference directory.
 
 namespace kOS.Screen
 {
@@ -116,7 +117,7 @@ namespace kOS.Screen
 
             GUI.skin = HighLogic.Skin;
 
-            WindowRect = GUILayout.Window(UniqueId, WindowRect, WidgetGui, TitleText, style);
+            WindowRect = ClickThruBlocker.GUILayoutWindow(UniqueId, WindowRect, WidgetGui, TitleText, style);
 
             if (currentPopup != null) {
                 var r = RectExtensions.EnsureCompletelyVisible(currentPopup.popupRect);
@@ -124,7 +125,7 @@ namespace kOS.Screen
                     currentPopup.PopDown();
                 } else {
                     GUI.BringWindowToFront(UniqueId + 1);
-                    currentPopup.popupRect = GUILayout.Window(UniqueId + 1, r, PopupGui, "", style);
+                    currentPopup.popupRect = ClickThruBlocker.GUILayoutWindow(UniqueId + 1, r, PopupGui, "", style);
                 }
             }
         }

--- a/src/kOS/Screen/KOSManagedWindow.cs
+++ b/src/kOS/Screen/KOSManagedWindow.cs
@@ -1,14 +1,23 @@
 using System.Collections.Generic;
 using UnityEngine;
+using ClickThroughFix; // Needs ClickThroughBlocker DLL to be in the Reference directory.
 
 namespace kOS.Screen
 {
     /// <summary>
     /// kOSManagedWindow is for any Unity Monobehavior that you'd like to
-    /// have contain a GUI.Window, and you need kOS to keep track of the
+    /// have contain an IMGUI Window, and you need kOS to keep track of the
     /// window stacking for which click is on top of which other click.
     /// Unity's built in systems for this don't work well at all, so
     /// we had to make up our own.
+    /// 
+    /// Issue #2697 - In addition to KOS's own system to handle this,
+    /// This also is now layered on top of Linuxgurugamer's ClickThroughBlocker
+    /// mod, so it uses its wrappers around GUI.Window.  That was needed because
+    /// if SOME mods use ClickThruBlocker windows, then those windows will get first
+    /// dibs on events before kOS gets to, making kOS helpless to intercept events it's
+    /// trying to protect other windows from seeing.  ClickThruBlocker is a mod that
+    /// once some mods use it, then all the other mods have to as well.
     /// </summary>
     public abstract class KOSManagedWindow : MonoBehaviour
     {

--- a/src/kOS/Screen/KOSNameTagWindow.cs
+++ b/src/kOS/Screen/KOSNameTagWindow.cs
@@ -1,6 +1,7 @@
-﻿using kOS.Utilities;
+using kOS.Utilities;
 using UnityEngine;
 using kOS.Module;
+using ClickThroughFix; // Needs ClickThroughBlocker DLL to be in the Reference directory.
 using System;
 
 namespace kOS.Screen
@@ -124,7 +125,7 @@ namespace kOS.Screen
                 EditorLogic.fetch.Lock(false, false, false, "KOSNameTagLock");
 
             GUI.skin = HighLogic.Skin;
-            GUILayout.Window(myWindowId, windowRect, DrawWindow,"KOS nametag");
+            ClickThruBlocker.GUILayoutWindow(myWindowId, windowRect, DrawWindow,"KOS nametag");
             
             // Ensure that the first time the window is made, it gets keybaord focus,
             // but allow the focus to leave the window after that:

--- a/src/kOS/Screen/KOSTextEditPopup.cs
+++ b/src/kOS/Screen/KOSTextEditPopup.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using kOS.Safe.Exceptions;
 using kOS.Safe.Utilities;
 using kOS.Module;
+using ClickThroughFix; // Needs ClickThroughBlocker DLL to be in the Reference directory.
 
 namespace kOS.Screen
 {
@@ -170,7 +171,7 @@ namespace kOS.Screen
             CalcOuterCoords(); // force windowRect to lock to bottom edge of the parents
             CalcInnerCoords();
 
-            WindowRect = GUI.Window(UniqueId, WindowRect, ProcessWindow, "");
+            WindowRect = ClickThruBlocker.GUIWindow(UniqueId, WindowRect, ProcessWindow, "");
             // Some mouse global state data used by several of the checks:
 
             if (consumeEvent)

--- a/src/kOS/Screen/KOSToolbarWindow.cs
+++ b/src/kOS/Screen/KOSToolbarWindow.cs
@@ -10,6 +10,8 @@ using System.Globalization;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using ClickThroughFix; // Needs ClickThroughBlocker DLL to be in the Reference directory.
+
 
 namespace kOS.Screen
 {
@@ -443,7 +445,7 @@ namespace kOS.Screen
 
             GUI.skin = HighLogic.Skin;
 
-            windowRect = GUILayout.Window(UNIQUE_ID, windowRect, DrawWindow, "kOS " + versionString);
+            windowRect = ClickThruBlocker.GUILayoutWindow(UNIQUE_ID, windowRect, DrawWindow, "kOS " + versionString);
             windowRect = RectExtensions.ClampToRectAngle(windowRect, rectToFit);
         }
 

--- a/src/kOS/Screen/ListPickerDialog.cs
+++ b/src/kOS/Screen/ListPickerDialog.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using UnityEngine;
+using ClickThroughFix; // Needs ClickThroughBlocker DLL to be in the Reference directory.
+
 
 namespace kOS.Screen
 {
@@ -110,7 +112,7 @@ namespace kOS.Screen
 
             // Make sure it shifts enough to the left to fit the biggest string:
             outerWindowRect.x = Mathf.Min(outerWindowRect.x, UnityEngine.Screen.width - outerWindowRect.width - 60);
-            outerWindowRect = GUILayout.Window(
+            outerWindowRect = ClickThruBlocker.GUILayoutWindow(
                 title.GetHashCode(),
                 outerWindowRect,
                 DrawInnards,

--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -10,6 +10,7 @@ using kOS.UserIO;
 using kOS.Safe.UserIO;
 using KSP.UI.Dialogs;
 using kOS.Safe.Utilities;
+using ClickThroughFix; // Needs ClickThroughBlocker DLL to be in the Reference directory.
 
 namespace kOS.Screen
 {
@@ -360,7 +361,7 @@ namespace kOS.Screen
             // Should probably make "gui screen name for my CPU part" into some sort of utility method:
             ChangeTitle(CalcualteTitle());
 
-            WindowRect = GUI.Window(UniqueId, WindowRect, TerminalGui, TitleText);
+            WindowRect = ClickThruBlocker.GUIWindow(UniqueId, WindowRect, TerminalGui, TitleText);
             
             if (consumeEvent)
             {

--- a/src/kOS/UserIO/TelnetMainServer.cs
+++ b/src/kOS/UserIO/TelnetMainServer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Collections.Generic;
@@ -8,6 +8,8 @@ using KSP.IO;
 using kOS.Suffixed;
 using UnityEngine;
 using Debug = UnityEngine.Debug;
+using ClickThroughFix; // Needs ClickThroughBlocker DLL to be in the Reference directory.
+
 
 namespace kOS.UserIO
 {
@@ -371,10 +373,10 @@ namespace kOS.UserIO
         void OnGUI()
         {
             if (activeOptInDialog)
-                optInRect = GUILayout.Window(401123, // any made up number unlikely to clash is okay here
+                optInRect = ClickThruBlocker.GUILayoutWindow(401123, // any made up number unlikely to clash is okay here
                                              optInRect, OptInOnGui, "kOS Telnet Opt-In Permisssion");
             if (activeRealIPDialog)
-                realIPRect = GUILayout.Window(401124, // any made up number unlikely to clash is okay here
+                realIPRect = ClickThruBlocker.GUILayoutWindow(401124, // any made up number unlikely to clash is okay here
                                               realIPRect, RealIPOnGui, "kOS Telnet Non-Loopback Permisssion");
             if (activeBgSimDialog)
                 bgSimRect = GUILayout.Window(401125, // any made up number unlikely to clash is okay here

--- a/src/kOS/kOS.csproj
+++ b/src/kOS/kOS.csproj
@@ -37,6 +37,9 @@
     <Reference Include="Assembly-CSharp-firstpass">
       <HintPath>..\..\Resources\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
+    <Reference Include="ClickThroughBlocker">
+      <HintPath>..\..\Resources\ClickThroughBlocker.dll</HintPath>
+    </Reference>
     <Reference Include="ICSharpCode.SharpZipLib">
       <HintPath>..\..\Resources\GameData\kOS\Plugins\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>

--- a/src/kOS/kOS.csproj
+++ b/src/kOS/kOS.csproj
@@ -37,7 +37,8 @@
     <Reference Include="Assembly-CSharp-firstpass">
       <HintPath>..\..\Resources\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
-    <Reference Include="ClickThroughBlocker">
+    <Reference Include="ClickThroughBlocker, Version=0.1.9.5, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Resources\ClickThroughBlocker.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib">


### PR DESCRIPTION
This edit makes kOS use the ClickThroughBlocker mod to handle its keyboard focus.  ClickThroughBlocker is a nice mod, but it does require all mods to get on board and use it or else it starts acting very hostile toward the ones that don't, stealing their focus away.  (Ironically it was *causing* clickthrough bugs when one of ClickThroughBlocker's windows was stacked underneath kOS's terminal window and stealing its focus.)

The only way to fix the fact that CTB windows were stealing focus from the kOS terminal even when they were stacked underneath it was to make the kOS terminal *become* a CTB window too so CTB knows it exists and can track its ``rect`` and stacking order relative to the other CTB windows.

To make this work, I spoke at length with @LinuxGuruGamer (maintainer of ClickThroughBlocker) on our Twitch channels and spoke of how moving kOS to using ClickThroughBlocker would change its behavior to focus-follows-mouse, which wasn't necessarily desired.  At the time focus-follows-mouse was the only option ClickThroughBlocker had.  He has since added the option to use click-to-focus depending on player preference.  It is for THAT reason that this mod requires ClickThroughBloocker to be at least version 0.10.  Old versions of ClickThroughBlocker will be missing the ``focusFollowsClick`` boolean field that our code in kOS explicitly reads to change its own behavior.  With that field missing, there would be errors.

### A NOTE ABOUT THIS PR and the kOS.netkan file:

This PR "wants" to edit the kOS.netkan file to reflect the new mod dependency on ClickThroughBlocker, but it can't.  That had to be put in a separate PR ( To be called #2730 ).  For reasons, see the edits to documentation files in PR #2730. )
