### PR TITLE
Addon update for Trajectories v2.4.0

### DIFF
--- a/doc/source/addons/Trajectories.rst
+++ b/doc/source/addons/Trajectories.rst
@@ -230,7 +230,7 @@ Access structure TRAddon via ``ADDONS:TR``.
     *If :attr:`TRAddons:ISVERTWOFOUR` is false, using this suffix will cause
     a runtime error.*
 
-    Resets all the Trajectories descent profile nodes to the passed AoA value (in Radians),
+    Resets all the Trajectories descent profile nodes to the passed AoA value (in Degrees),
     also sets Retrograde if AoA value is greater than ±90° (±PI/2) otherwise sets to Prograde.
 
 .. attribute:: TRAddon:DESCENTANGLES
@@ -243,7 +243,7 @@ Access structure TRAddon via ``ADDONS:TR``.
     *If :attr:`TRAddons:ISVERTWOFOUR` is false, using this suffix will cause
     a runtime error.*
 
-    Returns or sets all the Trajectories descent profile AoA values (in Radians),
+    Returns or sets all the Trajectories descent profile AoA values (in Degrees),
     also sets a node to Retrograde if it's passed AoA is greater than ±90° (±PI/2)
     Note. also use with :attr:`TRAddons:DESCENTGRADES` to set a nodes grade
     if needed and passing AoA values as displayed in the gui with max ±90° (±PI/2).

--- a/doc/source/addons/Trajectories.rst
+++ b/doc/source/addons/Trajectories.rst
@@ -4,7 +4,7 @@ Trajectories
 ==================
 
 - Download: https://github.com/neuoy/KSPTrajectories/releases
-- Forum thread: https://forum.kerbalspaceprogram.com/index.php?/topic/162324-131-110x-trajectories-v234-2020-07-13-atmospheric-predictions/
+- Forum thread: https://forum.kerbalspaceprogram.com/index.php?/topic/162324-131-110/
 
 Trajectories is a mod that displays trajectory predictions, accounting for atmospheric drag, lift, etc.. See the forum thread for more details.
 
@@ -64,9 +64,9 @@ Access structure TRAddon via ``ADDONS:TR``.
      :attr:`IMPACTPOS`                    :struct:`GeoCoordinates` (readonly)   Returns a :struct:`GeoCoordinates` with the predicted impact position.
      :attr:`TIMETILLIMPACT`               :struct:`ScalarValue` (readonly)      **(only TR 2.2.0 and up)** Seconds until impact.
      :meth:`RESETDESCENTPROFILE(AoA)`     None                                  **(only TR 2.4.0 and up)** Reset all the Descent profile nodes.
-     :attr:`DESCENTPROFILEANGLES`         :struct:`List<ScalarValue>`           **(only TR 2.4.0 and up)** Descent profile angles.
-     :attr:`DESCENTPROFILEGRADES`         :struct:`List<Boolean>`               **(only TR 2.4.0 and up)** Descent profile grades (Retro or Pro).
-     :attr:`DESCENTPROFILEMODES`          :struct:`List<Boolean>`               **(only TR 2.4.0 and up)** Descent profile modes (AoA or Horizon).
+     :attr:`DESCENTANGLES`                :struct:`List<ScalarValue>`           **(only TR 2.4.0 and up)** Descent profile angles.
+     :attr:`DESCENTGRADES`                :struct:`List<Boolean>`               **(only TR 2.4.0 and up)** Descent profile grades (Retro or Pro).
+     :attr:`DESCENTMODES`                 :struct:`List<Boolean>`               **(only TR 2.4.0 and up)** Descent profile modes (AoA or Horizon).
      :attr:`PROGRADE`                     :struct:`Boolean`                     **(only TR 2.2.0 and up** Descent profile all prograde.
      :attr:`RETROGRADE`                   :struct:`Boolean`                     **(only TR 2.2.0 and up** Descent profile all retrograde.
      :attr:`PLANNEDVEC`                   :struct:`Vector` (readonly)           Vector at which to point to follow predicted trajectory.
@@ -173,7 +173,7 @@ Access structure TRAddon via ``ADDONS:TR``.
     Resets all the Trajectories descent profile nodes to the passed AoA value (in Radians),
     also sets Retrograde if AoA value is greater than ±90° (±PI/2) otherwise sets to Prograde.
 
-.. attribute:: TRAddon:DESCENTPROFILEANGLES
+.. attribute:: TRAddon:DESCENTANGLES
 
     :type: :struct:`List<Scalar>`
     :access: Get/Set
@@ -185,12 +185,12 @@ Access structure TRAddon via ``ADDONS:TR``.
 
     Returns or sets all the Trajectories descent profile AoA values (in Radians),
     also sets a node to Retrograde if it's passed AoA is greater than ±90° (±PI/2)
-    Note. also use with :attr:`TRAddons:DESCENTPROFILEGRADES` to set a nodes grade
+    Note. also use with :attr:`TRAddons:DESCENTGRADES` to set a nodes grade
     if needed and passing AoA values as displayed in the gui with max ±90° (±PI/2).
 
     List<Scalar>(atmospheric entry, high altitude, low altitude, final approach).
 
-.. attribute:: TRAddon:DESCENTPROFILEGRADES
+.. attribute:: TRAddon:DESCENTGRADES
 
     :type: :struct:`List<Boolean>`
     :access: Get/Set
@@ -205,7 +205,7 @@ Access structure TRAddon via ``ADDONS:TR``.
 
     List<Boolean>(atmospheric entry, high altitude, low altitude, final approach).
 
-.. attribute:: TRAddon:DESCENTPROFILEMODES
+.. attribute:: TRAddon:DESCENTMODES
 
     :type: :struct:`List<Boolean>`
     :access: Get/Set

--- a/doc/source/addons/Trajectories.rst
+++ b/doc/source/addons/Trajectories.rst
@@ -56,7 +56,10 @@ Access structure TRAddon via ``ADDONS:TR``.
      Suffix                               Type                                  Description
     ==================================== ===================================== =============
      :attr:`AVAILABLE`                    :struct:`Boolean` (readonly)          True if a compatible Trajectories version is installed.
-     :attr:`GETVERSION`                   :struct:`String` (readonly)           **(only TR 2.2.0 and up)** Trajectories version string.
+     :attr:`GETVERSION`                   :struct:`String` (readonly)           Trajectories version string.
+     :attr:`GETVERSIONMAJOR`              :struct:`ScalarValue` (readonly)      Trajectories version Major.
+     :attr:`GETVERSIONMINOR`              :struct:`ScalarValue` (readonly)      Trajectories version Minor.
+     :attr:`GETVERSIONPATCH`              :struct:`ScalarValue` (readonly)      Trajectories version Patch.
      :attr:`ISVERTWO`                     :struct:`Boolean` (readonly)          True if Trajectories version is 2.0.0 or above.
      :attr:`ISVERTWOTWO`                  :struct:`Boolean` (readonly)          True if Trajectories version is 2.2.0 or above.
      :attr:`ISVERTWOFOUR`                 :struct:`Boolean` (readonly)          True if Trajectories version is 2.4.0 or above.
@@ -110,7 +113,64 @@ Access structure TRAddon via ``ADDONS:TR``.
     For cases where you need to check for a known minimum Trajectories
     version, it is probably better to use the specific boolean suffix
     for that version (for example, :attr:`TRAddon:ISVERTWO`, or
-    :attr:`TRAddon:ISVERTWOTWO`.)
+    :attr:`TRAddon:ISVERTWOTWO` etc.)
+
+.. attribute:: TRAddon:GETVERSIONMAJOR
+
+    :type: :struct:`Scalar`
+    :access: Get
+
+    **Only gives the correct answer for Trajectries version >= 2.0.0**
+
+    *For earlier versions, it gives a hardcoded fixed answer, as follows:*
+
+    - For any Trajectories version earlier than 2.0.0,
+      this returns "0".
+    - If your Trajectories version is at least 2.0.0 or above,
+      this returns the specific version major value correctly.
+
+    For cases where you need to check for a known minimum Trajectories
+    version, it is probably better to use the specific boolean suffix
+    for that version (for example, :attr:`TRAddon:ISVERTWO`, or
+    :attr:`TRAddon:ISVERTWOTWO` etc.)
+
+.. attribute:: TRAddon:GETVERSIONMINOR
+
+    :type: :struct:`Scalar`
+    :access: Get
+
+    **Only gives the correct answer for Trajectries version >= 2.2.0**
+
+    *For earlier versions, it gives a hardcoded fixed answer, as follows:*
+
+    - For any Trajectories version below 2.2.0, this returns
+      "0" regardless of the precise version number within that range.
+    - If your Trajectories version is at least 2.2.0 or above,
+      this returns the specific version minor value correctly.
+
+    For cases where you need to check for a known minimum Trajectories
+    version, it is probably better to use the specific boolean suffix
+    for that version (for example, :attr:`TRAddon:ISVERTWO`, or
+    :attr:`TRAddon:ISVERTWOTWO` etc.)
+
+.. attribute:: TRAddon:GETVERSIONPATCH
+
+    :type: :struct:`Scalar`
+    :access: Get
+
+    **Only gives the correct answer for Trajectries version >= 2.2.0**
+
+    *For earlier versions, it gives a hardcoded fixed answer, as follows:*
+
+    - For any Trajectories version below 2.2.0, this returns
+      "0" regardless of the precise version number within that range.
+    - If your Trajectories version is at least 2.2.0 or above,
+      this returns the specific version patch value correctly.
+
+    For cases where you need to check for a known minimum Trajectories
+    version, it is probably better to use the specific boolean suffix
+    for that version (for example, :attr:`TRAddon:ISVERTWO`, or
+    :attr:`TRAddon:ISVERTWOTWO` etc.)
 
 .. attribute:: TRAddon:ISVERTWO
 

--- a/doc/source/addons/Trajectories.rst
+++ b/doc/source/addons/Trajectories.rst
@@ -4,7 +4,7 @@ Trajectories
 ==================
 
 - Download: https://github.com/neuoy/KSPTrajectories/releases
-- Forum thread: http://forum.kerbalspaceprogram.com/index.php?/topic/94368-trajectories
+- Forum thread: https://forum.kerbalspaceprogram.com/index.php?/topic/162324-131-110x-trajectories-v234-2020-07-13-atmospheric-predictions/
 
 Trajectories is a mod that displays trajectory predictions, accounting for atmospheric drag, lift, etc.. See the forum thread for more details.
 
@@ -13,7 +13,7 @@ This addon is not associated with and not supported by the creator of Trajectori
 The Trajectories API is accessed through C# reflection, and is designed for the
 current version. This means that future Trajectories updates may break this
 addon, in which case ``ADDONS:TR:AVAILABLE`` will return false.  It is also
-possible for future versions of Trjectories to remain fully compatible.
+possible for future versions of Trajectories to remain fully compatible.
 
 .. note::
 
@@ -45,32 +45,39 @@ and Trajectories 2.x.  These changes alter the way that the kOS
 Trajectories AddOn has to communicate with the Trajectories mod, and
 added new suffixes that kOS could use.  However, for backward
 compatibility kOS will try to support an older version of Trajectories
-if that's what's installed.  Places where a suffx only works with
+if that's what's installed.  Places where a suffix only works with
 newer versions of Trajectories are noted below in the suffix table.
 
 Access structure TRAddon via ``ADDONS:TR``.
 
 .. structure:: TRAddon
 
-    ============================= ===================================== =============
-     Suffix                        Type                                  Description
-    ============================= ===================================== =============
-     :attr:`AVAILABLE`             :struct:`Boolean` (readonly)          True if a compatible Trajectories version is installed.
-     :attr:`GETVERSION`            :struct:`String` (readonly)           **(only TR 2.2.0 and up)** Trajectories version string.
-     :attr:`ISVERTWO`              :struct:`Boolean` (readonly)          True if Trajectories version is 2.0.0 or above.
-     :attr:`ISVERTWOTWO`           :struct:`Boolean` (readonly)          True if Trajectories version is 2.2.0 or above.
-     :attr:`HASIMPACT`             :struct:`Boolean` (readonly)          True if Trajectories has calculated an impact position for the current vessel.
-     :attr:`IMPACTPOS`             :struct:`GeoCoordinates` (readonly)   Returns a :struct:`GeoCoordinates` with the predicted impact position.
-     :attr:`PLANNEDVEC`            :struct:`Vector` (readonly)           Vector at which to point to follow predicted trajectory.
-     :attr:`PLANNEDVECTOR`         :struct:`Vector` (readonly)           Alias for :attr:`PLANNEDVEC`
-     :meth:`SETTARGET(position)`   None                                  Set Trajectories target.
-     :attr:`HASTARGET`             :struct:`Boolean` (readonly)          **(only TR 2.0.0 and up)** True if Trajectories' target position has been selected.
-     :attr:`TIMETILLIMPACT`        :struct:`ScalarValue` (readonly)      **(only TR 2.2.0 and up)** Seconds until impact
-     :attr:`RETROGRADE`            :struct:`Boolean`                     **(only TR 2.2.0 and up)** Descent profile is retrograde mode.
-     :attr:`PROGRADE`              :struct:`Boolean`                     **(only TR 2.2.0 and up)** Descent profile is prograde mode.
-     :attr:`CORRECTEDVEC`          :struct:`Vector` (readonly)           Offset plus :attr:`PLANNEDVEC` to correct path for targeted impact.
-     :attr:`CORRECTEDVECTOR`       :struct:`Vector` (readonly)           Alias for :attr:`CORRECTEDVEC`
-    ============================= ===================================== =============
+    ==================================== ===================================== =============
+     Suffix                               Type                                  Description
+    ==================================== ===================================== =============
+     :attr:`AVAILABLE`                    :struct:`Boolean` (readonly)          True if a compatible Trajectories version is installed.
+     :attr:`GETVERSION`                   :struct:`String` (readonly)           **(only TR 2.2.0 and up)** Trajectories version string.
+     :attr:`ISVERTWO`                     :struct:`Boolean` (readonly)          True if Trajectories version is 2.0.0 or above.
+     :attr:`ISVERTWOTWO`                  :struct:`Boolean` (readonly)          True if Trajectories version is 2.2.0 or above.
+     :attr:`ISVERTWOFOUR`                 :struct:`Boolean` (readonly)          True if Trajectories version is 2.4.0 or above.
+     :attr:`HASIMPACT`                    :struct:`Boolean` (readonly)          True if Trajectories has calculated an impact position for the current vessel.
+     :attr:`IMPACTPOS`                    :struct:`GeoCoordinates` (readonly)   Returns a :struct:`GeoCoordinates` with the predicted impact position.
+     :attr:`TIMETILLIMPACT`               :struct:`ScalarValue` (readonly)      **(only TR 2.2.0 and up)** Seconds until impact.
+     :meth:`RESETDESCENTPROFILE(AoA)`     None                                  **(only TR 2.4.0 and up)** Reset all the Descent profile nodes.
+     :attr:`DESCENTPROFILEANGLES`         :struct:`List<ScalarValue>`           **(only TR 2.4.0 and up)** Descent profile angles.
+     :attr:`DESCENTPROFILEGRADES`         :struct:`List<Boolean>`               **(only TR 2.4.0 and up)** Descent profile grades (Retro or Pro).
+     :attr:`DESCENTPROFILEMODES`          :struct:`List<Boolean>`               **(only TR 2.4.0 and up)** Descent profile modes (AoA or Horizon).
+     :attr:`PROGRADE`                     :struct:`Boolean`                     **(only TR 2.2.0 and up** Descent profile all prograde.
+     :attr:`RETROGRADE`                   :struct:`Boolean`                     **(only TR 2.2.0 and up** Descent profile all retrograde.
+     :attr:`PLANNEDVEC`                   :struct:`Vector` (readonly)           Vector at which to point to follow predicted trajectory.
+     :attr:`PLANNEDVECTOR`                :struct:`Vector` (readonly)           Alias for :attr:`PLANNEDVEC`
+     :meth:`SETTARGET(position)`          None                                  Set Trajectories target.
+     :attr:`HASTARGET`                    :struct:`Boolean` (readonly)          **(only TR 2.0.0 and up)** True if Trajectories target position has been set.
+     :attr:`GETTARGET`                    :struct:`GeoCoordinates` (readonly)   **(only TR 2.4.0 and up)** Returns a :struct:`GeoCoordinates` with the Trajectories target position.
+     :meth:`CLEARTARGET()`                None                                  **(only TR 2.4.0 and up)** Clear Trajectories target.
+     :attr:`CORRECTEDVEC`                 :struct:`Vector` (readonly)           Offset plus :attr:`PLANNEDVEC` to correct path for targeted impact.
+     :attr:`CORRECTEDVECTOR`              :struct:`Vector` (readonly)           Alias for :attr:`CORRECTEDVEC`
+    ==================================== ===================================== =============
 
 
 
@@ -89,7 +96,7 @@ Access structure TRAddon via ``ADDONS:TR``.
     :access: Get
 
     **Only gives the correct answer for Trajectries version >= 2.2.0**
-    
+
     *For earlier versions, it gives a hardcoded fixed answer, as follows:*
 
     - For any Trajectories version earlier than 2.0.0,
@@ -102,7 +109,7 @@ Access structure TRAddon via ``ADDONS:TR``.
 
     For cases where you need to check for a known minimum Trajectories
     version, it is probably better to use the specific boolean suffix
-    for that version (for example, :attr:`TRAddon:ISVERTWO`, or 
+    for that version (for example, :attr:`TRAddon:ISVERTWO`, or
     :attr:`TRAddon:ISVERTWOTWO`.)
 
 .. attribute:: TRAddon:ISVERTWO
@@ -119,6 +126,13 @@ Access structure TRAddon via ``ADDONS:TR``.
 
     True if the Trajectories mod is at least version 2.2.0 or above.
 
+.. attribute:: TRAddon:ISVERTWOFOUR
+
+    :type: :struct:`Boolean`
+    :access: Get
+
+    True if the Trajectories mod is at least version 2.4.0 or above.
+
 .. attribute:: TRAddon:HASIMPACT
 
     :type: :struct:`Boolean`
@@ -133,6 +147,123 @@ Access structure TRAddon via ``ADDONS:TR``.
 
     Estimated impact position.
 
+.. attribute:: TRAddon:TIMETILLIMPACT
+
+    :type: :struct:`Scalar`
+    :access: Get
+
+    **Did Not Exist in Trajectories before 2.2.0!**
+
+    *If :attr:`TRAddons:ISVERTWOTWO` is false, using this suffix will cause
+    a runtime error.*
+
+    Gives you Trajectories prediction of how many seconds until impact
+    on ground or water.
+
+.. method:: TRAddon:RESETDESCENTPROFILE(AoA)
+
+    :parameter AoA: :struct:`Scalar`
+    :return: None
+
+    **Did Not Exist in Trajectories before 2.4.0!**
+
+    *If :attr:`TRAddons:ISVERTWOFOUR` is false, using this suffix will cause
+    a runtime error.*
+
+    Resets all the Trajectories descent profile nodes to the passed AoA value (in Radians),
+    also sets Retrograde if AoA value is greater than ±90° (±PI/2) otherwise sets to Prograde.
+
+.. attribute:: TRAddon:DESCENTPROFILEANGLES
+
+    :type: :struct:`List<Scalar>`
+    :access: Get/Set
+
+    **Did Not Exist in Trajectories before 2.4.0!**
+
+    *If :attr:`TRAddons:ISVERTWOFOUR` is false, using this suffix will cause
+    a runtime error.*
+
+    Returns or sets all the Trajectories descent profile AoA values (in Radians),
+    also sets a node to Retrograde if it's passed AoA is greater than ±90° (±PI/2)
+    Note. also use with :attr:`TRAddons:DESCENTPROFILEGRADES` to set a nodes grade
+    if needed and passing AoA values as displayed in the gui with max ±90° (±PI/2).
+
+    List<Scalar>(atmospheric entry, high altitude, low altitude, final approach).
+
+.. attribute:: TRAddon:DESCENTPROFILEGRADES
+
+    :type: :struct:`List<Boolean>`
+    :access: Get/Set
+
+    **Did Not Exist in Trajectories before 2.4.0!**
+
+    *If :attr:`TRAddons:ISVERTWOFOUR` is false, using this suffix will cause
+    a runtime error.*
+
+    Returns or sets all the Trajectories descent profile grades,
+    True = Retrograde, False = Prograde.
+
+    List<Boolean>(atmospheric entry, high altitude, low altitude, final approach).
+
+.. attribute:: TRAddon:DESCENTPROFILEMODES
+
+    :type: :struct:`List<Boolean>`
+    :access: Get/Set
+
+    **Did Not Exist in Trajectories before 2.4.0!**
+
+    *If :attr:`TRAddons:ISVERTWOFOUR` is false, using this suffix will cause
+    a runtime error.*
+
+    Returns or sets all the Trajectories descent profile modes,
+    True = AoA, False = Horizon.
+
+    List<Boolean>(atmospheric entry, high altitude, low altitude, final approach).
+
+.. attribute:: TRAddon:PROGRADE
+
+    :type: :struct:`Boolean`
+    :access: Get/Set
+
+    **Did Not Exist in Trajectories before 2.2.0!**
+
+    *If :attr:`TRAddons:ISVERTWOTWO` is false, using this suffix will cause
+    a runtime error.*
+
+    For Trajectories 2.2.0 True if all the descent profile AoA values are 0°
+    For Trajectories 2.4.0 True if all the descent profile nodes are 'prograde'
+
+    You can set this to have the same effect as clicking on prograde mode
+    in the trajectories GUI. Setting this value to true causes
+    :attr:`TRAddon:RETROGRADE` to become false. (They cannot both be
+    true at the same time.)
+
+    Setting this causes all Trajectories descent profile nodes
+    to be set to 'prograde' mode if True or 'retrograde' mode if False.
+    Also resets all AoA values to 0°.
+
+.. attribute:: TRAddon:RETROGRADE
+
+    :type: :struct:`Boolean`
+    :access: Get/Set
+
+    **Did Not Exist in Trajectories before 2.2.0!**
+
+    *If :attr:`TRAddons:ISVERTWOTWO` is false, using this suffix will cause
+    a runtime error.*
+
+    For Trajectories 2.2.0 True if all the descent profile AoA values are 180°
+    For Trajectories 2.4.0 True if all the descent profile nodes are 'retrograde'
+
+    You can set this to have the same effect as clicking on retrograde mode
+    in the trajectories GUI. Setting this value to true causes
+    :attr:`TRAddon:PROGRADE` to become false. (They cannot both be
+    true at the same time.)
+
+    Setting this causes all Trajectories descent profile nodes
+    to be set to 'retrograde' mode if True or 'prograde' mode if False.
+    Also resets all AoA values to 0°.
+
 .. attribute:: TRAddon:PLANNEDVEC
 
     :type: :struct:`Vector`
@@ -140,7 +271,7 @@ Access structure TRAddon via ``ADDONS:TR``.
 
     Vector pointing the direction your vessel should face to follow the
     predicted trajectory, based on the angle of attack selected in the
-    Trajectories user interface.
+    Trajectories descent profile.
 
 .. attribute:: TRAddon:PLANNEDVECTOR
 
@@ -162,57 +293,36 @@ Access structure TRAddon via ``ADDONS:TR``.
     :access: Get
 
     **Did Not Exist in Trajectories before 2.0.0!**
-    
+
     *If :attr:`TRAddons:ISVERTWO` is false, using this suffix will cause
     a runtime error.*
 
-    The Trajectories Addon can be given a target position on the ground.
-    This is true if such a position is selected, or false if it is not.
+    The Trajectories Addon can be given a target position.
+    This is true if such a position is set, or false if it is not.
 
-.. attribute:: TRAddon:TIMETILLIMPACT
+.. attribute:: TRAddon:GETTARGET
 
-    :type: :struct:`Scalar`
+    :type: :struct:`GeoCoordinates`
     :access: Get
 
-    **Did Not Exist in Trajectories before 2.2.0!**
-    
-    *If :attr:`TRAddons:ISVERTWOTWO` is false, using this suffix will cause
+    **Did Not Exist in Trajectories before 2.4.0!**
+
+    *If :attr:`TRAddons:ISVERTWOFOUR` is false, using this suffix will cause
     a runtime error.*
 
-    Gives you Trajectories' prediction of how many seconds until impact
-    on ground or water.
+    Returns the Trajectories target position if one is set.
 
-.. attribute:: TRAddon:PROGRADE
+.. method:: TRAddon:CLEARTARGET()
 
-    :type: :struct:`Boolean`
-    :access: Get/Set
+    :parameter None
+    :return: None
 
-    **Did Not Exist in Trajectories before 2.2.0!**
-    
-    *If :attr:`TRAddons:ISVERTWOTWO` is false, using this suffix will cause
+    **Did Not Exist in Trajectories before 2.4.0!**
+
+    *If :attr:`TRAddons:ISVERTWOFOUR` is false, using this suffix will cause
     a runtime error.*
 
-    True if the Trajectories descent profile is set to 'prograde' mode.
-    You can set this to have the same effect as clicking on prograde mode
-    in the trajectories GUI.  Setting this value to true causes
-    :attr:`TRAddon:RETROGRADE` to become false.  (They cannot both be
-    true at the same time.)
-
-.. attribute:: TRAddon:RETROGRADE
-
-    :type: :struct:`Boolean`
-    :access: Get/Set
-
-    **Did Not Exist in Trajectories before 2.2.0!**
-    
-    *If :attr:`TRAddons:ISVERTWOTWO` is false, using this suffix will cause
-    a runtime error.*
-
-    True if the Trajectories descent profile is set to 'retrograde' mode.
-    You can set this to have the same effect as clicking on retrograde mode
-    in the trajectories GUI.  Setting this value to true causes
-    :attr:`TRAddon:PROGRADE` to become false.  (They cannot both be
-    true at the same time.)
+    Clears the Trajectories target position.
 
 .. attribute:: TRAddon:CORRECTEDVEC
 

--- a/src/kOS/AddOns/Trajectories/Addon.cs
+++ b/src/kOS/AddOns/Trajectories/Addon.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Exceptions;
@@ -26,8 +27,14 @@ namespace kOS.AddOns.TrajectoriesAddon
             AddSuffix("SETTARGET", new OneArgsSuffix<GeoCoordinates>(SetTarget, "Set CorrectedVect target."));
             AddSuffix("HASTARGET", new Suffix<BooleanValue>(HasTarget, "Check whether Trajectories has a target position set."));
             AddSuffix("TIMETILLIMPACT", new Suffix<ScalarValue>(TimeTillImpact, "Remaining time until Impact in seconds."));
-            AddSuffix("RETROGRADE", new SetSuffix<BooleanValue>(IsRetrograde, SetRetrograde, "Check the descent profile is Retrograde or Set the descent profile to Retrograde."));
-            AddSuffix("PROGRADE", new SetSuffix<BooleanValue>(IsPrograde, SetPrograde, "Check the descent profile is Prograde or Set the descent profile to Prograde."));
+            AddSuffix("RETROGRADE", new SetSuffix<BooleanValue>(IsRetrograde, SetRetrograde, "Check all the descent profile nodes are Retrograde or Reset all the descent profile nodes to Retrograde."));
+            AddSuffix("PROGRADE", new SetSuffix<BooleanValue>(IsPrograde, SetPrograde, "Check all the descent profile nodes are Prograde or Reset all the descent profile nodes to Prograde."));
+            AddSuffix("GETTARGET", new Suffix<GeoCoordinates>(GetTarget, "Get the currently set target position coordinates."));
+            AddSuffix("CLEARTARGET", new NoArgsVoidSuffix(ClearTarget, "Clear the current target."));
+            AddSuffix("RESETDESCENTPROFILE", new OneArgsSuffix<ScalarValue>(ResetDescentProfile, "Reset the descent profile to the passed AoA value in radians."));
+            AddSuffix("DESCENTPROFILEANGLES", new SetSuffix<ListValue<ScalarValue>>(GetProfileAngles, SetProfileAngles, "Descent profile angles in radians, also sets Retrograde if any values are greater than ±90°, List(entry, high altitude, low altitude, final approach)."));
+            AddSuffix("DESCENTPROFILEMODES", new SetSuffix<ListValue<BooleanValue>>(GetProfileModes, SetProfileModes, "Descent profile modes, true = AoA, false = Horizon, List(entry, high altitude, low altitude, final approach)."));
+            AddSuffix("DESCENTPROFILEGRADES", new SetSuffix<ListValue<BooleanValue>>(GetProfileGrades, SetProfileGrades, "Descent profile grades, true = Retrograde, false = Prograde, List(entry, high altitude, low altitude, final approach)."));
         }
 
         // Version checking suffixes.
@@ -189,10 +196,7 @@ namespace kOS.AddOns.TrajectoriesAddon
                 throw new KOSException("You may only call addons:TR:Prograde from the active vessel.");
             if (Available())
             {
-                if (value)
-                    TRWrapper.ProgradeEntry = true;
-                else
-                    TRWrapper.RetrogradeEntry = true;
+                TRWrapper.ProgradeEntry = value;
                 return;
             }
             throw new KOSUnavailableAddonException("PROGRADE", "Trajectories");
@@ -219,15 +223,186 @@ namespace kOS.AddOns.TrajectoriesAddon
                 throw new KOSException("You may only call addons:TR:Retrograde from the active vessel.");
             if (Available())
             {
-                if (value)
-                    TRWrapper.RetrogradeEntry = true;
-                else
-                    TRWrapper.ProgradeEntry = true;
+                TRWrapper.RetrogradeEntry = value;
                 return;
             }
             throw new KOSUnavailableAddonException("RETROGRADE", "Trajectories");
         }
 
+        // v2.4.0 and above suffixes.
+        private GeoCoordinates GetTarget()
+        {
+            if (shared.Vessel != FlightGlobals.ActiveVessel)
+                throw new KOSException("You may only call addons:TR:GetTarget from the active vessel and must also have a trajectories target set." +
+                    " Always check addons:tr:HasTarget");
+            if (Available())
+            {
+                Vector3d? result = TRWrapper.GetTarget();
+                if (result != null)
+                    return new GeoCoordinates(shared, result.Value.x, result.Value.y);
+
+                throw new KOSException("GetTarget is not available or no target is set. Remember to check addons:tr:HasTarget." +
+                    " Also GetTarget was added in Trajectories v2.4.0. and your version might be older." +
+                    " Check addons:tr:IsVerTwoFour or addons:tr:GetVersion");
+            }
+            throw new KOSUnavailableAddonException("GETTARGET", "Trajectories");
+        }
+
+        private void ClearTarget()
+        {
+            if (shared.Vessel != FlightGlobals.ActiveVessel)
+                throw new KOSException("You may only call addons:TR:ClearTarget from the active vessel.");
+            if (Available())
+            {
+                TRWrapper.ClearTarget();
+                return;
+            }
+            throw new KOSUnavailableAddonException("CLEARTARGET", "Trajectories");
+        }
+
+        private void ResetDescentProfile(ScalarValue aoa)
+        {
+            if (shared.Vessel != FlightGlobals.ActiveVessel)
+                throw new KOSException("You may only call addons:TR:ResetDescentProfile from the active vessel.");
+            if (Available())
+            {
+                TRWrapper.ResetDescentProfile(aoa);
+                return;
+            }
+            throw new KOSUnavailableAddonException("RESETDESCENTPROFILE", "Trajectories");
+        }
+
+        private ListValue<ScalarValue> GetProfileAngles()
+        {
+            if (shared.Vessel != FlightGlobals.ActiveVessel)
+                throw new KOSException("You may only call addons:TR:DescentProfileAngles from the active vessel.");
+            if (Available())
+            {
+                List<double> result = TRWrapper.DescentProfileAngles;
+                if (result != null && result.Count > 3)
+                {
+                    return new ListValue<ScalarValue>
+                    {
+                        result[0],    // atmospheric entry node
+                        result[1],    // high altitude node
+                        result[2],    // low altitude node
+                        result[3]     // final approach node
+                    };
+                }
+                throw new KOSException("DescentProfileAngles is not available. It was added in Trajectories v2.4.0. and your version might be older." +
+                    " Check addons:tr:IsVerTwoFour or addons:tr:GetVersion");
+            }
+            throw new KOSUnavailableAddonException("DESCENTPROFILEANGLES", "Trajectories");
+        }
+
+        private void SetProfileAngles(ListValue<ScalarValue> aoa)
+        {
+            if (shared.Vessel != FlightGlobals.ActiveVessel)
+                throw new KOSException("You may only call addons:TR:DescentProfileAngles from the active vessel.");
+            if (Available())
+            {
+                if (aoa != null && aoa.Count > 3)
+                {
+                    TRWrapper.DescentProfileAngles = new List<double>
+                    {
+                        aoa[0],    // atmospheric entry node
+                        aoa[1],    // high altitude node
+                        aoa[2],    // low altitude node
+                        aoa[3]     // final approach node
+                    };
+                }
+                throw new KOSException("DescentProfileAngles was passed an invalid list, make sure to have at least 4 values in the list.");
+            }
+            throw new KOSUnavailableAddonException("DESCENTPROFILEANGLES", "Trajectories");
+        }
+
+        private ListValue<BooleanValue> GetProfileModes()
+        {
+            if (shared.Vessel != FlightGlobals.ActiveVessel)
+                throw new KOSException("You may only call addons:TR:DescentProfileModes from the active vessel.");
+            if (Available())
+            {
+                List<bool> result = TRWrapper.DescentProfileModes;
+                if (result != null && result.Count > 3)
+                {
+                    return new ListValue<BooleanValue>
+                    {
+                        result[0],    // atmospheric entry node
+                        result[1],    // high altitude node
+                        result[2],    // low altitude node
+                        result[3]     // final approach node
+                    };
+                }
+                throw new KOSException("DescentProfileModes is not available. It was added in Trajectories v2.4.0. and your version might be older." +
+                    " Check addons:tr:IsVerTwoFour or addons:tr:GetVersion");
+            }
+            throw new KOSUnavailableAddonException("DESCENTPROFILEMODES", "Trajectories");
+        }
+
+        private void SetProfileModes(ListValue<BooleanValue> modes)
+        {
+            if (shared.Vessel != FlightGlobals.ActiveVessel)
+                throw new KOSException("You may only call addons:TR:DescentProfileModes from the active vessel.");
+            if (Available())
+            {
+                if (modes != null && modes.Count > 3)
+                {
+                    TRWrapper.DescentProfileModes = new List<bool>
+                    {
+                        modes[0],    // atmospheric entry node
+                        modes[1],    // high altitude node
+                        modes[2],    // low altitude node
+                        modes[3]     // final approach node
+                    };
+                }
+                throw new KOSException("DescentProfileModes was passed an invalid list, make sure to have at least 4 values in the list.");
+            }
+            throw new KOSUnavailableAddonException("DESCENTPROFILEMODES", "Trajectories");
+        }
+
+        private ListValue<BooleanValue> GetProfileGrades()
+        {
+            if (shared.Vessel != FlightGlobals.ActiveVessel)
+                throw new KOSException("You may only call addons:TR:DescentProfileGrades from the active vessel.");
+            if (Available())
+            {
+                List<bool> result = TRWrapper.DescentProfileGrades;
+                if (result != null && result.Count > 3)
+                {
+                    return new ListValue<BooleanValue>
+                    {
+                        result[0],    // atmospheric entry node
+                        result[1],    // high altitude node
+                        result[2],    // low altitude node
+                        result[3]     // final approach node
+                    };
+                }
+                throw new KOSException("DescentProfileGrades is not available. It was added in Trajectories v2.4.0. and your version might be older." +
+                    " Check addons:tr:IsVerTwoFour or addons:tr:GetVersion");
+            }
+            throw new KOSUnavailableAddonException("DESCENTPROFILEGRADES", "Trajectories");
+        }
+
+        private void SetProfileGrades(ListValue<BooleanValue> grades)
+        {
+            if (shared.Vessel != FlightGlobals.ActiveVessel)
+                throw new KOSException("You may only call addons:TR:DescentProfileGrades from the active vessel.");
+            if (Available())
+            {
+                if (grades != null && grades.Count > 3)
+                {
+                    TRWrapper.DescentProfileGrades = new List<bool>
+                    {
+                        grades[0],    // atmospheric entry node
+                        grades[1],    // high altitude node
+                        grades[2],    // low altitude node
+                        grades[3]     // final approach node
+                    };
+                }
+                throw new KOSException("DescentProfileGrades was passed an invalid list, make sure to have at least 4 values in the list.");
+            }
+            throw new KOSUnavailableAddonException("DESCENTPROFILEGRADES", "Trajectories");
+        }
 
         public override BooleanValue Available() => TRWrapper.Wrapped();
     }

--- a/src/kOS/AddOns/Trajectories/Addon.cs
+++ b/src/kOS/AddOns/Trajectories/Addon.cs
@@ -18,6 +18,7 @@ namespace kOS.AddOns.TrajectoriesAddon
             AddSuffix("GETVERSION", new Suffix<StringValue>(GetVersion, "Get version string (Major.Minor.Patch)."));
             AddSuffix("ISVERTWO", new Suffix<BooleanValue>(IsVerTwo, "Check whether Trajectories is v2.0.0 and above."));
             AddSuffix("ISVERTWOTWO", new Suffix<BooleanValue>(IsVerTwoTwo, "Check whether Trajectories is v2.2.0 and above."));
+            AddSuffix("ISVERTWOFOUR", new Suffix<BooleanValue>(IsVerTwoFour, "Check whether Trajectories is v2.4.0 and above."));
             AddSuffix("IMPACTPOS", new Suffix<GeoCoordinates>(ImpactPos, "Get impact position coordinates."));
             AddSuffix("HASIMPACT", new Suffix<BooleanValue>(HasImpact, "Check whether Trajectories has predicted an impact position for the current vessel."));
             AddSuffix(new string[] { "CORRECTEDVEC", "CORRECTEDVECTOR" }, new Suffix<Vector>(CorrectedVector, "Offset plus PlannedVect, somewhat corrected to glide ship towards target."));
@@ -49,6 +50,13 @@ namespace kOS.AddOns.TrajectoriesAddon
             if (Available())
                 return TRWrapper.IsVerTwoTwo;
             throw new KOSUnavailableAddonException("ISVERTWOTWO", "Trajectories");
+        }
+
+        private BooleanValue IsVerTwoFour()
+        {
+            if (Available())
+                return TRWrapper.IsVerTwoFour;
+            throw new KOSUnavailableAddonException("ISVERTWOFOUR", "Trajectories");
         }
 
         // Older suffixes.

--- a/src/kOS/AddOns/Trajectories/Addon.cs
+++ b/src/kOS/AddOns/Trajectories/Addon.cs
@@ -1,4 +1,4 @@
-﻿using kOS.Safe.Encapsulation;
+using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Exceptions;
 using kOS.Suffixed;
@@ -9,12 +9,9 @@ namespace kOS.AddOns.TrajectoriesAddon
 {
     [kOSAddon("TR")]
     [Safe.Utilities.KOSNomenclature("TRAddon")]
-    public class Addon: Suffixed.Addon
+    public class Addon : Suffixed.Addon
     {
-        public Addon(SharedObjects shared) : base(shared)
-        {
-            InitializeSuffixes();
-        }
+        public Addon(SharedObjects shared) : base(shared) => InitializeSuffixes();
 
         private void InitializeSuffixes()
         {
@@ -65,9 +62,9 @@ namespace kOS.AddOns.TrajectoriesAddon
                 Vector3? impactVect = TRWrapper.ImpactVector();
                 if (impactVect != null)
                 {
-                    var worldImpactPos = (Vector3d)impactVect + body.position;
-                    var lat = body.GetLatitude(worldImpactPos);
-                    var lng = Utils.DegreeFix(body.GetLongitude(worldImpactPos), -180);
+                    Vector3d worldImpactPos = (Vector3d)impactVect + body.position;
+                    double lat = body.GetLatitude(worldImpactPos);
+                    double lng = Utils.DegreeFix(body.GetLongitude(worldImpactPos), -180);
                     return new GeoCoordinates(shared, lat, lng);
                 }
                 throw new KOSException("Impact position is not available. Remember to check addons:tr:HasImpact");
@@ -224,9 +221,6 @@ namespace kOS.AddOns.TrajectoriesAddon
         }
 
 
-        public override BooleanValue Available()
-        {
-            return TRWrapper.Wrapped();
-        }
+        public override BooleanValue Available() => TRWrapper.Wrapped();
     }
 }

--- a/src/kOS/AddOns/Trajectories/Addon.cs
+++ b/src/kOS/AddOns/Trajectories/Addon.cs
@@ -34,8 +34,8 @@ namespace kOS.AddOns.TrajectoriesAddon
             AddSuffix("PROGRADE", new SetSuffix<BooleanValue>(IsPrograde, SetPrograde, "Check all the descent profile nodes are Prograde or Reset all the descent profile nodes to Prograde."));
             AddSuffix("GETTARGET", new Suffix<GeoCoordinates>(GetTarget, "Get the currently set target position coordinates."));
             AddSuffix("CLEARTARGET", new NoArgsVoidSuffix(ClearTarget, "Clear the current target."));
-            AddSuffix("RESETDESCENTPROFILE", new OneArgsSuffix<ScalarValue>(ResetDescentProfile, "Reset the descent profile to the passed AoA value in radians."));
-            AddSuffix("DESCENTANGLES", new SetSuffix<ListValue>(GetProfileAngles, SetProfileAngles, "Descent profile angles in radians, also sets Retrograde if any values are greater than ±90°, List(entry, high altitude, low altitude, final approach)."));
+            AddSuffix("RESETDESCENTPROFILE", new OneArgsSuffix<ScalarValue>(ResetDescentProfile, "Reset the descent profile to the passed AoA value in degrees."));
+            AddSuffix("DESCENTANGLES", new SetSuffix<ListValue>(GetProfileAngles, SetProfileAngles, "Descent profile angles in degrees, also sets Retrograde if any values are greater than ±90°, List(entry, high altitude, low altitude, final approach)."));
             AddSuffix("DESCENTMODES", new SetSuffix<ListValue>(GetProfileModes, SetProfileModes, "Descent profile modes, true = AoA, false = Horizon, List(entry, high altitude, low altitude, final approach)."));
             AddSuffix("DESCENTGRADES", new SetSuffix<ListValue>(GetProfileGrades, SetProfileGrades, "Descent profile grades, true = Retrograde, false = Prograde, List(entry, high altitude, low altitude, final approach)."));
         }
@@ -290,7 +290,7 @@ namespace kOS.AddOns.TrajectoriesAddon
                 throw new KOSException("You may only call addons:tr:RESETDESCENTPROFILE from the active vessel.");
             if (Available())
             {
-                TRWrapper.ResetDescentProfile(aoa);
+                TRWrapper.ResetDescentProfile(aoa * Mathf.Deg2Rad);
                 return;
             }
             throw new KOSUnavailableAddonException("RESETDESCENTPROFILE", "Trajectories");
@@ -307,10 +307,10 @@ namespace kOS.AddOns.TrajectoriesAddon
                 {
                     return new ListValue
                     {
-                        (ScalarValue)result[0],    // atmospheric entry node
-                        (ScalarValue)result[1],    // high altitude node
-                        (ScalarValue)result[2],    // low altitude node
-                        (ScalarValue)result[3]     // final approach node
+                        (ScalarValue)result[0] * Mathf.Rad2Deg,    // atmospheric entry node
+                        (ScalarValue)result[1] * Mathf.Rad2Deg,    // high altitude node
+                        (ScalarValue)result[2] * Mathf.Rad2Deg,    // low altitude node
+                        (ScalarValue)result[3] * Mathf.Rad2Deg     // final approach node
                     };
                 }
                 throw new KOSException("DESCENTANGLES is not available. It was added in Trajectories v2.4.0. and your version might be older." +
@@ -336,10 +336,10 @@ namespace kOS.AddOns.TrajectoriesAddon
 
                     TRWrapper.DescentProfileAngles = new List<double>
                     {
-                        (ScalarValue)aoa[0],    // atmospheric entry node
-                        (ScalarValue)aoa[1],    // high altitude node
-                        (ScalarValue)aoa[2],    // low altitude node
-                        (ScalarValue)aoa[3]     // final approach node
+                        ((ScalarValue)aoa[0]) * Mathf.Deg2Rad,    // atmospheric entry node
+                        ((ScalarValue)aoa[1]) * Mathf.Deg2Rad,    // high altitude node
+                        ((ScalarValue)aoa[2]) * Mathf.Deg2Rad,    // low altitude node
+                        ((ScalarValue)aoa[3]) * Mathf.Deg2Rad     // final approach node
                     };
                     return;
                 }

--- a/src/kOS/AddOns/Trajectories/Addon.cs
+++ b/src/kOS/AddOns/Trajectories/Addon.cs
@@ -310,6 +310,7 @@ namespace kOS.AddOns.TrajectoriesAddon
                         aoa[2],    // low altitude node
                         aoa[3]     // final approach node
                     };
+                    return;
                 }
                 throw new KOSException("DescentProfileAngles was passed an invalid list, make sure to have at least 4 values in the list.");
             }
@@ -354,6 +355,7 @@ namespace kOS.AddOns.TrajectoriesAddon
                         modes[2],    // low altitude node
                         modes[3]     // final approach node
                     };
+                    return;
                 }
                 throw new KOSException("DescentProfileModes was passed an invalid list, make sure to have at least 4 values in the list.");
             }
@@ -398,6 +400,7 @@ namespace kOS.AddOns.TrajectoriesAddon
                         grades[2],    // low altitude node
                         grades[3]     // final approach node
                     };
+                    return;
                 }
                 throw new KOSException("DescentProfileGrades was passed an invalid list, make sure to have at least 4 values in the list.");
             }

--- a/src/kOS/AddOns/Trajectories/Addon.cs
+++ b/src/kOS/AddOns/Trajectories/Addon.cs
@@ -32,9 +32,9 @@ namespace kOS.AddOns.TrajectoriesAddon
             AddSuffix("GETTARGET", new Suffix<GeoCoordinates>(GetTarget, "Get the currently set target position coordinates."));
             AddSuffix("CLEARTARGET", new NoArgsVoidSuffix(ClearTarget, "Clear the current target."));
             AddSuffix("RESETDESCENTPROFILE", new OneArgsSuffix<ScalarValue>(ResetDescentProfile, "Reset the descent profile to the passed AoA value in radians."));
-            AddSuffix("DESCENTPROFILEANGLES", new SetSuffix<ListValue<ScalarValue>>(GetProfileAngles, SetProfileAngles, "Descent profile angles in radians, also sets Retrograde if any values are greater than ±90°, List(entry, high altitude, low altitude, final approach)."));
-            AddSuffix("DESCENTPROFILEMODES", new SetSuffix<ListValue<BooleanValue>>(GetProfileModes, SetProfileModes, "Descent profile modes, true = AoA, false = Horizon, List(entry, high altitude, low altitude, final approach)."));
-            AddSuffix("DESCENTPROFILEGRADES", new SetSuffix<ListValue<BooleanValue>>(GetProfileGrades, SetProfileGrades, "Descent profile grades, true = Retrograde, false = Prograde, List(entry, high altitude, low altitude, final approach)."));
+            AddSuffix("DESCENTANGLES", new SetSuffix<ListValue>(GetProfileAngles, SetProfileAngles, "Descent profile angles in radians, also sets Retrograde if any values are greater than ±90°, List(entry, high altitude, low altitude, final approach)."));
+            AddSuffix("DESCENTMODES", new SetSuffix<ListValue>(GetProfileModes, SetProfileModes, "Descent profile modes, true = AoA, false = Horizon, List(entry, high altitude, low altitude, final approach)."));
+            AddSuffix("DESCENTGRADES", new SetSuffix<ListValue>(GetProfileGrades, SetProfileGrades, "Descent profile grades, true = Retrograde, false = Prograde, List(entry, high altitude, low altitude, final approach)."));
         }
 
         // Version checking suffixes.
@@ -272,139 +272,160 @@ namespace kOS.AddOns.TrajectoriesAddon
             throw new KOSUnavailableAddonException("RESETDESCENTPROFILE", "Trajectories");
         }
 
-        private ListValue<ScalarValue> GetProfileAngles()
+        private ListValue GetProfileAngles()
         {
             if (shared.Vessel != FlightGlobals.ActiveVessel)
-                throw new KOSException("You may only call addons:TR:DescentProfileAngles from the active vessel.");
+                throw new KOSException("You may only call addons:tr:DESCENTANGLES from the active vessel.");
             if (Available())
             {
                 List<double> result = TRWrapper.DescentProfileAngles;
                 if (result != null && result.Count > 3)
                 {
-                    return new ListValue<ScalarValue>
+                    return new ListValue
                     {
-                        result[0],    // atmospheric entry node
-                        result[1],    // high altitude node
-                        result[2],    // low altitude node
-                        result[3]     // final approach node
+                        (ScalarValue)result[0],    // atmospheric entry node
+                        (ScalarValue)result[1],    // high altitude node
+                        (ScalarValue)result[2],    // low altitude node
+                        (ScalarValue)result[3]     // final approach node
                     };
                 }
-                throw new KOSException("DescentProfileAngles is not available. It was added in Trajectories v2.4.0. and your version might be older." +
-                    " Check addons:tr:IsVerTwoFour or addons:tr:GetVersion");
+                throw new KOSException("DESCENTANGLES is not available. It was added in Trajectories v2.4.0. and your version might be older." +
+                    " Check addons:tr:ISVERTWOFOUR or addons:tr:GETVERSION");
             }
-            throw new KOSUnavailableAddonException("DESCENTPROFILEANGLES", "Trajectories");
+            throw new KOSUnavailableAddonException("DESCENTANGLES", "Trajectories");
         }
 
-        private void SetProfileAngles(ListValue<ScalarValue> aoa)
+        private void SetProfileAngles(ListValue aoa)
         {
             if (shared.Vessel != FlightGlobals.ActiveVessel)
-                throw new KOSException("You may only call addons:TR:DescentProfileAngles from the active vessel.");
+                throw new KOSException("You may only call addons:tr:DESCENTANGLES from the active vessel.");
             if (Available())
             {
                 if (aoa != null && aoa.Count > 3)
                 {
+                    // check for correct types
+                    foreach (Structure item in aoa)
+                    {
+                        if (!(item.GetType() == typeof(ScalarIntValue) || item.GetType() == typeof(ScalarDoubleValue)))
+                            throw new KOSException("DESCENTANGLES was passed an invalid type in its list, it requires a list of ScalarValues.");
+                    }
+
                     TRWrapper.DescentProfileAngles = new List<double>
                     {
-                        aoa[0],    // atmospheric entry node
-                        aoa[1],    // high altitude node
-                        aoa[2],    // low altitude node
-                        aoa[3]     // final approach node
+                        (ScalarValue)aoa[0],    // atmospheric entry node
+                        (ScalarValue)aoa[1],    // high altitude node
+                        (ScalarValue)aoa[2],    // low altitude node
+                        (ScalarValue)aoa[3]     // final approach node
                     };
                     return;
                 }
-                throw new KOSException("DescentProfileAngles was passed an invalid list, make sure to have at least 4 values in the list.");
+                throw new KOSException("DESCENTANGLES was passed an invalid list, make sure to have at least 4 items in the list.");
             }
-            throw new KOSUnavailableAddonException("DESCENTPROFILEANGLES", "Trajectories");
+            throw new KOSUnavailableAddonException("DESCENTANGLES", "Trajectories");
         }
 
-        private ListValue<BooleanValue> GetProfileModes()
+        private ListValue GetProfileModes()
         {
             if (shared.Vessel != FlightGlobals.ActiveVessel)
-                throw new KOSException("You may only call addons:TR:DescentProfileModes from the active vessel.");
+                throw new KOSException("You may only call addons:tr:DESCENTMODES from the active vessel.");
             if (Available())
             {
                 List<bool> result = TRWrapper.DescentProfileModes;
                 if (result != null && result.Count > 3)
                 {
-                    return new ListValue<BooleanValue>
+                    return new ListValue
                     {
-                        result[0],    // atmospheric entry node
-                        result[1],    // high altitude node
-                        result[2],    // low altitude node
-                        result[3]     // final approach node
+                        (BooleanValue)result[0],    // atmospheric entry node
+                        (BooleanValue)result[1],    // high altitude node
+                        (BooleanValue)result[2],    // low altitude node
+                        (BooleanValue)result[3]     // final approach node
                     };
                 }
-                throw new KOSException("DescentProfileModes is not available. It was added in Trajectories v2.4.0. and your version might be older." +
-                    " Check addons:tr:IsVerTwoFour or addons:tr:GetVersion");
+                throw new KOSException("DESCENTMODES is not available. It was added in Trajectories v2.4.0. and your version might be older." +
+                    " Check addons:tr:IsVerTwoFour or addons:tr:GETVERSION");
             }
-            throw new KOSUnavailableAddonException("DESCENTPROFILEMODES", "Trajectories");
+            throw new KOSUnavailableAddonException("DESCENTMODES", "Trajectories");
         }
 
-        private void SetProfileModes(ListValue<BooleanValue> modes)
+        private void SetProfileModes(ListValue modes)
         {
             if (shared.Vessel != FlightGlobals.ActiveVessel)
-                throw new KOSException("You may only call addons:TR:DescentProfileModes from the active vessel.");
+                throw new KOSException("You may only call addons:tr:DESCENTMODES from the active vessel.");
             if (Available())
             {
                 if (modes != null && modes.Count > 3)
                 {
+                    // check for correct types
+                    foreach (Structure item in modes)
+                    {
+                        if (item.GetType() != typeof(BooleanValue))
+                            throw new KOSException("DESCENTMODES was passed an invalid type in its list, it requires a list of BooleanValues.");
+                    }
+
                     TRWrapper.DescentProfileModes = new List<bool>
                     {
-                        modes[0],    // atmospheric entry node
-                        modes[1],    // high altitude node
-                        modes[2],    // low altitude node
-                        modes[3]     // final approach node
+                        (BooleanValue)modes[0],    // atmospheric entry node
+                        (BooleanValue)modes[1],    // high altitude node
+                        (BooleanValue)modes[2],    // low altitude node
+                        (BooleanValue)modes[3]     // final approach node
                     };
                     return;
                 }
-                throw new KOSException("DescentProfileModes was passed an invalid list, make sure to have at least 4 values in the list.");
+                throw new KOSException("DESCENTMODES was passed an invalid list, make sure to have at least 4 items in the list.");
             }
-            throw new KOSUnavailableAddonException("DESCENTPROFILEMODES", "Trajectories");
+            throw new KOSUnavailableAddonException("DESCENTMODES", "Trajectories");
         }
 
-        private ListValue<BooleanValue> GetProfileGrades()
+        private ListValue GetProfileGrades()
         {
             if (shared.Vessel != FlightGlobals.ActiveVessel)
-                throw new KOSException("You may only call addons:TR:DescentProfileGrades from the active vessel.");
+                throw new KOSException("You may only call addons:tr:DESCENTGRADES from the active vessel.");
             if (Available())
             {
                 List<bool> result = TRWrapper.DescentProfileGrades;
                 if (result != null && result.Count > 3)
                 {
-                    return new ListValue<BooleanValue>
+                    return new ListValue
                     {
-                        result[0],    // atmospheric entry node
-                        result[1],    // high altitude node
-                        result[2],    // low altitude node
-                        result[3]     // final approach node
+                        (BooleanValue)result[0],    // atmospheric entry node
+                        (BooleanValue)result[1],    // high altitude node
+                        (BooleanValue)result[2],    // low altitude node
+                        (BooleanValue)result[3]     // final approach node
                     };
                 }
-                throw new KOSException("DescentProfileGrades is not available. It was added in Trajectories v2.4.0. and your version might be older." +
-                    " Check addons:tr:IsVerTwoFour or addons:tr:GetVersion");
+                throw new KOSException("DESCENTGRADES is not available. It was added in Trajectories v2.4.0. and your version might be older." +
+                    " Check addons:tr:ISVERTWOFOUR or addons:tr:GETVERSION");
             }
-            throw new KOSUnavailableAddonException("DESCENTPROFILEGRADES", "Trajectories");
+            throw new KOSUnavailableAddonException("DESCENTGRADES", "Trajectories");
         }
 
-        private void SetProfileGrades(ListValue<BooleanValue> grades)
+        private void SetProfileGrades(ListValue grades)
         {
             if (shared.Vessel != FlightGlobals.ActiveVessel)
-                throw new KOSException("You may only call addons:TR:DescentProfileGrades from the active vessel.");
+                throw new KOSException("You may only call addons:tr:DESCENTGRADES from the active vessel.");
             if (Available())
             {
                 if (grades != null && grades.Count > 3)
                 {
+                    // check for correct types
+                    foreach (Structure item in grades)
+                    {
+                        if (item.GetType() != typeof(BooleanValue))
+                            throw new KOSException("DESCENTGRADES was passed an invalid type in its list, it requires a list of BooleanValues.");
+                    }
+
                     TRWrapper.DescentProfileGrades = new List<bool>
                     {
-                        grades[0],    // atmospheric entry node
-                        grades[1],    // high altitude node
-                        grades[2],    // low altitude node
-                        grades[3]     // final approach node
+                        (BooleanValue)grades[0],    // atmospheric entry node
+                        (BooleanValue)grades[1],    // high altitude node
+                        (BooleanValue)grades[2],    // low altitude node
+                        (BooleanValue)grades[3]     // final approach node
                     };
                     return;
                 }
-                throw new KOSException("DescentProfileGrades was passed an invalid list, make sure to have at least 4 values in the list.");
+                throw new KOSException("DESCENTGRADES was passed an invalid list, make sure to have at least 4 items in the list.");
             }
-            throw new KOSUnavailableAddonException("DESCENTPROFILEGRADES", "Trajectories");
+            throw new KOSUnavailableAddonException("DESCENTGRADES", "Trajectories");
         }
 
         public override BooleanValue Available() => TRWrapper.Wrapped();

--- a/src/kOS/AddOns/Trajectories/Addon.cs
+++ b/src/kOS/AddOns/Trajectories/Addon.cs
@@ -70,7 +70,7 @@ namespace kOS.AddOns.TrajectoriesAddon
         private GeoCoordinates ImpactPos()
         {
             if (shared.Vessel != FlightGlobals.ActiveVessel)
-                throw new KOSException("You may only call addons:TR:ImpactPos from the active vessel. Always check addons:tr:HasImpact");
+                throw new KOSException("You may only call addons:tr:IMPACTPOS from the active vessel. Always check addons:tr:HASIMPACT");
             if (Available())
             {
                 CelestialBody body = shared.Vessel.orbit.referenceBody;
@@ -82,7 +82,7 @@ namespace kOS.AddOns.TrajectoriesAddon
                     double lng = Utils.DegreeFix(body.GetLongitude(worldImpactPos), -180);
                     return new GeoCoordinates(shared, lat, lng);
                 }
-                throw new KOSException("Impact position is not available. Remember to check addons:tr:HasImpact");
+                throw new KOSException("IMPACTPOS is not available. Remember to check addons:tr:HASIMPACT");
             }
             throw new KOSUnavailableAddonException("IMPACTPOS", "Trajectories");
         }
@@ -97,8 +97,8 @@ namespace kOS.AddOns.TrajectoriesAddon
         private Vector CorrectedVector()
         {
             if (shared.Vessel != FlightGlobals.ActiveVessel)
-                throw new KOSException("You may only call addons:TR:CorrectedVect from the active vessel and must also have a trajectories target set." +
-                    " Always check addons:tr:HasImpact and addons:tr:HasTarget");
+                throw new KOSException("You may only call addons:tr:CORRECTEDVECT from the active vessel and must also have a trajectories target set." +
+                    " Always check addons:tr:HASIMPACT and addons:tr:HASTARGET");
             if (Available())
             {
                 Vector3? vect = TRWrapper.CorrectedDirection();
@@ -107,16 +107,16 @@ namespace kOS.AddOns.TrajectoriesAddon
                     Vector3 vector = (Vector3)vect;
                     return new Vector(vector.x, vector.y, vector.z);
                 }
-                throw new KOSException("Corrected Vector is not available. Remember to check addons:tr:HasImpact and addons:tr:HasTarget");
+                throw new KOSException("CORRECTEDVECT is not available. Remember to check addons:tr:HASIMPACT and addons:tr:HASTARGET");
             }
-            throw new KOSUnavailableAddonException("CORRECTEDDIRECTION", "Trajectories");
+            throw new KOSUnavailableAddonException("CORRECTEDVECT", "Trajectories");
         }
 
         private Vector PlannedVector()
         {
             if (shared.Vessel != FlightGlobals.ActiveVessel)
-                throw new KOSException("You may only call addons:TR:plannedVect from the active vessel and must also have a trajectories target set." +
-                    " Always check addons:tr:HasImpact and addons:tr:HasTarget");
+                throw new KOSException("You may only call addons:tr:PLANNEDVECT from the active vessel and must also have a trajectories target set." +
+                    " Always check addons:tr:HASIMPACT and addons:tr:HASTARGET");
             if (Available())
             {
                 Vector3? vect = TRWrapper.PlannedDirection();
@@ -125,15 +125,15 @@ namespace kOS.AddOns.TrajectoriesAddon
                     Vector3 vector = (Vector3)vect;
                     return new Vector(vector.x, vector.y, vector.z);
                 }
-                throw new KOSException("Planned Vector is not available. Remember to check addons:tr:HasImpact and addons:tr:HasTarget");
+                throw new KOSException("PLANNEDVECT is not available. Remember to check addons:tr:HASIMPACT and addons:tr:HASTARGET");
             }
-            throw new KOSUnavailableAddonException("PLANNEDDIRECTION", "Trajectories");
+            throw new KOSUnavailableAddonException("PLANNEDVECT", "Trajectories");
         }
 
         private void SetTarget(GeoCoordinates target)
         {
             if (shared.Vessel != FlightGlobals.ActiveVessel)
-                throw new KOSException("You may only call addons:TR:SetTarget from the active vessel.");
+                throw new KOSException("You may only call addons:tr:SETTARGET from the active vessel.");
             if (Available())
             {
                 TRWrapper.SetTarget(target.Latitude, target.Longitude, target.GetTerrainAltitude());
@@ -146,14 +146,14 @@ namespace kOS.AddOns.TrajectoriesAddon
         private BooleanValue HasTarget()
         {
             if (shared.Vessel != FlightGlobals.ActiveVessel)
-                throw new KOSException("You may only call addons:TR:HasTarget from the active vessel.");
+                throw new KOSException("You may only call addons:tr:HASTARGET from the active vessel.");
             if (Available())
             {
                 bool? result = TRWrapper.HasTarget();
                 if (result != null)
                     return result;
-                throw new KOSException("HasTarget is not available. It was added in Trajectories v2.0.0. and your version might be older." +
-                    " Check addons:tr:IsVerTwo or addons:tr:GetVersion");
+                throw new KOSException("HASTARGET is not available. It was added in Trajectories v2.0.0. and your version might be older." +
+                    " Check addons:tr:ISVERTWO or addons:tr:GETVERSION");
             }
             throw new KOSUnavailableAddonException("HASTARGET", "Trajectories");
         }
@@ -162,15 +162,15 @@ namespace kOS.AddOns.TrajectoriesAddon
         private ScalarValue TimeTillImpact()
         {
             if (shared.Vessel != FlightGlobals.ActiveVessel)
-                throw new KOSException("You may only call addons:TR:TimeTillImpact from the active vessel.");
+                throw new KOSException("You may only call addons:tr:TIMETILLIMPACT from the active vessel.");
             if (Available())
             {
                 double? result = TRWrapper.GetTimeTillImpact();
                 if (result != null)
                     return result;
-                throw new KOSException("TimeTillImpact is not available. Remember to check addons:tr:HasImpact." +
-                    " Also TimeTillImpact was added in Trajectories v2.2.0. and your version might be older." +
-                    " Check addons:tr:IsVerTwoTwo or addons:tr:GetVersion");
+                throw new KOSException("TIMETILLIMPACT is not available. Remember to check addons:tr:HASIMPACT." +
+                    " Also TIMETILLIMPACT was added in Trajectories v2.2.0. and your version might be older." +
+                    " Check addons:tr:ISVERTWOTWO or addons:tr:GETVERSION");
             }
             throw new KOSUnavailableAddonException("TIMETILLIMPACT", "Trajectories");
         }
@@ -178,14 +178,14 @@ namespace kOS.AddOns.TrajectoriesAddon
         private BooleanValue IsPrograde()
         {
             if (shared.Vessel != FlightGlobals.ActiveVessel)
-                throw new KOSException("You may only call addons:TR:Prograde from the active vessel.");
+                throw new KOSException("You may only call addons:tr:PROGRADE from the active vessel.");
             if (Available())
             {
                 bool? result = TRWrapper.ProgradeEntry;
                 if (result != null)
                     return result;
-                throw new KOSException("Prograde is not available. It was added in Trajectories v2.2.0. and your version might be older." +
-                    " Check addons:tr:IsVerTwoTwo or addons:tr:GetVersion");
+                throw new KOSException("PROGRADE is not available. It was added in Trajectories v2.2.0. and your version might be older." +
+                    " Check addons:tr:ISVERTWOTWO or addons:tr:GETVERSION");
             }
             throw new KOSUnavailableAddonException("PROGRADE", "Trajectories");
         }
@@ -193,7 +193,7 @@ namespace kOS.AddOns.TrajectoriesAddon
         private void SetPrograde(BooleanValue value)
         {
             if (shared.Vessel != FlightGlobals.ActiveVessel)
-                throw new KOSException("You may only call addons:TR:Prograde from the active vessel.");
+                throw new KOSException("You may only call addons:tr:PROGRADE from the active vessel.");
             if (Available())
             {
                 TRWrapper.ProgradeEntry = value;
@@ -205,14 +205,14 @@ namespace kOS.AddOns.TrajectoriesAddon
         private BooleanValue IsRetrograde()
         {
             if (shared.Vessel != FlightGlobals.ActiveVessel)
-                throw new KOSException("You may only call addons:TR:Retrograde from the active vessel.");
+                throw new KOSException("You may only call addons:tr:RETROGRADE from the active vessel.");
             if (Available())
             {
                 bool? result = TRWrapper.RetrogradeEntry;
                 if (result != null)
                     return result;
-                throw new KOSException("Retrograde is not available. It was added in Trajectories v2.2.0. and your version might be older." +
-                    " Check addons:tr:IsVerTwoTwo or addons:tr:GetVersion");
+                throw new KOSException("RETROGRADE is not available. It was added in Trajectories v2.2.0. and your version might be older." +
+                    " Check addons:tr:ISVERTWOTWO or addons:tr:GETVERSION");
             }
             throw new KOSUnavailableAddonException("RETROGRADE", "Trajectories");
         }
@@ -220,7 +220,7 @@ namespace kOS.AddOns.TrajectoriesAddon
         private void SetRetrograde(BooleanValue value)
         {
             if (shared.Vessel != FlightGlobals.ActiveVessel)
-                throw new KOSException("You may only call addons:TR:Retrograde from the active vessel.");
+                throw new KOSException("You may only call addons:tr:RETROGRADE from the active vessel.");
             if (Available())
             {
                 TRWrapper.RetrogradeEntry = value;
@@ -233,17 +233,17 @@ namespace kOS.AddOns.TrajectoriesAddon
         private GeoCoordinates GetTarget()
         {
             if (shared.Vessel != FlightGlobals.ActiveVessel)
-                throw new KOSException("You may only call addons:TR:GetTarget from the active vessel and must also have a trajectories target set." +
-                    " Always check addons:tr:HasTarget");
+                throw new KOSException("You may only call addons:tr:GETTARGET from the active vessel and must also have a trajectories target set." +
+                    " Always check addons:tr:HASTARGET");
             if (Available())
             {
                 Vector3d? result = TRWrapper.GetTarget();
                 if (result != null)
                     return new GeoCoordinates(shared, result.Value.x, result.Value.y);
 
-                throw new KOSException("GetTarget is not available or no target is set. Remember to check addons:tr:HasTarget." +
-                    " Also GetTarget was added in Trajectories v2.4.0. and your version might be older." +
-                    " Check addons:tr:IsVerTwoFour or addons:tr:GetVersion");
+                throw new KOSException("GETTARGET is not available or no target is set. Remember to check addons:tr:HASTARGET." +
+                    " Also GETTARGET was added in Trajectories v2.4.0. and your version might be older." +
+                    " Check addons:tr:ISVERTWOFOUR or addons:tr:GETVERSION");
             }
             throw new KOSUnavailableAddonException("GETTARGET", "Trajectories");
         }
@@ -251,7 +251,7 @@ namespace kOS.AddOns.TrajectoriesAddon
         private void ClearTarget()
         {
             if (shared.Vessel != FlightGlobals.ActiveVessel)
-                throw new KOSException("You may only call addons:TR:ClearTarget from the active vessel.");
+                throw new KOSException("You may only call addons:tr:CLEARTARGET from the active vessel.");
             if (Available())
             {
                 TRWrapper.ClearTarget();
@@ -263,7 +263,7 @@ namespace kOS.AddOns.TrajectoriesAddon
         private void ResetDescentProfile(ScalarValue aoa)
         {
             if (shared.Vessel != FlightGlobals.ActiveVessel)
-                throw new KOSException("You may only call addons:TR:ResetDescentProfile from the active vessel.");
+                throw new KOSException("You may only call addons:tr:RESETDESCENTPROFILE from the active vessel.");
             if (Available())
             {
                 TRWrapper.ResetDescentProfile(aoa);

--- a/src/kOS/AddOns/Trajectories/Addon.cs
+++ b/src/kOS/AddOns/Trajectories/Addon.cs
@@ -17,6 +17,9 @@ namespace kOS.AddOns.TrajectoriesAddon
         private void InitializeSuffixes()
         {
             AddSuffix("GETVERSION", new Suffix<StringValue>(GetVersion, "Get version string (Major.Minor.Patch)."));
+            AddSuffix("GETVERSIONMAJOR", new Suffix<ScalarValue>(GetVersionMajor, "Get version Major."));
+            AddSuffix("GETVERSIONMINOR", new Suffix<ScalarValue>(GetVersionMinor, "Get version Minor."));
+            AddSuffix("GETVERSIONPATCH", new Suffix<ScalarValue>(GetVersionPatch, "Get version Patch."));
             AddSuffix("ISVERTWO", new Suffix<BooleanValue>(IsVerTwo, "Check whether Trajectories is v2.0.0 and above."));
             AddSuffix("ISVERTWOTWO", new Suffix<BooleanValue>(IsVerTwoTwo, "Check whether Trajectories is v2.2.0 and above."));
             AddSuffix("ISVERTWOFOUR", new Suffix<BooleanValue>(IsVerTwoFour, "Check whether Trajectories is v2.4.0 and above."));
@@ -43,6 +46,27 @@ namespace kOS.AddOns.TrajectoriesAddon
             if (Available())
                 return TRWrapper.GetVersion;
             throw new KOSUnavailableAddonException("GETVERSION", "Trajectories");
+        }
+
+        private ScalarValue GetVersionMajor()
+        {
+            if (Available())
+                return TRWrapper.GetVersionMajor;
+            throw new KOSUnavailableAddonException("GETVERSIONMAJOR", "Trajectories");
+        }
+
+        private ScalarValue GetVersionMinor()
+        {
+            if (Available())
+                return TRWrapper.GetVersionMinor;
+            throw new KOSUnavailableAddonException("GETVERSIONMINOR", "Trajectories");
+        }
+
+        private ScalarValue GetVersionPatch()
+        {
+            if (Available())
+                return TRWrapper.GetVersionPatch;
+            throw new KOSUnavailableAddonException("GETVERSIONPATCH", "Trajectories");
         }
 
         private BooleanValue IsVerTwo()

--- a/src/kOS/AddOns/Trajectories/TRWrapper.cs
+++ b/src/kOS/AddOns/Trajectories/TRWrapper.cs
@@ -55,6 +55,9 @@ namespace kOS.AddOns.TrajectoriesAddon
                 if (trajectoriesAPIType.GetMethod("HasTarget") == null) // assume pre v2.0.0 (Old API)
                 {
                     GetVersion = "";
+                    GetVersionMajor = 0;
+                    GetVersionMinor = 0;
+                    GetVersionPatch = 0;
                     IsVerTwo = false;
                     IsVerTwoTwo = false;
                     IsVerTwoFour = false;
@@ -63,6 +66,9 @@ namespace kOS.AddOns.TrajectoriesAddon
                 else // assume v2.0.0 and v2.1.0 (API is identical in these versions)
                 {
                     GetVersion = "2.0.0";
+                    GetVersionMajor = 2;
+                    GetVersionMinor = 0;
+                    GetVersionPatch = 0;
                     IsVerTwo = true;
                     IsVerTwoTwo = false;
                     IsVerTwoFour = false;
@@ -73,6 +79,9 @@ namespace kOS.AddOns.TrajectoriesAddon
             {
                 GetVersion = (string)trajectoriesAPIType.GetProperty("GetVersion").GetValue(null, null);
                 Version version = new Version(GetVersion);
+                GetVersionMajor = version.Major;
+                GetVersionMinor = version.Minor;
+                GetVersionPatch = version.Build;
                 IsVerTwo = true;
                 IsVerTwoTwo = true;
                 // check for major versions above v2
@@ -222,6 +231,9 @@ namespace kOS.AddOns.TrajectoriesAddon
 
         // Version checking properties
         public static string GetVersion { get; private set; }
+        public static int GetVersionMajor { get; private set; }
+        public static int GetVersionMinor { get; private set; }
+        public static int GetVersionPatch { get; private set; }
         public static bool IsVerTwo { get; private set; }
         public static bool IsVerTwoTwo { get; private set; }
         public static bool IsVerTwoFour { get; private set; }

--- a/src/kOS/AddOns/Trajectories/TRWrapper.cs
+++ b/src/kOS/AddOns/Trajectories/TRWrapper.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 namespace kOS.AddOns.TrajectoriesAddon
 {
-    public class TRWrapper
+    public static class TRWrapper
     {
         private static bool? wrapped = null;
         private static Type trajectoriesAPIType = null;
@@ -37,7 +37,6 @@ namespace kOS.AddOns.TrajectoriesAddon
             });
             return type;
         }
-
 
         private static void Init()
         {

--- a/src/kOS/AddOns/Trajectories/TRWrapper.cs
+++ b/src/kOS/AddOns/Trajectories/TRWrapper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using kOS.Safe.Encapsulation;
 using kOS.Safe.Utilities;
@@ -16,9 +17,15 @@ namespace kOS.AddOns.TrajectoriesAddon
         private static MethodInfo trPlannedDirection = null;
         private static MethodInfo trHasTarget = null;
         private static MethodInfo trSetTarget = null;
+        private static MethodInfo trGetTarget = null;
+        private static MethodInfo trClearTarget = null;
+        private static MethodInfo trResetDescentProfile = null;
         private static PropertyInfo trAlwaysUpdate = null;
         private static PropertyInfo trProgradeEntry = null;
         private static PropertyInfo trRetrogradeEntry = null;
+        private static PropertyInfo trDescentProfileAngles = null;
+        private static PropertyInfo trDescentProfileModes = null;
+        private static PropertyInfo trDescentProfileGrades = null;
 
         private static Type GetType(string name)
         {
@@ -114,6 +121,7 @@ namespace kOS.AddOns.TrajectoriesAddon
             trAlwaysUpdate = trajectoriesAPIType.GetProperty("AlwaysUpdate") ?? trajectoriesAPIType.GetProperty("alwaysUpdate");
             if (trAlwaysUpdate == null)
             {
+                SafeHouse.Logger.Log("Trajectories.API.AlwaysUpdate property is null.");
                 wrapped = false;
                 return;
             }
@@ -128,7 +136,6 @@ namespace kOS.AddOns.TrajectoriesAddon
             // Trajectories v2.0.0 HasTarget method
             if (IsVerTwo)
             {
-                // HasTarget is avalable in Trajectories v2.0.0 and above
                 trHasTarget = trajectoriesAPIType.GetMethod("HasTarget");
                 if (trHasTarget == null)
                 {
@@ -141,7 +148,6 @@ namespace kOS.AddOns.TrajectoriesAddon
             // Trajectories v2.2.0 and above methods and properties
             if (IsVerTwoTwo)
             {
-                // GetTimeTillImpact is avalable in Trajectories v2.2.0 and above
                 trGetTimeTillImpact = trajectoriesAPIType.GetMethod("GetTimeTillImpact");
                 if (trGetTimeTillImpact == null)
                 {
@@ -152,12 +158,61 @@ namespace kOS.AddOns.TrajectoriesAddon
                 trProgradeEntry = trajectoriesAPIType.GetProperty("ProgradeEntry");
                 if (trProgradeEntry == null)
                 {
+                    SafeHouse.Logger.Log("Trajectories.API.ProgradeEntry property is null");
                     wrapped = false;
                     return;
                 }
                 trRetrogradeEntry = trajectoriesAPIType.GetProperty("RetrogradeEntry");
                 if (trRetrogradeEntry == null)
                 {
+                    SafeHouse.Logger.Log("Trajectories.API.RetrogradeEntry property is null");
+                    wrapped = false;
+                    return;
+                }
+            }
+
+            // Trajectories v2.4.0 and above methods and properties
+            if (IsVerTwoFour)
+            {
+                trGetTarget = trajectoriesAPIType.GetMethod("GetTarget");
+                if (trGetTarget == null)
+                {
+                    SafeHouse.Logger.Log("Trajectories.API.GetTarget method is null");
+                    wrapped = false;
+                    return;
+                }
+                trClearTarget = trajectoriesAPIType.GetMethod("ClearTarget");
+                if (trClearTarget == null)
+                {
+                    SafeHouse.Logger.Log("Trajectories.API.ClearTarget method is null");
+                    wrapped = false;
+                    return;
+                }
+                trResetDescentProfile = trajectoriesAPIType.GetMethod("ResetDescentProfile");
+                if (trResetDescentProfile == null)
+                {
+                    SafeHouse.Logger.Log("Trajectories.API.ResetDescentProfile method is null");
+                    wrapped = false;
+                    return;
+                }
+                trDescentProfileAngles = trajectoriesAPIType.GetProperty("DescentProfileAngles");
+                if (trDescentProfileAngles == null)
+                {
+                    SafeHouse.Logger.Log("Trajectories.API.DescentProfileAngles property is null");
+                    wrapped = false;
+                    return;
+                }
+                trDescentProfileModes = trajectoriesAPIType.GetProperty("DescentProfileModes");
+                if (trDescentProfileModes == null)
+                {
+                    SafeHouse.Logger.Log("Trajectories.API.DescentProfileModes property is null");
+                    wrapped = false;
+                    return;
+                }
+                trDescentProfileGrades = trajectoriesAPIType.GetProperty("DescentProfileGrades");
+                if (trDescentProfileGrades == null)
+                {
+                    SafeHouse.Logger.Log("Trajectories.API.DescentProfileGrades property is null");
                     wrapped = false;
                     return;
                 }
@@ -224,6 +279,73 @@ namespace kOS.AddOns.TrajectoriesAddon
             {
                 if (trRetrogradeEntry != null) // will be null if TR version too low.
                     trRetrogradeEntry.SetValue(null, true, null);
+            }
+        }
+
+        // Trajectories v2.4.0 and above methods and properties
+        public static Vector3d? GetTarget()
+        {
+            if (trGetTarget == null)
+                return null;
+            return (Vector3d?)trGetTarget.Invoke(null, new object[] { });
+        }
+
+        public static void ClearTarget()
+        {
+            if (trClearTarget == null)
+                return;
+            trClearTarget.Invoke(null, new object[] { });
+        }
+
+        public static void ResetDescentProfile(double AoA)
+        {
+            if (trResetDescentProfile == null)
+                return;
+            trResetDescentProfile.Invoke(null, new object[] { AoA });
+        }
+
+        public static List<double> DescentProfileAngles
+        {
+            get
+            {
+                if (trDescentProfileAngles == null)
+                    return null;
+                return (List<double>)trDescentProfileAngles.GetValue(null, null);
+            }
+            set
+            {
+                if (trDescentProfileAngles != null)
+                    trDescentProfileAngles.SetValue(null, value, null);
+            }
+        }
+
+        public static List<bool> DescentProfileModes
+        {
+            get
+            {
+                if (trDescentProfileModes == null)
+                    return null;
+                return (List<bool>)trDescentProfileModes.GetValue(null, null);
+            }
+            set
+            {
+                if (trDescentProfileModes != null)
+                    trDescentProfileModes.SetValue(null, value, null);
+            }
+        }
+
+        public static List<bool> DescentProfileGrades
+        {
+            get
+            {
+                if (trDescentProfileGrades == null)
+                    return null;
+                return (List<bool>)trDescentProfileGrades.GetValue(null, null);
+            }
+            set
+            {
+                if (trDescentProfileGrades != null)
+                    trDescentProfileGrades.SetValue(null, value, null);
             }
         }
 

--- a/src/kOS/AddOns/Trajectories/TRWrapper.cs
+++ b/src/kOS/AddOns/Trajectories/TRWrapper.cs
@@ -32,7 +32,7 @@ namespace kOS.AddOns.TrajectoriesAddon
         }
 
 
-        private static void init()
+        private static void Init()
         {
             SafeHouse.Logger.Log("Attempting to Grab Trajectories Assembly...");
             trajectoriesAPIType = GetType("Trajectories.API");
@@ -51,6 +51,7 @@ namespace kOS.AddOns.TrajectoriesAddon
                     GetVersion = "";
                     IsVerTwo = false;
                     IsVerTwoTwo = false;
+                    IsVerTwoFour = false;
                     SafeHouse.Logger.Log("Checking Trajectories version: API.HasTarget method is null. Assuming version is pre 2.0.0");
                 }
                 else // assume v2.0.0 and v2.1.0 (API is identical in these versions)
@@ -58,14 +59,21 @@ namespace kOS.AddOns.TrajectoriesAddon
                     GetVersion = "2.0.0";
                     IsVerTwo = true;
                     IsVerTwoTwo = false;
+                    IsVerTwoFour = false;
                     SafeHouse.Logger.Log("Checking Trajectories version: API.GetVersion method is null. Assuming version is pre 2.2.0");
                 }
             }
             else // assume v2.2.0 and above (New API)
             {
                 GetVersion = (string)trajectoriesAPIType.GetProperty("GetVersion").GetValue(null, null);
+                Version version = new Version(GetVersion);
                 IsVerTwo = true;
                 IsVerTwoTwo = true;
+                // check for major versions above v2
+                if (version.Major > 2)
+                    IsVerTwoFour = true;
+                else
+                    IsVerTwoFour = (version.Major == 2 && version.Minor >= 4);
                 SafeHouse.Logger.Log("Checking Trajectories version: API.GetVersion returned version: v" + GetVersion);
             }
 
@@ -162,6 +170,7 @@ namespace kOS.AddOns.TrajectoriesAddon
         public static string GetVersion { get; private set; }
         public static bool IsVerTwo { get; private set; }
         public static bool IsVerTwoTwo { get; private set; }
+        public static bool IsVerTwoFour { get; private set; }
 
         // Standard methods
         public static Vector3? ImpactVector() => (Vector3?)trGetImpactPosition.Invoke(null, new object[] { });
@@ -226,7 +235,7 @@ namespace kOS.AddOns.TrajectoriesAddon
             }
             else //if wrapped == null
             {
-                init();
+                Init();
                 return wrapped;
             }
         }

--- a/src/kOS/AddOns/Trajectories/TRWrapper.cs
+++ b/src/kOS/AddOns/Trajectories/TRWrapper.cs
@@ -263,7 +263,7 @@ namespace kOS.AddOns.TrajectoriesAddon
             set
             {
                 if (trProgradeEntry != null) // will be null if TR version too low.
-                    trProgradeEntry.SetValue(null, true, null);
+                    trProgradeEntry.SetValue(null, value, null);
             }
         }
 
@@ -278,7 +278,7 @@ namespace kOS.AddOns.TrajectoriesAddon
             set
             {
                 if (trRetrogradeEntry != null) // will be null if TR version too low.
-                    trRetrogradeEntry.SetValue(null, true, null);
+                    trRetrogradeEntry.SetValue(null, value, null);
             }
         }
 

--- a/src/kOS/AddOns/Trajectories/TRWrapper.cs
+++ b/src/kOS/AddOns/Trajectories/TRWrapper.cs
@@ -1,7 +1,7 @@
-﻿using kOS.Safe.Encapsulation;
-using kOS.Safe.Utilities;
 using System;
 using System.Reflection;
+using kOS.Safe.Encapsulation;
+using kOS.Safe.Utilities;
 using UnityEngine;
 
 namespace kOS.AddOns.TrajectoriesAddon
@@ -43,7 +43,7 @@ namespace kOS.AddOns.TrajectoriesAddon
                 return;
             }
 
-            // Trajectories v2.2.0 API Has version properties. Checking versions here.
+            // Trajectories v2.2.0+ API Has version properties. Checking versions here.
             if (trajectoriesAPIType.GetProperty("GetVersion") == null)
             {
                 if (trajectoriesAPIType.GetMethod("HasTarget") == null) // assume pre v2.0.0 (Old API)
@@ -159,33 +159,18 @@ namespace kOS.AddOns.TrajectoriesAddon
         }
 
         // Version checking properties
-        public static string getVersion = "";
-        public static string GetVersion { get { return getVersion; } private set {getVersion = value;} }
-        public static bool isVerTwo = false;
-        public static bool IsVerTwo { get { return isVerTwo; } private set { isVerTwo = value; } }
-        public static bool isVerTwoTwo = false;
-        public static bool IsVerTwoTwo { get { return isVerTwoTwo; }  private set { isVerTwoTwo = value; } }
+        public static string GetVersion { get; private set; }
+        public static bool IsVerTwo { get; private set; }
+        public static bool IsVerTwoTwo { get; private set; }
 
         // Standard methods
-        public static Vector3? ImpactVector()
-        {
-            return (Vector3?)trGetImpactPosition.Invoke(null, new object[] { });
-        }
+        public static Vector3? ImpactVector() => (Vector3?)trGetImpactPosition.Invoke(null, new object[] { });
 
-        public static Vector3? CorrectedDirection()
-        {
-            return (Vector3?)trCorrectedDirection.Invoke(null, new object[] { });
-        }
+        public static Vector3? CorrectedDirection() => (Vector3?)trCorrectedDirection.Invoke(null, new object[] { });
 
-        public static Vector3? PlannedDirection()
-        {
-            return (Vector3?)trPlannedDirection.Invoke(null, new object[] { });
-        }
+        public static Vector3? PlannedDirection() => (Vector3?)trPlannedDirection.Invoke(null, new object[] { });
 
-        public static void SetTarget(double lat, double lon, double alt)
-        {
-            trSetTarget.Invoke(null, new object[] { lat, lon, alt });
-        }
+        public static void SetTarget(double lat, double lon, double alt) => trSetTarget.Invoke(null, new object[] { lat, lon, alt });
 
         // Trajectories v2.0.0 HasTarget method
         public static bool? HasTarget()


### PR DESCRIPTION
An update to the addons for Trajectories, bringing in support for new API functionality in Trajectories v2.4.0.

See Issue #2263 - A few missing features for Trajectories Addon.

New Suffix's have been added as follows:

`IsVerTwoFour()` returns true if the installed version of Trajectories is >= 2.4.0
`GetVersionMajor, GetVersionMinor, GetVersionPatch` return version information.
`GetTarget()` returns the `GeoCoordinates` of the set target.
`ClearTarget()` clears the target.
`ResetDescentProfile(ScalarValue aoa)` resets all descent profile nodes to the passed angle (in degrees).
`DescentAngles` returns or sets all the angles of the descent profile nodes via a list of values (in degrees).
`DescentModes` returns or sets all the modes of the descent profile nodes via a list of booleans.
`DescentGrades` returns or sets all the grades of the descent profile nodes via a list of booleans.

Documentation has also been updated to include the new changes.
