### PR TITLE
Force all input through buffer unless flushing buffer.

### DIFF
--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -325,8 +325,6 @@ namespace kOS.Screen
 
             GetFontIfChanged(true);
 
-            ProcessUnconsumedInput();
-
             if (isLocked) ProcessKeyEvents();
             if (FlightResultsDialog.isDisplaying) return;
             if (uiGloballyHidden)
@@ -362,6 +360,7 @@ namespace kOS.Screen
             GetNewestBuffer();
             TelnetOutputUpdate();
             ProcessTelnetInput(); // want to do this even when the terminal isn't actually displaying.
+            ProcessUnconsumedInput(); // Moved here from OnGUI because it needs to run even when the GUI terminal is closed.
             if (telnetsGotRepainted)
             {
                 // Move the beeps from the screenbuffer "queue" to my own local terminal "queue".

--- a/src/kOS/Sound/SoundMaker.cs
+++ b/src/kOS/Sound/SoundMaker.cs
@@ -103,7 +103,6 @@ namespace kOS.Sound
             AudioClip clip = fileGetter.GetAudioClip();
             AudioSource source = soundObject.AddComponent<AudioSource>();
             source.clip = clip;
-            Console.Out.WriteLine("eraseme: PROOF I AM NEW!.  LOADFILESOUND!!");
             source.spatialBlend = 0; // Makes it ignore spatial position for calculating sound.
             sounds[name] = source;
         }


### PR DESCRIPTION
Fixes #2753 (I hope - I can't test it because I couldn't cause the bug in the first place - I need @JonnyOThan to test it for me.)

Now the only input that is allowed to immediately get
sent to the interpreter is that which came FROM the
buffer flusher routine ProcessUnconsmedInput().  It
uses flags that allow its input to come through
directly, but *everything else* that types input is
now required to queue it (so it will pass through
ProcessUnconsumedInput() a moment later).  Hypothetically
this should fix the ability for input to skip the buffer
and jump in line.

The one exception is the immediate characters related
to terminal closing or program interruption like CTRL-C.
They are allowed to jump in out of order and happen immediately.
And in the case of CTRL-C, it also flushes whatever was in the
buffer so if you typed anything ahead it will no longer
get executed after a CTRL-C like it used to.