### PR TITLE
Fixes #2235 by changing the name to match the meaning.

### DIFF
--- a/doc/source/structures/volumes_and_files/volumedirectory.rst
+++ b/doc/source/structures/volumes_and_files/volumedirectory.rst
@@ -21,14 +21,35 @@ Instances of this class are enumerable, every step of iteration will provide a :
           -
           - :struct:`VolumeDirectory` objects are a type of :struct:`VolumeItem`
 
-        * - :meth:`LIST`
-          - :struct:`List` of :struct:`VolumeFile` or :struct:`VolumeDirectory`
+        * - :meth:`LEXICON`
+          - :struct:`LEXICON` of :struct:`VolumeFile` or :struct:`VolumeDirectory`
           - Lists all files and directories
 
+        * - :meth:`LEX`
+          - :struct:`LEXICON` of :struct:`VolumeFile` or :struct:`VolumeDirectory`
+          - Alias for :meth:`LEXICON`
+
+        * - :meth:`LIST`
+          - :struct:`LEXICON` of :struct:`VolumeFile` or :struct:`VolumeDirectory`
+          - Alias for :meth:`LEXICON`
+
+
+.. method:: VolumeDirectory:LEXICON
+
+    :return: :struct:`Lexicon` of :struct:`VolumeFile` or :struct:`VolumeDirectory`
+
+    Returns a Lexicon of all files and directories in this director,
+    with each pair in the Lexcion having the string name of the file or directorry
+    as the key, and the :struct:`VolumeFile` or :struct:`VolumeDirectory` itself
+    as the value.
+
+.. method:: VolumeDirectory:LEX
+
+    An alias for :meth:`LEXICON`.
 
 .. method:: VolumeDirectory:LIST
 
-    :return: :struct:`List` of :struct:`VolumeFile` or :struct:`VolumeDirectory`
-
-    Returns a list of all files and directories in this directory.
-
+    An alias for :meth:`LEXICON`. It's slightly wrong that a method called "List"
+    returns a Lexicon instead of a List, but it has been that way long enough that
+    now for backward compatibility, the name "List" had to remain as an alias
+    for this method.

--- a/src/kOS.Safe/Persistence/VolumeDirectory.cs
+++ b/src/kOS.Safe/Persistence/VolumeDirectory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using kOS.Safe.Persistence;
 using System.Collections.Generic;
 using kOS.Safe.Encapsulation;
@@ -42,7 +42,7 @@ namespace kOS.Safe
         private void InitializeSuffixes()
         {
             AddSuffix("ITERATOR", new NoArgsSuffix<Enumerator>(() => new Enumerator(GetEnumerator())));
-            AddSuffix("LIST", new Suffix<Lexicon>(ListAsLexicon));
+            AddSuffix(new string[] { "LIST","LEXICON","LEX"}, new Suffix<Lexicon>(ListAsLexicon));
         }
     }
 }


### PR DESCRIPTION
Fixes #2235 by changing the suffix name to match the meaning,
but an alias using the old name remains so old code will still work too.