### PR TITLE
Fixes #2764 - Prevents duplicate KOSNameTag.

### DIFF
--- a/Resources/GameData/kOS/kOS-module-manager.cfg
+++ b/Resources/GameData/kOS/kOS-module-manager.cfg
@@ -1,7 +1,47 @@
-@PART[*]:FOR[kOS]
+//
+// ADD the KOSNameTag to all parts in the game.
+//
+//    THE FOLLOWING EXPLANATION IS FOR ISSUE #2764
+//
+// The "[!KOSNameTag]" rule below attempted to prevent duplicates
+// in a part, but it doesn't entirely succeed at that in the
+// case of KerbalEVA parts if the installation has all the DLCs,
+// due to a wacky messy way SQUAD implemented the alternate
+// kerbal types (with or without vintage suits, with or without
+// the ability to plant ground science, etc).  SQUAD implements
+// them as entirely different kerbal parts, then smashes their
+// definitions together later after Modulemanager is done.
+// ModuleManager is helpless to notice the duplication that will
+// cause because they were two *different* parts when it was looking
+// at them.
+//
+// Therefore there is extra code inside kOS's C# code to additionally
+// enforce the "no more than one KOSNameTag" rule, in its OnAwake().
+// You *cannot* force more than one KOSNameTag to exist in a part
+// no matter what you do in ModuleManager now, because KOSNameTag
+// itself refuses to allow it.
+//
+@PART[*]:FOR[kOS]:HAS[!KOSNameTag]
 {
 	MODULE
 	{
 		name = KOSNameTag
 	}
 }
+
+//
+// The following is commented out because it was an alternate possible
+// fix to #2764 that @Poodmund worked on for me, and even though I'm not
+// going with it, it's saved here for reference to look at later should
+// we change our mind and want to go to this instead:
+//
+// (In a nutshell, this removes the extra KOSNameTag PartModules from
+// those specfic part definitions in the known specific DLC folders
+// that trigger this exact problem, rather than creating a generic
+// solution that says "there can be only one, ever"):
+//
+// @PART[kerbalEV*]:HAS[~name[*Future],@MODULE[ModuleScienceExperiment]:HAS[#experimentID[ROCScience]]]:AFTER[kOS]
+// {
+//    !MODULE[KOSNameTag]{}
+// }
+//


### PR DESCRIPTION
Fixes #2764 

Note, the problem wasn't that ModuleManager was wrong,
but that SQUAD does something really wacky with the
KerbalEVA parts to handle having part variants
for DLC (i.e. if you have Breaking Ground, kerbals
have an additional science module for ground deployment.)

To make this work, SQUAD set it up to *pretend* DLC Eva kerbal
is a totally different part from stock EVA kerbal - a part that
only contains the DLC info.  Then at a late stage (after
MM has done its work), SQUAD melts these two different
EVA kerbal parts together into one, which is where the
duplicates came from.

Since kOS can't really handle two name tags on one part anyway
(maybe that could be another PR another day to support that),
the fix was to make KOSNameTag refuse to duplicate itself into
a part by actively deleting other copies of itself when it's
being inserted into a part in OnAwake().