### PR TITLE
Fixes #2648 - pretty straightforward.

### DIFF
--- a/doc/source/bindings.rst
+++ b/doc/source/bindings.rst
@@ -220,16 +220,18 @@ Further details are found on the `ALT page <structures/vessels/alt.html>`__ .
 ETA ALIAS
 ---------
 
-The special variable `ETA <structures/vessels/eta.html>`__ gives you
+The special variable :ref:`ETA <eta>` gives you
 access to a few time predictions:
 
 ETA:APOAPSIS
 
 ETA:PERIAPSIS
 
+ETA:NEXTNODE
+
 ETA:TRANSITION
 
-Further details are found on the `ETA page <structures/vessels/eta.html>`__ .
+Further details are found on the :ref:`ETA page <eta>`.
 
 ENCOUNTER
 ---------

--- a/doc/source/structures/orbits/eta.rst
+++ b/doc/source/structures/orbits/eta.rst
@@ -40,6 +40,10 @@ on an Orbit, and can be obtained one of two ways:
           - :ref:`scalar <scalar>`, seconds
           - Seconds from now until periapsis.
 
+        * - :attr:`NEXTNODE`
+          - :ref:`scalar <scalar>`, seconds
+          - Seconds from now until the next maneuver node.
+
         * - :attr:`TRANSITION`
           - :ref:`scalar <scalar>`, seconds
           - Seconds from now until the next orbit patch starts.
@@ -92,6 +96,23 @@ on an Orbit, and can be obtained one of two ways:
     to represent infinity, it will instead count time "backward" and show
     you a negative number, for how many seconds it's been since periapsis.
 
+.. attribute:: ETA:NEXTNODE
+
+    :type: :ref:`scalar <scalar>`, seconds
+    :access: Get only
+
+    Seconds until the next manuever node's timestamp.  NOTE this is the
+    time shown on the navball for the maneuver node, and does not
+    take into account the lead time shown on the navball.
+    
+    This should give the exact same value as ``NEXTNODE:ETA`` with one
+    important difference:  ``NEXTNODE:ETA`` will throw an error if
+    there is no next node, while this (``ETA:NEXTNODE``) will simply
+    return a **very big number** representing the biggest floating
+    point value (32-bit).  (For various reasons, kOS does not allow
+    the value "Infinity" in its Scalars, so "a really big number"
+    is used in its place.)
+
 .. attribute:: ETA:TRANSITION
 
     :type: :ref:`scalar <scalar>`, seconds
@@ -101,4 +122,11 @@ on an Orbit, and can be obtained one of two ways:
     This ignores the effect of any intervening manuever nodes it might
     hit before it gets there. (This will be the path you would follow
     if you never execute any of those manuever nodes.)
+
+    If there *is* no next transition (you are on a closed loop that
+    will not exit the current sphere of influence), this will
+    return a **very big number** representing the biggest floating
+    point value (32-bit).  (For various reasons, kOS does not allow
+    the value "Infinity" in its Scalars, so "a really big number"
+    is used in its place.)
 

--- a/src/kOS/Suffixed/OrbitEta.cs
+++ b/src/kOS/Suffixed/OrbitEta.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Utilities;
@@ -23,6 +24,7 @@ namespace kOS.Suffixed
             AddSuffix("APOAPSIS", new NoArgsSuffix<ScalarValue>(GetApoapsis));
             AddSuffix("PERIAPSIS", new NoArgsSuffix<ScalarValue>(GetPeriapsis));
             AddSuffix("TRANSITION", new NoArgsSuffix<ScalarValue>(GetEndTransition));
+            AddSuffix("NEXTNODE", new NoArgsSuffix<ScalarValue>(GetNextNode));
         }
 
         public ScalarValue GetApoapsis()
@@ -34,6 +36,16 @@ namespace kOS.Suffixed
         public ScalarValue GetPeriapsis()
         {
             return ObTToETA(0, Planetarium.GetUniversalTime());
+        }
+
+        public ScalarValue GetNextNode()
+        {
+            var vessel = shared.Vessel;
+            if (vessel.patchedConicSolver == null || vessel.patchedConicSolver.maneuverNodes.Count == 0)
+                return float.MaxValue;
+            if (vessel.patchedConicSolver.maneuverNodes.Count == 0)
+                return float.MaxValue;
+            return vessel.patchedConicSolver.maneuverNodes[0].UT - Planetarium.GetUniversalTime();
         }
 
         private BooleanValue IsClosedOrbit()


### PR DESCRIPTION
Also includes making the bignum return value of ETA:TRANSITION
explicitly documented (it was always that way, but the
documentation failed to mention it).