### PR TITLE
Fixes #2688 with just a warning message

### DIFF
--- a/src/kOS/Control/IFlightControlParameter.cs
+++ b/src/kOS/Control/IFlightControlParameter.cs
@@ -9,6 +9,14 @@ namespace kOS.Control
     {
         bool Enabled { get; }
         bool IsAutopilot { get; }
+
+        /// <summary>
+        /// If this FlightControlParameter tends to fight with SAS, then it should
+        /// have this be true so kOS knows to check for that condition when this
+        /// control is active.
+        /// </summary>
+        bool FightsWithSas { get; }
+
         uint ControlPartId { get; }
         void UpdateValue(object value, SharedObjects shared);
         object GetValue();

--- a/src/kOS/Control/SteeringManager.cs
+++ b/src/kOS/Control/SteeringManager.cs
@@ -42,6 +42,8 @@ namespace kOS.Control
             destination.YawTorqueFactor = origin.YawTorqueFactor;
         }
 
+        public bool FightsWithSas { get { return true; } }
+
         private Vessel internalVessel;
 
         public Vessel Vessel

--- a/src/kOS/Control/ThrottleManager.cs
+++ b/src/kOS/Control/ThrottleManager.cs
@@ -14,6 +14,8 @@ namespace kOS.Control
         public bool Enabled { get; private set; }
         public double Value { get; set; }
 
+        public bool FightsWithSas { get { return false; } }
+
         public ThrottleManager(Vessel vessel)
         {
             Enabled = false;

--- a/src/kOS/Control/WheelSteeringManager.cs
+++ b/src/kOS/Control/WheelSteeringManager.cs
@@ -17,6 +17,8 @@ namespace kOS.Control
         public bool Enabled { get; private set; }
         public float Value { get; set; }
 
+        public bool FightsWithSas { get { return false; } }
+
         public WheelSteeringManager(Vessel vessel)
         {
             Enabled = false;

--- a/src/kOS/Control/WheelThrottleManager.cs
+++ b/src/kOS/Control/WheelThrottleManager.cs
@@ -14,6 +14,8 @@ namespace kOS.Control
         public bool Enabled { get; private set; }
         public double Value { get; set; }
 
+        public bool FightsWithSas { get { return false; } }
+
         public WheelThrottleManager(Vessel vessel)
         {
             Enabled = false;

--- a/src/kOS/Module/kOSVesselModule.cs
+++ b/src/kOS/Module/kOSVesselModule.cs
@@ -403,6 +403,7 @@ namespace kOS.Module
 
             // Default it to false until it gets turned on below:
             Screen.KOSToolbarWindow.ShowSuppressMessage = false;
+            Screen.KOSToolbarWindow.ShowSasMessage = false;
 
             if (Vessel != null)
             {
@@ -429,6 +430,9 @@ namespace kOS.Module
                             else
                             {
                                 parameter.UpdateAutopilot(c);
+
+                                if (parameter.FightsWithSas && vessel.ActionGroups[KSPActionGroup.SAS])
+                                    Screen.KOSToolbarWindow.ShowSasMessage = true;
                             }
                         }
                     }

--- a/src/kOS/Screen/KOSToolbarWindow.cs
+++ b/src/kOS/Screen/KOSToolbarWindow.cs
@@ -97,6 +97,15 @@ namespace kOS.Screen
         /// <summary>If true then the 'suppressing autopilot' message should be getting repeated to the screen right now.</summary>
         public static bool ShowSuppressMessage { get; set; }
 
+        /// <summary>Timestamp (using Unity3d's Time.time) for when the SAS message cooldown is over and a new message should be emitted.</summary>
+        private static float sasMessageCooldownEnd = 0;
+        /// <summary>Tracks a small window of time in which the message won't appear if the problem is fixed before then.</summary>
+        private static float sasMessageGracePeriodEnd = 0;
+        private static string sasMessageText = "kOS: SAS and lock steering fight. Please turn one of them off.";
+        private static ScreenMessage sasMessage;
+        /// <summary>If true then the 'SAS conflict' message should be getting repeated to the screen right now.</summary>
+        public static bool ShowSasMessage { get; set; }
+
         /// <summary>
         /// Unity hates it when a MonoBehaviour has a constructor,
         /// so all the construction work is here instead:
@@ -166,6 +175,30 @@ namespace kOS.Screen
                 {
                     // Get it to stop right away even if the timer isn't over:
                     suppressMessage.duration = 0;
+                }
+            }
+
+            // Handle the message and timeout of the message
+            if (ShowSasMessage)
+            {
+                if (Time.time > sasMessageCooldownEnd && Time.time > sasMessageGracePeriodEnd)
+                {
+                    sasMessageCooldownEnd = Time.time + 5f;
+                    sasMessage = ScreenMessages.PostScreenMessage(
+                        string.Format("<color=white><size=20>{0}</size></color>", sasMessageText),
+                        4, ScreenMessageStyle.UPPER_CENTER);
+                }
+            }
+            else
+            {
+                sasMessageCooldownEnd = 0f;
+                // If ShowSasMessage becomes true, this will be left as
+                // whatever 1 second past the last time it was false was:
+                sasMessageGracePeriodEnd = Time.time + 1f;
+                if (sasMessage != null)
+                {
+                    // Get it to stop right away even if the timer isn't over:
+                    sasMessage.duration = 0;
                 }
             }
 

--- a/src/kOS/Suffixed/FlightControl.cs
+++ b/src/kOS/Suffixed/FlightControl.cs
@@ -51,6 +51,8 @@ namespace kOS.Suffixed
 
         public Vessel Vessel { get; private set; }
 
+        public bool FightsWithSas { get { return false; } }
+
         public override bool SetSuffix(string suffixName, object value, bool failOkay = false)
         {
             float floatValue = 0;


### PR DESCRIPTION
Issue #2688 had some back and forth discussion about whether to actually PREVENT using SAS and lock steering, or to merely warn about it, or both.

In the end I decided to merely warn about it with a screen message.

Also, the message has a grace period so it won't appear until both lock steering and SAS have been on for more than 1 second.