### PR TITLE
Fixes #2782 by moving msg hooks around.

### DIFF
--- a/src/kOS/Module/kOSVesselModule.cs
+++ b/src/kOS/Module/kOSVesselModule.cs
@@ -312,6 +312,8 @@ namespace kOS.Module
                 TimingManager.FixedUpdateRemove(TimingManager.TimingStage.BetterLateThanNever, resetControllable);
                 workAroundEventsEnabled = false;
             }
+            AutopilotMsgManager.Instance.TurnOffSuppressMessage(this);
+            AutopilotMsgManager.Instance.TurnOffSasMessage(this);
         }
 
         #region Hack to fix "Require Signal for Control"
@@ -394,6 +396,7 @@ namespace kOS.Module
         /// <param name="c"></param>
         private void UpdateAutopilot(FlightCtrlState c)
         {
+            Console.WriteLine("eraseme: kOSVesselModule.Update() is Calling UpdateAutopilot()");
             // Lock out controls if insufficient avionics in RP-0.
             ControlTypes RP0Lock = InputLockManager.GetControlLock("RP0ControlLocker");
             if (RP0Lock != 0)
@@ -401,9 +404,8 @@ namespace kOS.Module
 
             bool isSuppressing = SafeHouse.Config.SuppressAutopilot;
 
-            // Default it to false until it gets turned on below:
-            Screen.KOSToolbarWindow.ShowSuppressMessage = false;
-            Screen.KOSToolbarWindow.ShowSasMessage = false;
+            AutopilotMsgManager.Instance.TurnOffSuppressMessage(this);
+            AutopilotMsgManager.Instance.TurnOffSasMessage(this);
 
             if (Vessel != null)
             {
@@ -425,14 +427,17 @@ namespace kOS.Module
                             if (isSuppressing)
                             {
                                 if (parameter.SuppressAutopilot(c))
-                                    Screen.KOSToolbarWindow.ShowSuppressMessage = true;
+                                    AutopilotMsgManager.Instance.TurnOnSuppressMessage(this);
                             }
                             else
                             {
                                 parameter.UpdateAutopilot(c);
 
                                 if (parameter.FightsWithSas && vessel.ActionGroups[KSPActionGroup.SAS])
-                                    Screen.KOSToolbarWindow.ShowSasMessage = true;
+                                {
+                                    AutopilotMsgManager.Instance.TurnOnSasMessage(this);
+                                    Console.WriteLine("eraseme: kOSVesselModule.Update() setting ShowSasMessage true.");
+                                }
                             }
                         }
                     }

--- a/src/kOS/Screen/KOSToolbarWindow.cs
+++ b/src/kOS/Screen/KOSToolbarWindow.cs
@@ -90,21 +90,6 @@ namespace kOS.Screen
 
         private bool uiGloballyHidden = false;
 
-        /// <summary>Timestamp (using Unity3d's Time.time) for when the suppression message cooldown is over and a new message should be emitted.</summary>
-        private static float suppressMessageCooldownEnd = 0;
-        private static string suppressMessageText = "kOS's config setting is preventing kOS control.";
-        private static ScreenMessage suppressMessage;
-        /// <summary>If true then the 'suppressing autopilot' message should be getting repeated to the screen right now.</summary>
-        public static bool ShowSuppressMessage { get; set; }
-
-        /// <summary>Timestamp (using Unity3d's Time.time) for when the SAS message cooldown is over and a new message should be emitted.</summary>
-        private static float sasMessageCooldownEnd = 0;
-        /// <summary>Tracks a small window of time in which the message won't appear if the problem is fixed before then.</summary>
-        private static float sasMessageGracePeriodEnd = 0;
-        private static string sasMessageText = "kOS: SAS and lock steering fight. Please turn one of them off.";
-        private static ScreenMessage sasMessage;
-        /// <summary>If true then the 'SAS conflict' message should be getting repeated to the screen right now.</summary>
-        public static bool ShowSasMessage { get; set; }
 
         /// <summary>
         /// Unity hates it when a MonoBehaviour has a constructor,
@@ -150,58 +135,7 @@ namespace kOS.Screen
             // Prevent multiple calls of this:
             if (alreadyAwake) return;
             alreadyAwake = true;
-            ShowSuppressMessage = false;
-
             SafeHouse.Logger.SuperVerbose("[kOSToolBarWindow] Start succesful");
-        }
-
-        public void Update()
-        {
-            // Handle the message and timeout of the message
-            if (ShowSuppressMessage)
-            {
-                if (Time.time > suppressMessageCooldownEnd)
-                {
-                    suppressMessageCooldownEnd = Time.time + 5f;
-                    suppressMessage = ScreenMessages.PostScreenMessage(
-                        string.Format("<color=white><size=20>{0}</size></color>", suppressMessageText),
-                        4, ScreenMessageStyle.UPPER_CENTER);
-                }
-            }
-            else
-            {
-                suppressMessageCooldownEnd = 0f;
-                if (suppressMessage != null)
-                {
-                    // Get it to stop right away even if the timer isn't over:
-                    suppressMessage.duration = 0;
-                }
-            }
-
-            // Handle the message and timeout of the message
-            if (ShowSasMessage)
-            {
-                if (Time.time > sasMessageCooldownEnd && Time.time > sasMessageGracePeriodEnd)
-                {
-                    sasMessageCooldownEnd = Time.time + 5f;
-                    sasMessage = ScreenMessages.PostScreenMessage(
-                        string.Format("<color=white><size=20>{0}</size></color>", sasMessageText),
-                        4, ScreenMessageStyle.UPPER_CENTER);
-                }
-            }
-            else
-            {
-                sasMessageCooldownEnd = 0f;
-                // If ShowSasMessage becomes true, this will be left as
-                // whatever 1 second past the last time it was false was:
-                sasMessageGracePeriodEnd = Time.time + 1f;
-                if (sasMessage != null)
-                {
-                    // Get it to stop right away even if the timer isn't over:
-                    sasMessage.duration = 0;
-                }
-            }
-
         }
 
         public void AddButton()

--- a/src/kOS/kOS.csproj
+++ b/src/kOS/kOS.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Function\Suffixed.cs" />
     <Compile Include="KSPLogger.cs" />
     <Compile Include="Module\Bootstrapper.cs" />
+    <Compile Include="Module\AutopilotMsgManager.cs" />
     <Compile Include="Module\kOSCustomParameters.cs" />
     <Compile Include="Module\kOSLightModule.cs" />
     <Compile Include="Module\KOSNameTag.cs" />


### PR DESCRIPTION
Fixes #2782 
The best fix I could think of was to maintain a list of which
vessels' autopilots wanted to have the message on versus which
do not.  That avoids the problem of one vessel turning off the
flag when another vessel wanted it on.  Now there's a
HashSet of all the vessels that want the flag on.  As long as
there's at least one vessel that wants it on, it stays on.  Only
when all vessels want it off does it turn off.  Also,
the vessels can turn it off in their remove hooks code that
happens when their autopilots get destructed, thus avoiding the
scene change bug that the issue talked about.