### PR TITLE
Fixes #2721 Made RangeValue accept any Scalar including doubles.

### DIFF
--- a/src/kOS.Safe.Test/Collections/RangeValueTest.cs
+++ b/src/kOS.Safe.Test/Collections/RangeValueTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
@@ -51,7 +51,7 @@ namespace kOS.Safe.Test.Collections
             Assert.IsFalse((BooleanValue)InvokeDelegate(range, "CONTAINS", new ScalarIntValue(-3)));
             Assert.IsTrue((BooleanValue)InvokeDelegate(range, "CONTAINS", new ScalarIntValue(6)));
 
-            List<ScalarIntValue> l = range.ToList();
+            List<ScalarValue> l = range.ToList();
             Assert.AreEqual(new ScalarIntValue(6), l[0]);
             Assert.AreEqual(new ScalarIntValue(5), l[1]);
             Assert.AreEqual(new ScalarIntValue(-2), l[8]);
@@ -69,10 +69,28 @@ namespace kOS.Safe.Test.Collections
             Assert.IsTrue((BooleanValue)InvokeDelegate(range, "CONTAINS", new ScalarIntValue(5)));
             Assert.IsFalse((BooleanValue)InvokeDelegate(range, "CONTAINS", new ScalarIntValue(4)));
 
-            List<ScalarIntValue> l = range.ToList();
+            List<ScalarValue> l = range.ToList();
             Assert.AreEqual(new ScalarIntValue(2), l[0]);
             Assert.AreEqual(new ScalarIntValue(5), l[1]);
             Assert.AreEqual(new ScalarIntValue(11), l[3]);
+        }
+
+        [Test]
+        public void CanUseRangesWithValuesTooBigForInt32()
+        {
+            // This should be a range of values going [0, 1*max, 2*max, 3*max, 4*max]
+            int oneMaxInt = Int32.MaxValue;
+            long fiveTimesMaxInt = 5L * oneMaxInt;
+            var range = new RangeValue(0, fiveTimesMaxInt, oneMaxInt);
+
+            Assert.AreEqual(new ScalarIntValue(0), InvokeDelegate(range, "START"));
+            Assert.AreEqual(new ScalarDoubleValue(fiveTimesMaxInt), InvokeDelegate(range, "STOP"));
+            Assert.AreEqual(new ScalarIntValue(oneMaxInt), InvokeDelegate(range, "STEP"));
+
+            List<ScalarValue> l = range.ToList();
+            Assert.AreEqual(new ScalarIntValue(0), l[0]);
+            Assert.AreEqual(new ScalarIntValue(oneMaxInt), l[1]);
+            Assert.AreEqual((double)new ScalarDoubleValue(4d * oneMaxInt), (double)l[4]);
         }
     }
 }

--- a/src/kOS.Safe/Encapsulation/RangeValue.cs
+++ b/src/kOS.Safe/Encapsulation/RangeValue.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 namespace kOS.Safe
 {
     [kOS.Safe.Utilities.KOSNomenclature("Range")]
-    public class RangeValue : EnumerableValue<ScalarIntValue, Range>
+    public class RangeValue : EnumerableValue<ScalarValue, Range>
     {
         private const string DumpStart = "start";
         private const string DumpStop = "stop";
@@ -24,17 +24,17 @@ namespace kOS.Safe
         {
         }
 
-        public RangeValue(int stop)
+        public RangeValue(ScalarValue stop)
             : this(DEFAULT_START, stop)
         {
         }
 
-        public RangeValue(int start, int stop)
+        public RangeValue(ScalarValue start, ScalarValue stop)
             : this(start, stop, DEFAULT_STEP)
         {
         }
 
-        public RangeValue(int start, int stop, int step)
+        public RangeValue(ScalarValue start, ScalarValue stop, ScalarValue step)
             : base(Label, new Range(start, stop, step))
         {
             InitializeRangeSuffixes();
@@ -63,9 +63,9 @@ namespace kOS.Safe
 
         public override void LoadDump(Dump dump)
         {
-            InnerEnumerable.Stop = Convert.ToInt32(dump[DumpStop]);
-            InnerEnumerable.Start = Convert.ToInt32(dump[DumpStart]);
-            InnerEnumerable.Step = Convert.ToInt32(dump[DumpStep]);
+            InnerEnumerable.Stop = Convert.ToDouble(dump[DumpStop]);
+            InnerEnumerable.Start = Convert.ToDouble(dump[DumpStart]);
+            InnerEnumerable.Step = Convert.ToDouble(dump[DumpStep]);
         }
 
         public override Dump Dump()
@@ -87,31 +87,31 @@ namespace kOS.Safe
         }
     }
 
-    public class Range : IEnumerable<ScalarIntValue>
+    public class Range : IEnumerable<ScalarValue>
     {
-        public int Start { get; set; }
-        public int Stop { get; set; }
-        public int Step { get; set; }
+        public ScalarValue Start { get; set; }
+        public ScalarValue Stop { get; set; }
+        public ScalarValue Step { get; set; }
 
-        public Range(int start, int stop, int step)
+        public Range(ScalarValue start, ScalarValue stop, ScalarValue step)
         {
             Start = start;
             Stop = stop;
             Step = step;
         }
 
-        IEnumerator<ScalarIntValue> IEnumerable<ScalarIntValue>.GetEnumerator()
+        IEnumerator<ScalarValue> IEnumerable<ScalarValue>.GetEnumerator()
         {
             if (Start < Stop)
             {
-                for (int i = Start; i < Stop; i += Step)
+                for (ScalarValue i = Start; i < Stop; i += Step)
                 {
                     yield return i;
                 }
             }
             else
             {
-                for (int i = Start; i > Stop; i -= Step)
+                for (ScalarValue i = Start; i > Stop; i -= Step)
                 {
                     yield return i;
                 }

--- a/src/kOS.Safe/Encapsulation/ScalarDoubleValue.cs
+++ b/src/kOS.Safe/Encapsulation/ScalarDoubleValue.cs
@@ -1,4 +1,4 @@
-﻿namespace kOS.Safe.Encapsulation
+namespace kOS.Safe.Encapsulation
 {
     [kOS.Safe.Utilities.KOSNomenclature("Scalar", KOSToCSharp = false)]
     public class ScalarDoubleValue : ScalarValue

--- a/src/kOS.Safe/Function/Suffixed.cs
+++ b/src/kOS.Safe/Function/Suffixed.cs
@@ -1,4 +1,4 @@
-﻿using kOS.Safe.Encapsulation;
+using kOS.Safe.Encapsulation;
 using kOS.Safe.Exceptions;
 
 namespace kOS.Safe.Function
@@ -9,25 +9,25 @@ namespace kOS.Safe.Function
         public override void Execute(SafeSharedObjects shared)
         {
             // Default values for parameters
-            int from = RangeValue.DEFAULT_START;
-            int to = RangeValue.DEFAULT_STOP;
-            int step = RangeValue.DEFAULT_STEP;
+            double from = RangeValue.DEFAULT_START;
+            double to = RangeValue.DEFAULT_STOP;
+            double step = RangeValue.DEFAULT_STEP;
 
             int argCount = CountRemainingArgs(shared);
             // assign parameter values from the stack, pop them in reverse order
             switch (argCount)
             {
                 case 1:
-                    to = GetInt(PopStructureAssertEncapsulated(shared));
+                    to = GetDouble(PopStructureAssertEncapsulated(shared));
                     break;
                 case 2:
-                    to = GetInt(PopStructureAssertEncapsulated(shared));
-                    from = GetInt(PopStructureAssertEncapsulated(shared));
+                    to = GetDouble(PopStructureAssertEncapsulated(shared));
+                    from = GetDouble(PopStructureAssertEncapsulated(shared));
                     break;
                 case 3:
-                    step = GetInt(PopStructureAssertEncapsulated(shared));
-                    to = GetInt(PopStructureAssertEncapsulated(shared));
-                    from = GetInt(PopStructureAssertEncapsulated(shared));
+                    step = GetDouble(PopStructureAssertEncapsulated(shared));
+                    to = GetDouble(PopStructureAssertEncapsulated(shared));
+                    from = GetDouble(PopStructureAssertEncapsulated(shared));
                     break;
                 default:
                     throw new KOSArgumentMismatchException(new int[] { 1, 2, 3 }, argCount, "Thrown from function RANGE()");


### PR DESCRIPTION
Using Doubles should allow all whole numbers up to 2^52 before
it starts becoming impossible to store exact whole numbers.