### PR TITLE
Things had to be manually removed from display.

### DIFF
--- a/src/kOS/Module/kOSCustomParameters.cs
+++ b/src/kOS/Module/kOSCustomParameters.cs
@@ -167,7 +167,7 @@ namespace kOS.Module
 
         public override bool Enabled(MemberInfo member, GameParameters parameters)
         {
-            if (member.Name == "migrated" || member.Name == "version")
+            if (member.Name == "migrated" || member.Name == "version" || member.Name == "passedClickThroughCheck")
             {
                 return false;
             }


### PR DESCRIPTION
Fixes #2796 - Found where the other flags that were
suppressed from the settings screen were getting
suppressed, and just added this one to the list.