### PR TITLE
Fixes 2741 vedraw labels

### DIFF
--- a/doc/source/commands/terminalgui.rst
+++ b/doc/source/commands/terminalgui.rst
@@ -78,6 +78,12 @@ GUI display tools
     or to help show the player information.  The full description can be
     found on the `Vecdraw Page <../structures/misc/vecdraw.html>`__.
 
+    Note: Very large Vecdraws (for example if you try to draw a
+    vector pointing from your ship to another planet) might not get
+    drawn at all in the flight view, and only show up in the map
+    view.  A longer explanation as to why is on the
+    `Vecdraw Page <../structures/misc/vecdraw.html>`__.
+
 .. global:: HUDTEXT
 
     You can make text messages appear on the heads-up display, in the

--- a/doc/source/structures/misc/vecdraw.rst
+++ b/doc/source/structures/misc/vecdraw.rst
@@ -130,6 +130,28 @@ Drawing Vectors on the Screen
     done ``SET varname:show to FALSE`` for all vecdraw varnames in the
     entire system.
 
+Very large Vecdraws only show up on map view, not flight view
+-------------------------------------------------------------
+
+If your vecdraw is very big, for example if you try to draw a
+vector going from your ship to the Sun, or from one planet to
+another, you may find that it won't appear at all in the flight
+view, but will still appear in the map view.  There isn't much that
+kOS can do about this, as it is a feature of the camera settings
+chosen by KSP for the flight view camera.
+
+The reason very long vecdraws only get drawn in map view and not the
+flight view is the same as the reason you can only see distant planets
+in the map view and not the flight view.  Duna should still take up a
+few pixels of your screen when seen from Kerbin and yet there's nothing
+there not even a dot.  This has to do with a feature of computer
+graphics called the "camera far clipping plane", but the short version
+is that KSP's flight camera is configured to be unable to render any
+polygons where one of that polygons' vertices is very far away.
+
+Suffixes of Vecdraw
+-------------------
+
 .. structure:: VecDraw
 
     This is a structure that allows you to make a drawing of a vector on the screen in map view or in flight view.

--- a/src/kOS/Suffixed/VectorRenderer.cs
+++ b/src/kOS/Suffixed/VectorRenderer.cs
@@ -35,7 +35,6 @@ namespace kOS.Suffixed
         private Text label;
         private string labelStr = "";
         private Vector3 labelLocation;
-        private float labelScale;
 
         // These could probably be moved somewhere where they are updated
         // more globally just once per Update() rather than once per
@@ -52,7 +51,6 @@ namespace kOS.Suffixed
         private Vector3 prevCamLookVec;
         private Quaternion camRot;
         private Quaternion prevCamRot;
-        private Vector3 prevCamLookUp;
         private bool isOnMap; // true = Map view, false = Flight view.
         private bool prevIsOnMap;
         private const int MAP_LAYER  =10; // found through trial-and-error
@@ -296,7 +294,6 @@ namespace kOS.Suffixed
             prevIsOnMap = isOnMap;
             prevCamLookVec = camLookVec;
             prevCamRot = camRot;
-            prevCamLookUp = camLookUp;
 
             isOnMap = MapView.MapIsEnabled;
 

--- a/src/kOS/kOS.csproj
+++ b/src/kOS/kOS.csproj
@@ -80,6 +80,9 @@
     <Reference Include="UnityEngine">
       <HintPath>..\..\Resources\UnityEngine.dll</HintPath>
     </Reference>
+    <Reference Include="UnityEngine.UIModule">
+      <HintPath>..\..\Resources\UnityEngine.UIModule.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEngine.UnityWebRequestAudioModule">
       <HintPath>..\..\Resources\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
     </Reference>


### PR DESCRIPTION
Fixes #2741 with major refactor of drawing the text labels.

After failing to figure out what the heck changed about the text labels between KSP versions, I finally decided that if I am going to have to redo them from scratch I may as well bite the bullet and figure out how to use the new UI.Text feature since GUIText has been obsoleted for a while and for all I know that might be why it doesn't work anymore.  (KSP does some wacky stuff to keep the old IMGUI working in mods by including some DLLs for it that Unity itself no longer supports. There's a chance that DLL didn't include the bit that used to let me write GUITexts raw direct to the screen without a containing window.)

At any rate, it now uses the canvas system and UI.Text to draw the label.
While I was in there I also finally fixed the scaling of the vector lines themselves so they stay the same size no matter how far out you zoom the camaera, which was my original intention all along but it never did quite work right.

NOTE: The documentation on vecdraw should mention that the vector won't draw at all if one of its endpoints is outside the camera clipping distance.  So very long vectors might only be visible on map view.
