### PR TITLE
Fixes 2802 adjust label size for ground

### DIFF
--- a/src/kOS/Suffixed/VectorRenderer.cs
+++ b/src/kOS/Suffixed/VectorRenderer.cs
@@ -16,6 +16,7 @@ namespace kOS.Suffixed
     {
         public Vector3d Vector { get; set; }
         public RgbaColor Color { get; set; }
+        private RgbaColor prevColor;
         public Vector3d Start { get; set; }
         public double Scale { get; set; }
         public double Width { get; set; }
@@ -569,12 +570,11 @@ namespace kOS.Suffixed
             labelTransform.localPosition = labelLocation;
             labelTransform.localRotation = camRot;
 
-            // This seemed to fix it for flying near the ground but break it for map view:
-            // TODO - Revisit this tomorrow - still not quite right:
-            Vector3 labelScaledPos = (isOnMap ? (Vector3)ScaledSpace.LocalToScaledSpace(labelTransform.position) : labelTransform.position);
-            float distanceFromCamera = (camPos - labelScaledPos).magnitude;
-
-            labelTransform.localScale = new Vector3(0.0015f, 0.0015f, 0.0015f) * distanceFromCamera * (float)Scale;
+            Vector3 scaledLabelLocaton = (isOnMap ? (Vector3)ScaledSpace.LocalToScaledSpace(labelTransform.position) : labelTransform.position);
+            float distanceFromCamera = (camPos - scaledLabelLocaton).magnitude;
+            if (isOnMap)
+                distanceFromCamera *= ScaledSpace.ScaleFactor;
+            labelTransform.localScale = new Vector3(0.006f, 0.006f, 0.006f) * distanceFromCamera * (float)Width;
             label.enabled = true;
         }
 

--- a/src/kOS/Suffixed/VectorRenderer.cs
+++ b/src/kOS/Suffixed/VectorRenderer.cs
@@ -568,7 +568,12 @@ namespace kOS.Suffixed
             */
             labelTransform.localPosition = labelLocation;
             labelTransform.localRotation = camRot;
-            float distanceFromCamera = (camPos - labelLocation).magnitude;
+
+            // This seemed to fix it for flying near the ground but break it for map view:
+            // TODO - Revisit this tomorrow - still not quite right:
+            Vector3 labelScaledPos = (isOnMap ? (Vector3)ScaledSpace.LocalToScaledSpace(labelTransform.position) : labelTransform.position);
+            float distanceFromCamera = (camPos - labelScaledPos).magnitude;
+
             labelTransform.localScale = new Vector3(0.0015f, 0.0015f, 0.0015f) * distanceFromCamera * (float)Scale;
             label.enabled = true;
         }


### PR DESCRIPTION
Fixes #2802 - Didn't handle the way the center of the universe moves away from the ship when near the ground in motion.  It seems that the offset between the world origin and the ship CoM grows when moving within 150m of the ground, but stays locked in place when up in orbit, so that's why when near the ground the problem manifested.