### PR TITLE
fixes #2767 but in a different way, with zeroMode

### DIFF
--- a/src/kOS/Function/Suffixed.cs
+++ b/src/kOS/Function/Suffixed.cs
@@ -355,7 +355,7 @@ namespace kOS.Function
     }
 
     [Function("time")]
-    public class Time : FunctionBase
+    public class FunctionTime : FunctionBase
     {
         // Note: "TIME" is both a bound variable AND a built-in function now.
         // If it gets called with parentheses(), the script calls this built-in function.
@@ -379,6 +379,23 @@ namespace kOS.Function
             AssertArgBottomAndConsume(shared);
 
             ReturnValue = new kOS.Suffixed.TimeSpan(ut);
+        }
+    }
+
+    [Function("timespan")]
+    public class FunctionTimespan : FunctionBase
+    {
+        public override void Execute(SharedObjects shared)
+        {
+            // This version gives a timespan from filling all the values: year, day, hour, minute, month, zeroMode
+            bool zeroMode = Convert.ToBoolean(PopValueAssert(shared));
+            double sec = GetDouble(PopValueAssert(shared));
+            double min = GetDouble(PopValueAssert(shared));
+            double hour = GetDouble(PopValueAssert(shared));
+            double day = GetDouble(PopValueAssert(shared));
+            double year = GetDouble(PopValueAssert(shared));
+
+            ReturnValue = new kOS.Suffixed.TimeSpan(year, day, hour, min, sec, zeroMode);
         }
     }
 


### PR DESCRIPTION
Fixes #2767 but not in the way requested. 

I added a flag to change how the TimeSpan interprets the meaning of Year and Day, whether it counts them from zero or from one.  Under the hood nothiing has changed about the actual data in the TimeSpan since it never really *stored* year and day - it just stores the second since epoch and *calculates* the year and day from that.  this just changes how the calculation is done.

Note that while I was in there I also made the year, day, hour, minute, and second suffixes set-able, which they were not before.

The fact that it only really stores the seconds-since-epoch behind the scenes also means you can safely mix and match timespans that have zeroFlag false with ones that have zeroFlag true, doing adding and subtracting on them without issue since they do not care how the year and day are being extracted when the arithmetic itself happens just on the "unix time"-like data.

Synopsis of change:
```
set t1 to time(24*60*60*4 + 30). // 4 days and 30 seconds.
set t1:ZEROMODE to false. // this is the default anyway
print t1:calendar + ", " + t1:clock.
year 1, day 5, 00:00:30
set t1:ZEROMODE to true.
print t1:calendar + ", " + t1:clock.
year 0, day 4, 00:00:30 
```