### PR TITLE
Epsilons in PIDLoop and SteeringManager

### DIFF
--- a/doc/source/commands/flight/cooked.rst
+++ b/doc/source/commands/flight/cooked.rst
@@ -288,6 +288,18 @@ If you don't want to understand the intricate details of the cooked
 steering system, here's some quick suggestions for changes to the
 settings that might help solve some problems, in the list below:
 
+- **problem**: When rotating toward the target direction, ``lock steering``
+  is wiggling the controls back and forth trying to keep the exact
+  rotation rate even though it doesn't matter.  This is wasting RCS
+  fuel.
+
+  - **solution**: Increase :attr:`STEERINGMANAGER:ROTATIONEPSILONMAX` to make
+    it "not care" about the exact rotation rate until it gets closer to
+    the target orientation.
+    Increasing :attr:`STEERINGMANAGER:ROTATIONEPSILONMIN` can help also, but
+    making it too high could prevent the steering from holding the nose on
+    target once it does reach the desired direction.
+
 - **problem**: A large vessel with low torque doesn't seem to be even trying to
   rotate very quickly.  The controls may be fluctuating around the zero point,
   but it doesn't seem to want to even try to turn faster.

--- a/doc/source/structures/misc/pidloop.rst
+++ b/doc/source/structures/misc/pidloop.rst
@@ -162,6 +162,8 @@ Structure
     :attr:`OUTPUT`                        :struct:`scalar`          The most recent output value
     :attr:`MAXOUTPUT`                     :struct:`scalar`          The maximum output value
     :attr:`MINOUTPUT`                     :struct:`scalar`          The maximum output value
+    :attr:`EPSILON`                       :struct:`scalar`          The "don't care" tolerance of error
+    :attr:`IGNOREERROR`                   :struct:`scalar`          Alias for :attr:`EPSILON`.
     :attr:`ERRORSUM`                      :struct:`scalar`          The time weighted sum of error
     :attr:`PTERM`                         :struct:`scalar`          The proportional component of output
     :attr:`ITERM`                         :struct:`scalar`          The integral component of output
@@ -244,6 +246,55 @@ Structure
     :access: Get/Set
 
     The current minimum output value.  This value also helps with regulating integral wind up mitigation.
+
+
+.. attribute:: PIDLoop:EPSILON
+
+    :type: :struct:`scalar`
+    :access: Get/Set
+
+    Default = 0.
+
+    The size of the "don't care" tolerance window of the error measurement.
+
+    When the error measurement (difference between input and setpoint) is smaller
+    than this number, then this PID loop will simply *pretend* the error is
+    actually zero and react accordingly (it won't output any control deflection
+    to bother correcting the error until after it's bigger than epsilon.)
+    This can be handy when you want a null zone in the input measure.  (This is
+    different from having a null zone in the output, as in having a lever
+    that can't do anything unless it's moved far enough.  This is more of a
+    null zone on the input measurement.)
+
+    (In the PIDLoops that are contained internally within the
+    :struct:`SteeringManager` that ``lock steering`` uses, they use this
+    epsilon to try to reduce the use of RCS propellant that comes from
+    wiggling the controls unnecessarily.)
+
+    Because the PIDloop will pretend any error smaller than epsilon is zero,
+    it also will not incur any "integral windup" for that error.
+
+.. attribute:: PIDLoop:IGNOREERROR
+
+    :type: :struct:`scalar`
+    :access: Get/Set
+
+    This is just an alias that is the same thing as :attr:`EPSILON`.
+
+.. attribute:: PIDLoop:EPSILON
+
+    :type: :struct:`scalar`
+    :access: Get/Set
+
+    Default = 0.
+
+    The size of the "don't care" tolerance window of the error measurement.
+
+    When the error measurement (difference between input and setpoint) is smaller
+    than this number, then the PID loop will simply *pretend* the error is
+    actually zero and react accordingly (it won't bother trying to do anything with
+    the controls to fix the error.)  This can be handy when you want a null zone.
+
 
 .. attribute:: PIDLoop:ERRORSUM
 

--- a/doc/source/structures/misc/pidloop.rst
+++ b/doc/source/structures/misc/pidloop.rst
@@ -39,31 +39,77 @@ read the :ref:`tutorial about what PID loops are <pidloops>` first.
 Constructors
 ------------
 
-The `PIDLoop` has multiple constructors available.  Valid syntax can be seen here: ::
+The `PIDLoop` constructor function has a number of parametres, and
+they can be left off, leaving optional defaults.
 
-    // Create a loop with default parameters
+The full version is this::
+
+  SET MYPID TO PIDLOOP(Kp, Ki, Kd, min_output, max_output, epsilon).
+
+With these defaults:
+
+  .. list-table::
+    :header-rows: 1
+    :widths: 1 2 3
+
+    * - Parameter
+      - Default if left off
+      - Meaning
+    
+    * - Kp
+      - 1.0
+      - Proportional gain
+    * - Ki
+      - 0.0
+      - Integral gain
+    * - Kd
+      - 0.0
+      - Derivative gain
+    * - min_output
+      - Very Big negative number. about -1.7e308
+      - The minimum value this PIDLoop will output.
+    * - max_output
+      - Very Big positive number. about -1.7e308
+      - The maximum value this PIDLoop will output.
+    * - epsilon
+      - 0.0
+      - The PIDLoop will ignore any input error smaller than this.
+
+Examples
+~~~~~~~~
+::
+    // With zero parameters, the PIDLoop has default parameters:
     // kp = 1, ki = 0, kd = 0
     // maxoutput = maximum number value
     // minoutput = minimum number value
     SET PID TO PIDLOOP().
 
-    // Other constructors include:
-    SET PID TO PIDLOOP(KP).
-    SET PID TO PIDLOOP(KP, KI, KD).
-    // you must specify both minimum and maximum output directly.
-    SET PID TO PIDLOOP(KP, KI, KD, MINOUTPUT, MAXOUTPUT).
+    // Create a PIDLoop with a few stated paremeters:
+    SET PID TO PIDLOOP(2.5).
+    SET PID TO PIDLOOP(2.0, 0.05, 0.1).
+    SET PID TO PIDLOOP(2.0, 0.05, 0.1, -1, 1).
 
-    // remember to update both minimum and maximum output if the value changes symmetrically
-    SET LIMIT TO 0.5.
-    SET PID:MAXOUTPUT TO LIMIT.
-    SET PID:MINOUTPUT TO -LIMIT.
+Example of using it:
+~~~~~~~~~~~~~~~~~~~~
 
-    // call the update suffix to get the output
-    SET OUT TO PID:UPDATE(TIME:SECONDS, IN).
-
-    // you can also get the output value later from the PIDLoop object
-    SET OUT TO PID:OUTPUT.
-
+    // Throttle up when below target altitude, throttle down when above
+    // target altitude, trying to hover:
+    local target_alt is 100.
+    set HOVERPID to PIDLOOP(
+        50,  // adjust throttle 0.1 per 5m in error from desired altitude.
+        0.1, // adjust throttle 0.1 per second spent at 1m error in altitude.
+        30,  // adjust throttle 0.1 per 3 m/s speed toward desired altitude.
+        0,   // min possible throttle is zero.
+        1    // max possible throttle is one.
+      ).
+    set HOVERPID:SETPOINT to target_alt.
+    set mythrot to 0.
+    lock throttle to mythrot.
+    until false {
+      set mythrot to HOVERPID:UPDATE(TIME:SECONDS, alt:radar).
+      wait 0.
+    }
+    
 Please see the bottom of this page for information on the derivation of the loop's output.
 
 .. _basic_pidloop_example:

--- a/doc/source/structures/misc/steeringmanager.rst
+++ b/doc/source/structures/misc/steeringmanager.rst
@@ -35,6 +35,8 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
     :attr:`PITCHTS`                      :struct:`scalar` (s)      Settling time for the pitch torque calculation.
     :attr:`YAWTS`                        :struct:`scalar` (s)      Settling time for the yaw torque calculation.
     :attr:`ROLLTS`                       :struct:`scalar` (s)      Settling time for the roll torque calculation.
+    :attr:`ROTATIONEPSILONMIN`           :struct:`scalar` (s)      Rotation rate error to ignore (used when pointed the right way).
+    :attr:`ROTATIONEPSILONMAX`           :struct:`scalar` (s)      Rotation rate error to ignore (use when pointed the wrong way).
     :attr:`MAXSTOPPINGTIME`              :struct:`scalar` (s)      The maximum amount of stopping time to limit angular turn rate.
     :attr:`ROLLCONTROLANGLERANGE`        :struct:`scalar` (deg)    The maximum value of :attr:`ANGLEERROR` for which to control roll.
     :attr:`ANGLEERROR`                   :struct:`scalar` (deg)    The angle between vessel:facing and target directions
@@ -161,6 +163,67 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
     :access: Get/Set
 
     Represents the settling time for the :ref:`PID calculating roll torque based on target angular velocity <cooked_torque_pid>`.  The proportional and integral gain is calculated based on the settling time and the moment of inertia in the roll direction.  Ki = (moment of inertia) * (4 / (settling time)) ^ 2.  Kp = 2 * sqrt((moment of inertia) * Ki).
+
+.. attribute:: SteeringManager:ROTATIONEPSILONMIN
+
+    :type: :ref:`scalar <scalar>`
+    :access: Get/Set
+
+    DEFAULT VALUE: TODO.
+
+    Tweaking this value can help make the controls stop wiggling so fast.
+
+    You cannot set this value higher than
+    :attr:`SteeringManager:ROTATIONEPSILONMAX`.
+    If you attempt to do so, then
+    :attr:`SteeringManager:ROTATIONEPSILONMAX` will be increased to match
+    the value just set :attr:`SteeringManager:ROTATIONEPSILONMIN` to.
+
+    To see how to use this value, look at the description of
+    :attr:`SteeringManager:ROTATIONEPSILONMAX` below, which
+    has the full documentation about how these two values, Min and Max,
+    work together.
+
+.. attribute:: SteeringManager:ROTATIONEPSILONMAX
+
+    :type: :ref:`scalar <scalar>`
+    :access: Get/Set
+
+    DEFAULT VALUE: TODO.
+
+    Tweaking this value can help make the controls stop wiggling so fast.
+    If you have problems wasting too much RCS propellant because kOS
+    "cares too much" about getting the rotation rate exactly right and is
+    wiggling the controls unnecessarily when rotating toward a new direction,
+    setting thie value a bit higher can help.
+
+    You cannot set this value lower than
+    :attr:`SteeringManager:ROTATIONEPSILONMIN`.
+    If you attempt to do so, then
+    :attr:`SteeringManager:ROTATIONEPSILONMIN` will be decreased to match
+    the value just set :attr:`SteeringManager:ROTATIONEPSILONMAX` to.
+
+    **HOW IT WORKS:**
+    
+    If the error in the desired rotation rate is smaller than the current epsilon,
+    then the :ref:`PID that calculates a desired angular velocity <cooked_omega_pid>`
+    will ignore that error and not bother correcting it until it gets bigger.
+    The actual epsilon value used in the steering manager's internal PID controller 
+    is always something between 
+    :attr:`SteeringManager:ROTATIONEPSILONMIN`.
+    and
+    :attr:`SteeringManager:ROTATIONEPSILONMAX`.
+    It varies between these two values depending on how far the off the target
+    direction is from the current direction.  The closer the aim is to the right
+    direction, the smaller the epsilon gets (the more it cares about being
+    precise with the desired rotation rate).  The epsilon varies between
+    :attr:`SteeringManager:ROTATIONEPSILONMIN` (used when aimed the right way
+    already) and :attr:`SteeringManager:ROTATIONEPSILONMAX` (used when aimed
+    180 degrees away from the right way.)  If the angle error is 90 degrees,
+    the epsilon will be halfway between the min and max values, and so on.
+
+    If you desire a constant epsilon, set both the min and max values to the
+    same value.
 
 .. attribute:: SteeringManager:MAXSTOPPINGTIME
 

--- a/doc/source/structures/misc/steeringmanager.rst
+++ b/doc/source/structures/misc/steeringmanager.rst
@@ -169,7 +169,7 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
     :type: :ref:`scalar <scalar>`
     :access: Get/Set
 
-    DEFAULT VALUE: TODO.
+    DEFAULT VALUE: 0.01
 
     Tweaking this value can help make the controls stop wiggling so fast.
 
@@ -189,7 +189,7 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
     :type: :ref:`scalar <scalar>`
     :access: Get/Set
 
-    DEFAULT VALUE: TODO.
+    DEFAULT VALUE: 0.5
 
     Tweaking this value can help make the controls stop wiggling so fast.
     If you have problems wasting too much RCS propellant because kOS
@@ -224,6 +224,24 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
 
     If you desire a constant epsilon, set both the min and max values to the
     same value.
+
+.. _rotationepsilonmax_math:
+
+    ** MIN VESSEL CAPABILITY: **
+
+    Warning: Setting :attr:`SteeringManager:ROTATIONEPSILONMAX` too large can
+    make the SteeringManager fail to try turning the craft at all.  Use this
+    formula to decide what is probably the maximum safe value you can set
+    it to without it causing this problem:
+
+    Let :math:`\omega = \text{rotational acceleration the vessel is
+    capable of, expressed in} \frac{\text{degrees}}{\text{second}^2}`
+
+    Then :math:`\epsilon`, the maximum safe ``RotationEpsilonMax``
+    to pick, is:
+
+    :math:`\epsilon = \omega \cdot {MAXSTOPPINGTIME}`
+    Where MAXSTOPPINGTIME is :attr:`SteeringManager:MAXSTOPPINGTIME`
 
 .. attribute:: SteeringManager:MAXSTOPPINGTIME
 

--- a/src/kOS.Safe/Encapsulation/PIDLoop.cs
+++ b/src/kOS.Safe/Encapsulation/PIDLoop.cs
@@ -20,6 +20,7 @@ namespace kOS.Safe.Encapsulation
                 double kp;
                 double minoutput;
                 double maxoutput;
+                double epsilon;
                 switch (args)
                 {
                     case 0:
@@ -42,6 +43,15 @@ namespace kOS.Safe.Encapsulation
                         ki = GetDouble(PopValueAssert(shared));
                         kp = GetDouble(PopValueAssert(shared));
                         this.ReturnValue = new PIDLoop(kp, ki, kd, maxoutput, minoutput);
+                        break;
+                    case 6:
+                        epsilon = GetDouble(PopValueAssert(shared));
+                        maxoutput = GetDouble(PopValueAssert(shared));
+                        minoutput = GetDouble(PopValueAssert(shared));
+                        kd = GetDouble(PopValueAssert(shared));
+                        ki = GetDouble(PopValueAssert(shared));
+                        kp = GetDouble(PopValueAssert(shared));
+                        this.ReturnValue = new PIDLoop(kp, ki, kd, maxoutput, minoutput, epsilon);
                         break;
                     default:
                         throw new KOSArgumentMismatchException(new[] { 0, 1, 3, 5 }, args);
@@ -176,13 +186,11 @@ namespace kOS.Safe.Encapsulation
         public ScalarValue Update(ScalarValue sampleTime, ScalarValue input)
         {
             double error = Setpoint - input;
-            Console.WriteLine(string.Format("eraseme: PID Update before: {0}, {1}, {2}, {3}", Setpoint, input, error, Epsilon));
             if (error > -Epsilon && error < Epsilon)
             {
                 error = 0;
                 input = Setpoint; // some calculations below use input directly instead of error, so we need this too to fake them out.
             }
-            Console.WriteLine(string.Format("eraseme: PID Update after: {0}, {1}, {2}, {3}", Setpoint, input, error, Epsilon));
             double pTerm = error * Kp;
             double iTerm = 0;
             double dTerm = 0;

--- a/src/kOS/Control/SteeringManager.cs
+++ b/src/kOS/Control/SteeringManager.cs
@@ -165,7 +165,7 @@ namespace kOS.Control
         private double accPitch = 0;
         private double accYaw = 0;
         private double accRoll = 0;
-        private double rotationEpsilonMin = 0d; // really being precise here, but users can make this bigger to make it use less RCS.
+        private double rotationEpsilonMin = 0.01d; // really being precise here, but users can make this bigger to make it use less RCS.
         private double rotationEpsilonMax = 0.5d; // when it's totally off, as long as it's within this many degrees per second of the right rate, good enough.
 
         private double phi;

--- a/src/kOS/Control/SteeringManager.cs
+++ b/src/kOS/Control/SteeringManager.cs
@@ -166,7 +166,7 @@ namespace kOS.Control
         private double accYaw = 0;
         private double accRoll = 0;
         private double rotationEpsilonMin = 0d; // really being precise here, but users can make this bigger to make it use less RCS.
-        private double rotationEpsilonMax = 1d; // when it's totally off, as long as it's within 1 degree per second of the right rate, good enough.
+        private double rotationEpsilonMax = 0.5d; // when it's totally off, as long as it's within this many degrees per second of the right rate, good enough.
 
         private double phi;
         private double phiPitch;
@@ -740,7 +740,6 @@ namespace kOS.Control
             double pitchEpsilon = rotationEpsilonMin + (Math.Abs(phiPitch) / 180) * (rotationEpsilonMax - rotationEpsilonMin);
             double yawEpsilon = rotationEpsilonMin + (Math.Abs(phiYaw) / 180) * (rotationEpsilonMax - rotationEpsilonMin);
             double rollEpsilon = rotationEpsilonMin + (Math.Abs(phiRoll) / 180) * (rotationEpsilonMax - rotationEpsilonMin);
-            Console.WriteLine(string.Format("eraseme: pitch, yaw, roll Epsilons: {0}, {1}, {2}", pitchEpsilon, yawEpsilon, rollEpsilon));
 
             // Calculate the maximum allowable angular velocity and apply the limit, something we can stop in a reasonable amount of time
             maxPitchOmega = controlTorque.x * MaxStoppingTime / momentOfInertia.x;
@@ -749,9 +748,7 @@ namespace kOS.Control
 
             double sampletime = shared.UpdateHandler.CurrentFixedTime;
             // Because the value of phi is already error, we say the input is -error and the setpoint is 0 so the PID has the correct sign
-            Console.WriteLine(string.Format("eraseme: starting pitchpid update"));
             tgtPitchOmega = pitchRatePI.Update(sampletime, -phiPitch, 0, maxPitchOmega, pitchEpsilon);
-            Console.WriteLine(string.Format("eraseme: starting yawpid update"));
             tgtYawOmega = yawRatePI.Update(sampletime, -phiYaw, 0, maxYawOmega, yawEpsilon);
             if (Math.Abs(phi) > RollControlAngleRange * Math.PI / 180d)
             {
@@ -760,7 +757,6 @@ namespace kOS.Control
             }
             else
             {
-                Console.WriteLine(string.Format("eraseme: starting rollpid update"));
                 tgtRollOmega = rollRatePI.Update(sampletime, -phiRoll, 0, maxRollOmega, rollEpsilon);
             }
 


### PR DESCRIPTION
Fixes #2806 (I Hope).  I am merging this in so RO people may be able to test it.  I have tested it about as well as I can without RO installed.

The change is mainly that SteeringManager now has an epsilon error amount where it "doesn't care" about the rotational rate being a bit off until later on when it gets closer to the target orientation.  If you're trying to rotate at 1 degree per second toward the desired orientation and instead you're rotating at 1.05 degrees per second toward the desired orientation, you shouldn't really care yet about that small difference (and not bother correcting it with precious RCS fuel) until you're very close to the destination orientation.

This is accomplished by adding an epsilon to the PIDLoop structure, then using that epsilon in the PIDLoops the SteeringManager uses, and having the size of epsilon "Lerp" between a max and min value (max when pointed wrong where precision doesn't matter yet, and min when pointed right.)

The default values for these min and max epsilons are chosen arbitrarily and could be adjusted in future PRs if people find them problematic in testing.

While I was in there I also noticed that the existing EPSILON used in the torque pids was so small as to be utterly meaningless, and I increased it a bit, (While also splitting it into two constants because there were two different unrelated things the same EPSILON constant had been used for before, one of which should remain small and the other should not.)

There is also a lot of documentation to go with the changes.  If you are trying to test this out, read through the documentation diffs on this PR to see what there is to play with.