### PR TITLE
Workaround to fix wrong position of packed vessels

### DIFF
--- a/src/kOS/Suffixed/Part/PartValue.cs
+++ b/src/kOS/Suffixed/Part/PartValue.cs
@@ -191,7 +191,8 @@ namespace kOS.Suffixed.Part
 
         public Vector GetPosition()
         {
-            return new Vector(Part.transform.position - Shared.Vessel.CoMD);
+            Vector3d positionError = VesselTarget.CreateOrGetExisting(Part.vessel, Shared).GetPositionError();
+            return new Vector(Part.transform.position - Shared.Vessel.CoMD + positionError);
         }
 
         private void ControlFrom()

--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -45,13 +45,17 @@ namespace kOS.Suffixed
             // in the next simulation frame instead of the position where it is now.
             // To work around this issue the velocity of the target vessel is integrated over one frame
             // to calculate the corrent position in the current simulation frame.
-            if (Vessel.packed)
+
+            // normal time or physics warp
+            bool usingPhysics = TimeWarp.CurrentRate == 1f || TimeWarp.WarpMode == TimeWarp.Modes.LOW;
+
+            if (Vessel.loaded && Vessel.packed && usingPhysics && CurrentVessel.isActiveVessel)
             {
                 // If the body is in inverse rotation mode (i.e. the world axis are fixed to the body surface) the surface velocity is used
                 // because the position reported by KSP is accounting for the frame of reference rotation
                 Vector3d velocity = CurrentVessel.mainBody.inverseRotation ? Vessel.srf_velocity : Vessel.obt_velocity;
                 // Calculate the current position by integrating the velocity vector over one frame and subtracting that from the reported position
-                position -= velocity * 0.02;
+                position -= velocity * TimeWarp.fixedDeltaTime;
             }
 
             return position;


### PR DESCRIPTION
There's a bug in KSP where it returns the wrong position for packed vessels. Instead of returning the current position is returning the position where it will be in the next simulation frame.

Ideally we shouldn't be working around KSP bugs but this one is severe enough that I think merits the effort, and if KSP ever fixes the underlying issue it's easy to rollback.

![poserror](https://user-images.githubusercontent.com/5986544/100307733-5d747080-2f85-11eb-90b7-f3eb79ca9fb5.jpg)

In the image there are two arrows, the red one points to the position reported by KSP and the green one to the position using the workaround. Getting closer to the target vessel caused it to unpack and then the red arrow started pointing to the correct position.

In the example above the workaround was done in a kOS script BEFORE applying this patch and that's why I had access to the "wrong" position reported by KSP.