### PR TITLE
Steering null retune 1

### DIFF
--- a/doc/source/commands/flight/cooked.rst
+++ b/doc/source/commands/flight/cooked.rst
@@ -296,10 +296,10 @@ settings that might help solve some problems, in the list below:
   This is specifically for when it wiggles the controls *during* its
   rotation to the destination orientation.)
 
-  - **solution**: Increase :attr:`STEERINGMANAGER:ROTATIONEPSILONMAX` to make
+  - **solution**: Increase :attr:`STEERINGMANAGER:TORQUEPSILONMAX` to make
     it "not care" about the exact rotation rate until it gets closer to
     the target orientation.
-    Increasing :attr:`STEERINGMANAGER:ROTATIONEPSILONMIN` can help also, but
+    Increasing :attr:`STEERINGMANAGER:TORQUEPSILONMIN` can help also, but
     making it too high could prevent the steering from holding the nose on
     target once it does reach the desired direction.
 
@@ -309,7 +309,7 @@ settings that might help solve some problems, in the list below:
   controls at all).
 
   - **solution**: You might have to either decrease
-    :attr:`STEERINGMANAGER:ROTATIONEPSILONMAX` or increase
+    :attr:`STEERINGMANAGER:TORQUEEPSILONMAX` or increase
     :attr:`STEERINGMANAGER:MAXSTOPPINGTIME`.
 
   - **explanation**: The problem may be that your vessel is so slow at
@@ -355,7 +355,7 @@ settings that might help solve some problems, in the list below:
 
   - **solution 2**: If you don't care about the exact precision to
     point the correct direction to tiny fractions of a degree, then
-    increase :attr:`SteeringManager:ROTATIONEPSILONMIN` by a little bit.
+    increase :attr:`SteeringManager:TORQUEEPSILONMIN` by a little bit.
 
   - **explanation**: Once it's
     at the desired orientation and it has mostly zeroed the rotational

--- a/doc/source/structures/misc/steeringmanager.rst
+++ b/doc/source/structures/misc/steeringmanager.rst
@@ -169,7 +169,7 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
     :type: :ref:`scalar <scalar>`
     :access: Get/Set
 
-    DEFAULT VALUE: 0.002
+    DEFAULT VALUE: 0.0002
 
     Tweaking this value can help make the controls stop wiggling so fast.
 
@@ -189,7 +189,7 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
     :type: :ref:`scalar <scalar>`
     :access: Get/Set
 
-    DEFAULT VALUE: 0.01
+    DEFAULT VALUE: 0.001
 
     Tweaking this value can help make the controls stop wiggling so fast.
     If you have problems wasting too much RCS propellant because kOS

--- a/doc/source/structures/misc/steeringmanager.rst
+++ b/doc/source/structures/misc/steeringmanager.rst
@@ -35,8 +35,8 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
     :attr:`PITCHTS`                      :struct:`scalar` (s)      Settling time for the pitch torque calculation.
     :attr:`YAWTS`                        :struct:`scalar` (s)      Settling time for the yaw torque calculation.
     :attr:`ROLLTS`                       :struct:`scalar` (s)      Settling time for the roll torque calculation.
-    :attr:`ROTATIONEPSILONMIN`           :struct:`scalar` (s)      Rotation rate error to ignore (used when pointed the right way).
-    :attr:`ROTATIONEPSILONMAX`           :struct:`scalar` (s)      Rotation rate error to ignore (use when pointed the wrong way).
+    :attr:`TORQUEEPSILONMIN`             :struct:`scalar` (s)      Torque deadzone when not rotating at max rate
+    :attr:`TORQUEEPSILONMAX`             :struct:`scalar` (s)      Torquw deadzone when rotating at max roatation rate
     :attr:`MAXSTOPPINGTIME`              :struct:`scalar` (s)      The maximum amount of stopping time to limit angular turn rate.
     :attr:`ROLLCONTROLANGLERANGE`        :struct:`scalar` (deg)    The maximum value of :attr:`ANGLEERROR` for which to control roll.
     :attr:`ANGLEERROR`                   :struct:`scalar` (deg)    The angle between vessel:facing and target directions
@@ -164,32 +164,32 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
 
     Represents the settling time for the :ref:`PID calculating roll torque based on target angular velocity <cooked_torque_pid>`.  The proportional and integral gain is calculated based on the settling time and the moment of inertia in the roll direction.  Ki = (moment of inertia) * (4 / (settling time)) ^ 2.  Kp = 2 * sqrt((moment of inertia) * Ki).
 
-.. attribute:: SteeringManager:ROTATIONEPSILONMIN
+.. attribute:: SteeringManager:TORQUEEPSILONMIN
+
+    :type: :ref:`scalar <scalar>`
+    :access: Get/Set
+
+    DEFAULT VALUE: 0.002
+
+    Tweaking this value can help make the controls stop wiggling so fast.
+
+    You cannot set this value higher than
+    :attr:`SteeringManager:TORQUEEPSILONMAX`.
+    If you attempt to do so, then
+    :attr:`SteeringManager:TORQUEEPSILONMAX` will be increased to match
+    the value just set :attr:`SteeringManager:TORQUEEPSILONMIN` to.
+
+    To see how to use this value, look at the description of
+    :attr:`SteeringManager:TORQUEEPSILONMAX` below, which
+    has the full documentation about how these two values, Min and Max,
+    work together.
+
+.. attribute:: SteeringManager:TORQUEEPSILONMAX
 
     :type: :ref:`scalar <scalar>`
     :access: Get/Set
 
     DEFAULT VALUE: 0.01
-
-    Tweaking this value can help make the controls stop wiggling so fast.
-
-    You cannot set this value higher than
-    :attr:`SteeringManager:ROTATIONEPSILONMAX`.
-    If you attempt to do so, then
-    :attr:`SteeringManager:ROTATIONEPSILONMAX` will be increased to match
-    the value just set :attr:`SteeringManager:ROTATIONEPSILONMIN` to.
-
-    To see how to use this value, look at the description of
-    :attr:`SteeringManager:ROTATIONEPSILONMAX` below, which
-    has the full documentation about how these two values, Min and Max,
-    work together.
-
-.. attribute:: SteeringManager:ROTATIONEPSILONMAX
-
-    :type: :ref:`scalar <scalar>`
-    :access: Get/Set
-
-    DEFAULT VALUE: 0.5
 
     Tweaking this value can help make the controls stop wiggling so fast.
     If you have problems wasting too much RCS propellant because kOS
@@ -198,29 +198,34 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
     setting thie value a bit higher can help.
 
     You cannot set this value lower than
-    :attr:`SteeringManager:ROTATIONEPSILONMIN`.
+    :attr:`SteeringManager:TORQUEEPSILONMIN`.
     If you attempt to do so, then
-    :attr:`SteeringManager:ROTATIONEPSILONMIN` will be decreased to match
-    the value just set :attr:`SteeringManager:ROTATIONEPSILONMAX` to.
+    :attr:`SteeringManager:TORQUEEPSILONMIN` will be decreased to match
+    the value just set :attr:`SteeringManager:TORQUEEPSILONMAX` to.
 
     **HOW IT WORKS:**
     
     If the error in the desired rotation rate is smaller than the current epsilon,
-    then the :ref:`PID that calculates a desired angular velocity <cooked_omega_pid>`
-    will ignore that error and not bother correcting it until it gets bigger.
-    The actual epsilon value used in the steering manager's internal PID controller 
-    is always something between 
-    :attr:`SteeringManager:ROTATIONEPSILONMIN`.
+    then the PID that calculates desired torque will ignore that error and not
+    bother correcting it until it gets bigger.  The actual epsilon value used
+    in the steering manager's internal PID controller is always something between 
+    :attr:`SteeringManager:TORQUEEPSILONMIN`.
     and
-    :attr:`SteeringManager:ROTATIONEPSILONMAX`.
-    It varies between these two values depending on how far the off the target
-    direction is from the current direction.  The closer the aim is to the right
-    direction, the smaller the epsilon gets (the more it cares about being
-    precise with the desired rotation rate).  The epsilon varies between
-    :attr:`SteeringManager:ROTATIONEPSILONMIN` (used when aimed the right way
-    already) and :attr:`SteeringManager:ROTATIONEPSILONMAX` (used when aimed
-    180 degrees away from the right way.)  If the angle error is 90 degrees,
-    the epsilon will be halfway between the min and max values, and so on.
+    :attr:`SteeringManager:TORQUEEPSILONMAX`.
+    It varies between these two values depending on whether the
+    vessel is currently rotating at near the maximum rotation rate
+    the SteeringManager allows (as determined by
+    :attr:`SteeringManager:MAXSTOPPINGTIME`) or whether it's quite far
+    from its maximum rotation rate.
+    :attr:`SteeringManager:TORQUEEPSILONMAX` is used when the vessel is
+    at it's maximum rotation rate (i.e. it's coasting around to a new
+    orientation and shouldn't pointlessly spend RCS fuel trying to hold
+    that angular velocity precisely).
+    :attr:`SteeringManager:TORQUEEPSILONMIN` is used when the vessel is
+    not trying to rotate at all and is supposed to be using the steering
+    just to hold the aim at a standstill.  In between these two states,
+    it uses a value partway between the two, linearly interpolated between
+    them.
 
     If you desire a constant epsilon, set both the min and max values to the
     same value.

--- a/src/kOS.Safe/Encapsulation/PIDLoop.cs
+++ b/src/kOS.Safe/Encapsulation/PIDLoop.cs
@@ -188,8 +188,12 @@ namespace kOS.Safe.Encapsulation
             double error = Setpoint - input;
             if (error > -Epsilon && error < Epsilon)
             {
+                // Pretend there is no error (get everything to zero out)
+                // because the error is within the epsilon:
                 error = 0;
-                input = Setpoint; // some calculations below use input directly instead of error, so we need this too to fake them out.
+                input = Setpoint;
+                Input = input;
+                Error = error;
             }
             double pTerm = error * Kp;
             double iTerm = 0;

--- a/src/kOS/Control/SteeringManager.cs
+++ b/src/kOS/Control/SteeringManager.cs
@@ -723,6 +723,22 @@ namespace kOS.Control
                     neg = -1 * sum;
                 }
             }
+            else if (tp is ModuleReactionWheel)
+            {
+                // Although ModuleReactionWheel *mostly* works, the stock version ignores
+                // the authority limiter slider.  It would have been possible to just take
+                // the result it gives and multiply it by the slider, but that relies on
+                // stock KSP never fixing it themselves and thus kOS would end up double-
+                // applying that multiplitation.  To avoid that, it seems better to just
+                // make the entire thing homemade from scratch for now so if KSP ever fixes it
+                // on their end that doesn't break it on kOS's end:
+                tp.GetPotentialTorque(out pos, out neg);
+
+                ModuleReactionWheel wheel = tp as ModuleReactionWheel;
+                float nerf = wheel.authorityLimiter / 100f;
+                pos = new Vector3( nerf * wheel.PitchTorque, nerf * wheel.RollTorque, nerf * wheel.YawTorque);
+                neg = -1 * pos;
+            }
             else
             {
                 tp.GetPotentialTorque(out pos, out neg);

--- a/src/kOS/Control/SteeringManager.cs
+++ b/src/kOS/Control/SteeringManager.cs
@@ -691,7 +691,7 @@ namespace kOS.Control
                 // bug list forever (probably won't get fixed).
                 ModuleRCS rcs = tp as ModuleRCS;
                 Part p = rcs.part;
-                if (p.ShieldedFromAirstream || !rcs.rcsEnabled || !rcs.isEnabled || rcs.isJustForShow)
+                if (p.ShieldedFromAirstream || !rcs.rcsEnabled || !rcs.isEnabled || rcs.isJustForShow || rcs.flameout)
                 {
                     // RCS module shouldn't work in this case - so report zero:
                     pos = new Vector3(0f, 0f, 0f);

--- a/src/kOS/Control/SteeringManager.cs
+++ b/src/kOS/Control/SteeringManager.cs
@@ -706,8 +706,9 @@ namespace kOS.Control
                     Vector3 rotateEnables = new Vector3(rcs.enablePitch ? 1 : 0, rcs.enableRoll ? 1 : 0, rcs.enableYaw ? 1 : 0);
                     Vector3 translateEnables = new Vector3(rcs.enableX ? 1 : 0, rcs.enableZ ? 1 : 0, rcs.enableY ? 1 : 0);
 
-                    Vector3 sum = new Vector3(0f, 0f, 0f);
-                    for (int i = rcs.thrusterTransforms.Count-1; i >- 0; --i)
+                    pos = new Vector3(0f, 0f, 0f);
+                    neg = new Vector3(0f, 0f, 0f);
+                    for (int i = rcs.thrusterTransforms.Count-1; i >= 0; --i)
                     {
                         Transform rcsTransform = rcs.thrusterTransforms[i];
                         Vector3 rcsPosFromCoM = rcsTransform.position - Vessel.CurrentCoM;
@@ -717,10 +718,10 @@ namespace kOS.Control
                         // but kOS doesn't obey that.
                         Vector3 thrust = powerFactor * rcsThrustDir;
                         Vector3 torque = Vector3d.Cross(rcsPosFromCoM, thrust);
-                        sum += Vector3.Scale(Vessel.ReferenceTransform.InverseTransformDirection(torque), rotateEnables);
+                        Vector3 transformedTorque = Vector3.Scale(Vessel.ReferenceTransform.InverseTransformDirection(torque), rotateEnables);
+                        pos += Vector3.Max(transformedTorque, Vector3.zero);
+                        neg += Vector3.Min(transformedTorque, Vector3.zero);
                     }
-                    pos = sum;
-                    neg = -1 * sum;
                 }
             }
             else if (tp is ModuleReactionWheel)

--- a/src/kOS/Control/SteeringManager.cs
+++ b/src/kOS/Control/SteeringManager.cs
@@ -325,8 +325,8 @@ namespace kOS.Control
             MaxStoppingTime = 2;
             RollControlAngleRange = 5;
 
-            torquePIDEpsilonMin = 0.002d;
-            torquePIDEpsilonMax = 0.01d;
+            torquePIDEpsilonMin = 0.0002d;
+            torquePIDEpsilonMax = 0.001d;
 
             PitchTorqueAdjust = 0;
             YawTorqueAdjust = 0;

--- a/src/kOS/Control/SteeringManager.cs
+++ b/src/kOS/Control/SteeringManager.cs
@@ -691,9 +691,15 @@ namespace kOS.Control
                 // bug list forever (probably won't get fixed).
                 ModuleRCS rcs = tp as ModuleRCS;
                 Part p = rcs.part;
-                if (p.ShieldedFromAirstream || !rcs.rcsEnabled || !rcs.isEnabled || rcs.isJustForShow || rcs.flameout)
+
+                // This is the list of various reasons this RCS module might 
+                // be suppressed right now.  It would be nice if all this
+                // stuff flipped one common flag during Update for all the
+                // rest of the code to check, but sadly that doesn't seem to
+                // be the case and you have to check these things individually:
+                if (p.ShieldedFromAirstream || !rcs.rcsEnabled || !rcs.isEnabled ||
+                    rcs.isJustForShow || rcs.flameout || !rcs.rcs_active)
                 {
-                    // RCS module shouldn't work in this case - so report zero:
                     pos = new Vector3(0f, 0f, 0f);
                     neg = new Vector3(0f, 0f, 0f);
                 }

--- a/src/kOS/Control/SteeringManager.cs
+++ b/src/kOS/Control/SteeringManager.cs
@@ -733,12 +733,19 @@ namespace kOS.Control
                 // applying that multiplitation.  To avoid that, it seems better to just
                 // make the entire thing homemade from scratch for now so if KSP ever fixes it
                 // on their end that doesn't break it on kOS's end:
-                tp.GetPotentialTorque(out pos, out neg);
-
                 ModuleReactionWheel wheel = tp as ModuleReactionWheel;
-                float nerf = wheel.authorityLimiter / 100f;
-                pos = new Vector3( nerf * wheel.PitchTorque, nerf * wheel.RollTorque, nerf * wheel.YawTorque);
-                neg = -1 * pos;
+
+                if (!wheel.moduleIsEnabled || wheel.wheelState != ModuleReactionWheel.WheelState.Active || wheel.actuatorModeCycle == 2)
+                {
+                    pos = new Vector3(0f, 0f, 0f);
+                    neg = new Vector3(0f, 0f, 0f);
+                }
+                else
+                {
+                    float nerf = wheel.authorityLimiter / 100f;
+                    pos = new Vector3(nerf * wheel.PitchTorque, nerf * wheel.RollTorque, nerf * wheel.YawTorque);
+                    neg = -1 * pos;
+                }
             }
             else
             {


### PR DESCRIPTION
Fixes #2814 - had to make our own homemade replacement for GetPotentialTorque() in the case of RCS parts because the stock one is so very broken.

This starts from work other KSP modders did who also realized the stock ModuleRCS.GetPotentialTorque() is so wrong as to be impossible to just 'patch up', and wrote their own.