### PR TITLE
Fixes #2817 with sub-branch searches.

### DIFF
--- a/doc/source/structures/vessels/part.rst
+++ b/doc/source/structures/vessels/part.rst
@@ -114,6 +114,36 @@ These are the generic properties every PART has. You can obtain a list of values
         * - :meth:`SYMMETRYPARTNER(index)`
           - :struct:`part`
           - Return one of the other parts symmetrical to this one.
+        * - :meth:`PARTSNAMED(name)`
+          - :struct:`List` (of :struct:`Part`)
+          - Search the branch from here down based on name.
+        * - :meth:`PARTSNAMEDPATTERN(pattern)`
+          - :struct:`List` (of :struct:`Part`)
+          - Regex search the branch from here down based on name.
+        * - :meth:`PARTSTITLED(name)`
+          - :struct:`List` (of :struct:`Part`)
+          - Search the branch from here down for parts titled this.
+        * - :meth:`PARTSTITLEDPATTERN(pattern)`
+          - :struct:`List` (of :struct:`Part`)
+          - Regex Search the branch from here down for parts titled this.
+        * - :meth:`PARTSTAGGED(tag)`
+          - :struct:`List` (of :struct:`Part`)
+          - Search the branch from here down for parts tagged this.
+        * - :meth:`PARTSTAGGEDPATTERN(pattern)`
+          - :struct:`List` (of :struct:`Part`)
+          - Regex Search the branch from here down for parts tagged this.
+        * - :meth:`PARTSDUBBED(name)`
+          - :struct:`List` (of :struct:`Part`)
+          - Search the branch from here down for parts named, titled, or tagged this.
+        * - :meth:`PARTSDUBBEDPATTERN(name)`
+          - :struct:`List` (of :struct:`Part`)
+          - Regex Search the branch from here down for parts named, titled, or tagged this.
+        * - :meth:`MODULESNAMED(name)`
+          - :struct:`List` (of :struct:`PartModule`)
+          - Search the branch from here down for modules named, titled, or tagged this.
+        * - :meth:`ALLTAGGEDPARTS`
+          - :struct:`List` (of :struct:`Part`)
+          - Search the branch from here down for all parts with a non-blank tag name.
 
 
 .. attribute:: Part:NAME
@@ -479,4 +509,102 @@ These are the generic properties every PART has. You can obtain a list of values
             print "      [" + i + "] " + a_part:SYMMETRYPARTNER(i).
           }
         }
+
+.. method:: Parts:PARTSNAMED(name)
+
+    :parameter name: (:ref:`string <string>`) Name of the parts
+    :return: :struct:`List` of :struct:`Part` objects
+
+    Same as :meth:`Vessel:PARTSNAMED(name)` except that this version
+    doesn't search the entire vessel tree and instead it only searches the
+    branch of the vessel's part tree from the current part down through
+    its children and its children's children and so on.
+
+.. method:: Part:PARTSNAMEDPATTERN(namePattern)
+
+    :parameter namePattern: (:ref:`string <string>`) Pattern of the name of the parts
+    :return: :struct:`List` of :struct:`Part` objects
+
+    Same as :meth:`Vessel:PARTSNAMEDPATTERN(namePattern)` except that this version
+    doesn't search the entire vessel tree and instead it only searches the
+    branch of the vessel's part tree from the current part down through
+    its children and its children's children and so on.
+
+.. method:: Part:PARTSTITLED(title)
+
+    :parameter title: (:ref:`string <string>`) Title of the parts
+    :return: :struct:`List` of :struct:`Part` objects
+
+    Same as :meth:`Vessel:PARTSTITLED(title)` except that this version
+    doesn't search the entire vessel tree and instead it only searches the
+    branch of the vessel's part tree from the current part down through
+    its children and its children's children and so on.
+
+.. method:: Part:PARTSTITLEDPATTERN(titlePattern)
+
+    :parameter titlePattern: (:ref:`string <string>`) Patern of the title of the parts
+    :return: :struct:`List` of :struct:`Part` objects
+
+    Same as :meth:`Vessel:PARTSTITLEDPATTERN(titlePattern)` except that this version
+    doesn't search the entire vessel tree and instead it only searches the
+    branch of the vessel's part tree from the current part down through
+    its children and its children's children and so on.
+
+.. method:: Part:PARTSTAGGED(tag)
+
+    :parameter tag: (:ref:`string <string>`) Tag of the parts
+    :return: :struct:`List` of :struct:`Part` objects
+
+    Same as :meth:`Vessel:PARTSTAGGED(tag)` except that this version
+    doesn't search the entire vessel tree and instead it only searches the
+    branch of the vessel's part tree from the current part down through
+    its children and its children's children and so on.
+
+.. method:: Part:PARTSTAGGEDPATTERN(tagPattern)
+
+    :parameter tagPattern: (:ref:`string <string>`) Pattern of the tag of the parts
+    :return: :struct:`List` of :struct:`Part` objects
+
+    Same as :meth:`Vessel:PARTSTAGGEDPATTERN(tagPattern)` except that this version
+    doesn't search the entire vessel tree and instead it only searches the
+    branch of the vessel's part tree from the current part down through
+    its children and its children's children and so on.
+
+.. method:: Part:PARTSDUBBED(name)
+
+    :parameter name: (:ref:`string <string>`) name, title or tag of the parts
+    :return: :struct:`List` of :struct:`Part` objects
+
+    Same as :meth:`Vessel:PARTSDUBBED(name)` except that this version
+    doesn't search the entire vessel tree and instead it only searches the
+    branch of the vessel's part tree from the current part down through
+    its children and its children's children and so on.
+
+.. method:: Part:PARTSDUBBEDPATTERN(namePattern)
+
+    :parameter namePattern: (:ref:`string <string>`) Pattern of the name, title or tag of the parts
+    :return: :struct:`List` of :struct:`Part` objects
+
+    Same as :meth:`Vessel:PARTSDUBBEDPATERN(namePattern)` except that this version
+    doesn't search the entire vessel tree and instead it only searches the
+    branch of the vessel's part tree from the current part down through
+    its children and its children's children and so on.
+
+.. method:: Part:MODULESNAMED(name)
+
+    :parameter name: (:ref:`string <string>`) Name of the part modules
+    :return: :struct:`List` of :struct:`PartModule` objects
+
+    Same as :meth:`Vessel:MODULESNAMED(name)` except that this version
+    doesn't search the entire vessel tree and instead it only searches the
+    branch of the vessel's part tree from the current part down through
+    its children and its children's children and so on.
+
+.. method:: Part:ALLTAGGEDPARTS()
+
+    :return: :struct:`List` of :struct:`Part` objects
+    Same as :meth:`Vessel:ALLTAGGEDPARTS()` except that this version
+    doesn't search the entire vessel tree and instead it only searches the
+    branch of the vessel's part tree from the current part down through
+    its children and its children's children and so on.
 

--- a/doc/source/structures/vessels/vessel.rst
+++ b/doc/source/structures/vessels/vessel.rst
@@ -516,48 +516,55 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
     :parameter name: (:ref:`string <string>`) Name of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
-    Part:NAME. The matching is done case-insensitively. For more information, see :ref:`ship parts and modules <parts and partmodules>`.
+    Returns a list of all the parts that have this as their
+    ``Part:NAME``. The matching is done case-insensitively. For more information, see :ref:`ship parts and modules <parts and partmodules>`.
 
 .. method:: Vessel:PARTSNAMEDPATTERN(namePattern)
 
     :parameter namePattern: (:ref:`string <string>`) Pattern of the name of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
-    Part:NAME. The matching is done identically as in :meth:`String:MATCHESPATTERN`\ . For more information, see :ref:`ship parts and modules <parts and partmodules>`.
+    Returns a list of all the parts that have this Regex pattern in their
+    ``Part:NAME``. The matching is done identically as in :meth:`String:MATCHESPATTERN`\ . For more information, see :ref:`ship parts and modules <parts and partmodules>`.
 
 .. method:: Vessel:PARTSTITLED(title)
 
     :parameter title: (:ref:`string <string>`) Title of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
-    Part:TITLE. The matching is done case-insensitively. For more information, see :ref:`ship parts and modules <parts and partmodules>`.
+    Returns a list of all the parts that have this as their
+    ``Part:TITLE``. The matching is done case-insensitively. For more information, see :ref:`ship parts and modules <parts and partmodules>`.
 
 .. method:: Vessel:PARTSTITLEDPATTERN(titlePattern)
 
     :parameter titlePattern: (:ref:`string <string>`) Patern of the title of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
-    Part:TITLE. The matching is done identically as in :meth:`String:MATCHESPATTERN`\ . For more information, see :ref:`ship parts and modules <parts and partmodules>`.
+    Returns a list of all the parts that have this Regex pattern in their
+    ``Part:TITLE``. The matching is done identically as in :meth:`String:MATCHESPATTERN`\ . For more information, see :ref:`ship parts and modules <parts and partmodules>`.
 
 .. method:: Vessel:PARTSTAGGED(tag)
 
     :parameter tag: (:ref:`string <string>`) Tag of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
-    Part:TAG value. The matching is done case-insensitively. For more information, see :ref:`ship parts and modules <parts and partmodules>`.
+    Returns a list of all the parts that have this name as their
+    ``Part:TAG`` value. The matching is done case-insensitively. For more information, see :ref:`ship parts and modules <parts and partmodules>`.
 
 .. method:: Vessel:PARTSTAGGEDPATTERN(tagPattern)
 
     :parameter tagPattern: (:ref:`string <string>`) Pattern of the tag of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
-    Part:TAG value. The matching is done identically as in :meth:`String:MATCHESPATTERN`\ . For more information, see :ref:`ship parts and modules <parts and partmodules>`.
+    Returns a list of all the parts that match this Regex pattern in their
+    ``part:TAG`` value. The matching is done identically as in :meth:`String:MATCHESPATTERN`\ . For more information, see :ref:`ship parts and modules <parts and partmodules>`.
 
 .. method:: Vessel:PARTSDUBBED(name)
 
     :parameter name: (:ref:`string <string>`) name, title or tag of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
+    Return a list of all the parts that match this
     name regardless of whether that name is the Part:Name, the Part:Tag, or the Part:Title. It is effectively the distinct union of :PARTSNAMED(val), :PARTSTITLED(val), :PARTSTAGGED(val). The matching is done case-insensitively. For more information, see :ref:`ship parts and modules <parts and partmodules>`.
 
 .. method:: Vessel:PARTSDUBBEDPATTERN(namePattern)
@@ -565,13 +572,15 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
     :parameter namePattern: (:ref:`string <string>`) Pattern of the name, title or tag of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
-    name regardless of whether that name is the Part:Name, the Part:Tag, or the Part:Title. It is effectively the distinct union of :PARTSNAMEDPATTERN(val), :PARTSTITLEDPATTERN(val), :PARTSTAGGEDPATTERN(val). The matching is done identically as in :meth:`String:MATCHESPATTERN`\ . For more information, see :ref:`ship parts and modules <parts and partmodules>`.
+    Return a list of parts that match this Regex pattern
+    regardless of whether that name is the Part:Name, the Part:Tag, or the Part:Title. It is effectively the distinct union of :PARTSNAMEDPATTERN(val), :PARTSTITLEDPATTERN(val), :PARTSTAGGEDPATTERN(val). The matching is done identically as in :meth:`String:MATCHESPATTERN`\ . For more information, see :ref:`ship parts and modules <parts and partmodules>`.
 
 .. method:: Vessel:MODULESNAMED(name)
 
     :parameter name: (:ref:`string <string>`) Name of the part modules
     :return: :struct:`List` of :struct:`PartModule` objects
 
+    Return a list of all the :struct:`PartModule` objects that
     match the given name. The matching is done case-insensitively. For more information, see :ref:`ship parts and modules <parts and partmodules>`.
 
 .. method:: Vessel:PARTSINGROUP(group)
@@ -592,7 +601,8 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
     :return: :struct:`List` of :struct:`Part` objects
 
-    nametag on them of any sort that is nonblank. For more information, see :ref:`ship parts and modules <parts and partmodules>`.
+    Return all parts who's nametag isn't blank.
+    For more information, see :ref:`ship parts and modules <parts and partmodules>`.
 
 .. attribute:: Vessel:CREWCAPACITY
 

--- a/src/kOS.Safe.Test/kOS.Safe.Test.csproj
+++ b/src/kOS.Safe.Test/kOS.Safe.Test.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>kOS.Safe.Test</RootNamespace>
     <AssemblyName>kOS.Safe.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,6 +29,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>kOS.Safe</RootNamespace>
     <AssemblyName>kOS.Safe</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Shell|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -40,6 +42,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ICSharpCode.SharpZipLib">

--- a/src/kOS/Suffixed/Part/PartValue.cs
+++ b/src/kOS/Suffixed/Part/PartValue.cs
@@ -5,6 +5,7 @@ using kOS.Safe.Exceptions;
 using kOS.Suffixed.PartModuleField;
 using kOS.Utilities;
 using System;
+using System.Text.RegularExpressions;
 using System.Linq;
 using System.Collections.Generic;
 using kOS.Safe.Compilation.KS;
@@ -71,6 +72,17 @@ namespace kOS.Suffixed.Part
             AddSuffix("SYMMETRYTYPE", new Suffix<ScalarIntValue>(() => (int)Part.symMethod));
             AddSuffix("REMOVESYMMETRY", new NoArgsVoidSuffix(Part.RemoveFromSymmetry));
             AddSuffix("SYMMETRYPARTNER", new OneArgsSuffix<PartValue, ScalarValue>(GetSymmetryPartner));
+
+            AddSuffix("PARTSNAMED", new OneArgsSuffix<ListValue, StringValue>(GetPartsNamed));
+            AddSuffix("PARTSNAMEDPATTERN", new OneArgsSuffix<ListValue, StringValue>(GetPartsNamedPattern));
+            AddSuffix("PARTSTITLED", new OneArgsSuffix<ListValue, StringValue>(GetPartsTitled));
+            AddSuffix("PARTSTITLEDPATTERN", new OneArgsSuffix<ListValue, StringValue>(GetPartsTitledPattern));
+            AddSuffix("PARTSDUBBED", new OneArgsSuffix<ListValue, StringValue>(GetPartsDubbed));
+            AddSuffix("PARTSDUBBEDPATTERN", new OneArgsSuffix<ListValue, StringValue>(GetPartsDubbedPattern));
+            AddSuffix("MODULESNAMED", new OneArgsSuffix<ListValue, StringValue>(GetModulesNamed));
+            AddSuffix("PARTSTAGGED", new OneArgsSuffix<ListValue, StringValue>(GetPartsTagged));
+            AddSuffix("PARTSTAGGEDPATTERN", new OneArgsSuffix<ListValue, StringValue>(GetPartsTaggedPattern));
+            AddSuffix("ALLTAGGEDPARTS", new NoArgsSuffix<ListValue>(GetAllTaggedParts));
         }
 
         public BoundsValue GetBoundsValue()
@@ -242,6 +254,146 @@ namespace kOS.Suffixed.Part
                 returnValue.Add(new StringValue(mod.moduleName));
             }
             return returnValue;
+        }
+
+        /// <summary>
+        /// Return all the parts matching the condition given, in the parts
+        /// tree starting from this part downward (this branch of the vessel parts tree)
+        /// Note that this uses recursion to scan the children of the part and so on.
+        /// </summary>
+        /// <param name="p">The part to search from (root of the branch being searched)</param>
+        /// <param name="condition">The predicate comparison to check for</param>
+        /// <param name="listToFill">An empty list that this will fill with the result</param>
+        private static void StaticFindPartsInBranch(global::Part p, Predicate<global::Part> condition, List<global::Part> listToFill)
+        {
+            List<global::Part> childs = p.children;
+            int len = childs.Count();
+            for (int i = 0; i < len; ++i)
+            {
+                StaticFindPartsInBranch(childs[i], condition, listToFill);
+            }
+            if (condition(p))
+            {
+                listToFill.Add(p);
+            }
+        }
+        public List<global::Part> DynamicFindPartsInBranch(Predicate<global::Part> condition)
+        {
+            List<global::Part> hits = new List<global::Part>();
+            StaticFindPartsInBranch(this.Part, condition, hits);
+            return hits;
+        }
+        public ListValue GetPartsNamed(StringValue partName)
+        {
+            return PartValueFactory.Construct(
+            DynamicFindPartsInBranch(p => String.Equals(p.name, partName, StringComparison.CurrentCultureIgnoreCase)), Shared);
+        }
+        public ListValue GetPartsNamedPattern(StringValue partNamePattern)
+        {
+            // Prepare case-insensivie regex.
+            Regex r = new Regex(partNamePattern, RegexOptions.IgnoreCase);
+            return PartValueFactory.Construct(DynamicFindPartsInBranch(p => r.IsMatch(p.name)), Shared);
+        }
+        public ListValue GetPartsTitled(StringValue partTitle)
+        {
+            // Get the list of all the parts where the part's GUI title matches:
+            return PartValueFactory.Construct(
+                DynamicFindPartsInBranch(p => String.Equals(p.partInfo.title, partTitle, StringComparison.CurrentCultureIgnoreCase)),
+                Shared);
+        }
+        public ListValue GetPartsTitledPattern(StringValue partTitlePattern)
+        {
+            // Prepare case-insensivie regex.
+            Regex r = new Regex(partTitlePattern, RegexOptions.IgnoreCase);
+            return PartValueFactory.Construct(DynamicFindPartsInBranch(p => r.IsMatch(p.partInfo.title)), Shared);
+        }
+        public ListValue GetPartsTagged(StringValue tagName)
+        {
+            return PartValueFactory.Construct(
+                DynamicFindPartsInBranch(
+                    p => p.Modules.OfType<KOSNameTag>().Any(
+                        tag => String.Equals(tag.nameTag, tagName, StringComparison.CurrentCultureIgnoreCase))),
+                    Shared);
+        }
+        public ListValue GetPartsTaggedPattern(StringValue tagPattern)
+        {
+            Regex r = new Regex(tagPattern, RegexOptions.IgnoreCase);
+            return PartValueFactory.Construct(
+                DynamicFindPartsInBranch(
+                    p => p.Modules.OfType<KOSNameTag>().Any(
+                        tag => r.IsMatch(tag.nameTag))),
+                    Shared);
+        }
+        public ListValue GetPartsDubbed(StringValue searchTerm)
+        {
+            // Get the list of all the parts where the part's API name OR its GUI title or its tag name matches.
+            List<global::Part> kspParts = new List<global::Part>();
+            StaticFindPartsInBranch(this.Part,
+                p => String.Equals(p.name, searchTerm, StringComparison.CurrentCultureIgnoreCase), kspParts);
+            StaticFindPartsInBranch(this.Part,
+                p => String.Equals(p.partInfo.title, searchTerm, StringComparison.CurrentCultureIgnoreCase), kspParts);
+            StaticFindPartsInBranch(this.Part,
+                p => p.Modules.OfType<KOSNameTag>().Any(tag => String.Equals(tag.nameTag, searchTerm, StringComparison.CurrentCultureIgnoreCase)),
+                kspParts);
+
+            // The "Distinct" operation is there because it's possible for someone to use a tag name that matches the part name.
+            return PartValueFactory.Construct(kspParts.Distinct(), Shared);
+        }
+        public ListValue GetPartsDubbedPattern(StringValue searchPattern)
+        {
+            // Prepare case-insensivie regex.
+            Regex r = new Regex(searchPattern, RegexOptions.IgnoreCase);
+            // Get the list of all the parts where the part's API name OR its GUI title or its tag name matches the pattern.
+            List<global::Part> kspParts = new List<global::Part>();
+            StaticFindPartsInBranch(this.Part, p => r.IsMatch(p.name), kspParts);
+            StaticFindPartsInBranch(this.Part, p => r.IsMatch(p.partInfo.title), kspParts);
+            StaticFindPartsInBranch(this.Part, p => p.Modules.OfType<KOSNameTag>().Any(tag => r.IsMatch(tag.nameTag)), kspParts);
+
+            // The "Distinct" operation is there because it's possible for someone to use a tag name that matches the part name.
+            return PartValueFactory.Construct(kspParts.Distinct(), Shared);
+        }
+        /// <summary>
+        /// Get all the parts which have at least SOME non-default name:
+        /// </summary>
+        /// <returns></returns>
+        public ListValue GetAllTaggedParts()
+        {
+            return PartValueFactory.Construct(DynamicFindPartsInBranch(p => p.Modules.OfType<KOSNameTag>()
+                .Any(tag => !String.Equals(tag.nameTag, "", StringComparison.CurrentCultureIgnoreCase))), Shared);
+        }
+
+        /// <summary>
+        /// Return all the PartModules matching the condition given, in the parts
+        /// tree starting from this part downward (this branch of the vessel parts tree)
+        /// Note that this uses recursion to scan the children of the part and so on.
+        /// </summary>
+        /// <param name="p">The part to search from (root of the branch being searched)</param>
+        /// <param name="condition">The predicate comparison to check a PartModulefor</param>
+        /// <param name="listToFill">An empty list that this will fill with the result</param>
+        private static void StaticFindModulesInBranch(global::Part p, Predicate<global::PartModule> condition, List<global::PartModule> listToFill)
+        {
+            List<global::Part> childs = p.children;
+            int len = childs.Count();
+            for (int i = 0; i < len; ++i)
+            {
+                StaticFindModulesInBranch(childs[i], condition, listToFill);
+            }
+            // Can't use Linq query terms because PartModuleList doesn't seem to implement it as far
+            // as I can tell, so have to walk it manually:
+            int modCount = p.Modules.Count;
+            for (int modIndex = 0; modIndex < modCount; ++modIndex)
+            {
+                if (condition(p.Modules[modIndex]))
+                {
+                    listToFill.Add(p.Modules[modIndex]);
+                }
+            }
+        }
+        public ListValue GetModulesNamed(StringValue modName)
+        {
+            List<PartModule> result = new List<PartModule>();
+            StaticFindModulesInBranch(this.Part, m => String.Equals(m.moduleName, modName, StringComparison.CurrentCultureIgnoreCase), result);
+            return PartModuleFieldsFactory.Construct(result, Shared);
         }
 
         protected bool Equals(PartValue other)

--- a/src/kOS/Suffixed/VesselTarget.Parts.cs
+++ b/src/kOS/Suffixed/VesselTarget.Parts.cs
@@ -195,106 +195,42 @@ namespace kOS.Suffixed
 
         private ListValue GetPartsDubbed(StringValue searchTerm)
         {
-            // Get the list of all the parts where the part's API name OR its GUI title or its tag name matches.
-            List<global::Part> kspParts = new List<global::Part>();
-            kspParts.AddRange(GetRawPartsNamed(searchTerm));
-            kspParts.AddRange(GetRawPartsTitled(searchTerm));
-            kspParts.AddRange(GetRawPartsTagged(searchTerm));
-
-            // The "Distinct" operation is there because it's possible for someone to use a tag name that matches the part name.
-            return PartValueFactory.Construct(kspParts.Distinct(), Shared);
+            return PartValueFactory.Construct(Vessel.rootPart, Shared).GetPartsDubbed(searchTerm);
         }
 
         private ListValue GetPartsDubbedPattern(StringValue searchPattern)
         {
-            // Prepare case-insensivie regex.
-            Regex r = new Regex(searchPattern, RegexOptions.IgnoreCase);
-            // Get the list of all the parts where the part's API name OR its GUI title or its tag name matches the pattern.
-            List<global::Part> kspParts = new List<global::Part>();
-            kspParts.AddRange(GetRawPartsNamedPattern(r));
-            kspParts.AddRange(GetRawPartsTitledPattern(r));
-            kspParts.AddRange(GetRawPartsTaggedPattern(r));
-
-            // The "Distinct" operation is there because it's possible for someone to use a tag name that matches the part name.
-            return PartValueFactory.Construct(kspParts.Distinct(), Shared);
+            return PartValueFactory.Construct(Vessel.rootPart, Shared).GetPartsDubbedPattern(searchPattern);
         }
 
         private ListValue GetPartsNamed(StringValue partName)
         {
-            return PartValueFactory.Construct(GetRawPartsNamed(partName), Shared);
-        }
-
-        private IEnumerable<global::Part> GetRawPartsNamed(string partName)
-        {
-            // Get the list of all the parts where the part's KSP API title matches:
-            return Vessel.parts.FindAll(
-                part => String.Equals(part.name, partName, StringComparison.CurrentCultureIgnoreCase));
+            return PartValueFactory.Construct(Vessel.rootPart, Shared).GetPartsNamed(partName);
         }
 
         private ListValue GetPartsNamedPattern(StringValue partNamePattern)
         {
-            // Prepare case-insensivie regex.
-            Regex r = new Regex(partNamePattern, RegexOptions.IgnoreCase);
-            return PartValueFactory.Construct(GetRawPartsNamedPattern(r), Shared);
-        }
-
-        private IEnumerable<global::Part> GetRawPartsNamedPattern(Regex partNamePattern)
-        {
-            // Get the list of all the parts where the part's KSP API title matches the pattern:
-            return Vessel.parts.FindAll(
-                part => partNamePattern.IsMatch(part.name));
+            return PartValueFactory.Construct(Vessel.rootPart, Shared).GetPartsNamedPattern(partNamePattern);
         }
 
         private ListValue GetPartsTitled(StringValue partTitle)
         {
-            return PartValueFactory.Construct(GetRawPartsTitled(partTitle), Shared);
-        }
-
-        private IEnumerable<global::Part> GetRawPartsTitled(string partTitle)
-        {
-            // Get the list of all the parts where the part's GUI title matches:
-            return Vessel.parts.FindAll(
-                part => String.Equals(part.partInfo.title, partTitle, StringComparison.CurrentCultureIgnoreCase));
+            return PartValueFactory.Construct(Vessel.rootPart, Shared).GetPartsTitled(partTitle);
         }
 
         private ListValue GetPartsTitledPattern(StringValue partTitlePattern)
         {
-            // Prepare case-insensivie regex.
-            Regex r = new Regex(partTitlePattern, RegexOptions.IgnoreCase);
-            return PartValueFactory.Construct(GetRawPartsTitledPattern(r), Shared);
-        }
-
-        private IEnumerable<global::Part> GetRawPartsTitledPattern(Regex partTitlePattern)
-        {
-            // Get the list of all the parts where the part's GUI title matches the pattern:
-            return Vessel.parts.FindAll(
-                part => partTitlePattern.IsMatch(part.partInfo.title));
+            return PartValueFactory.Construct(Vessel.rootPart, Shared).GetPartsTitledPattern(partTitlePattern);
         }
 
         private ListValue GetPartsTagged(StringValue tagName)
         {
-            return PartValueFactory.Construct(GetRawPartsTagged(tagName), Shared);
-        }
-
-        private IEnumerable<global::Part> GetRawPartsTagged(string tagName)
-        {
-            return Vessel.parts
-                .Where(p => p.Modules.OfType<KOSNameTag>()
-                .Any(tag => String.Equals(tag.nameTag, tagName, StringComparison.CurrentCultureIgnoreCase)));
+            return PartValueFactory.Construct(Vessel.rootPart, Shared).GetPartsTagged(tagName);
         }
 
         private ListValue GetPartsTaggedPattern(StringValue tagPattern)
         {
-            // Prepare case-insensivie regex.
-            Regex r = new Regex(tagPattern, RegexOptions.IgnoreCase);
-            return PartValueFactory.Construct(GetRawPartsTaggedPattern(r), Shared);
-        }
-
-        private IEnumerable<global::Part> GetRawPartsTaggedPattern(Regex tagPattern)
-        {
-            return Vessel.parts
-                .Where(p => p.Modules.OfType<KOSNameTag>()
-                .Any(tag => tagPattern.IsMatch(tag.nameTag)));
+            return PartValueFactory.Construct(Vessel.rootPart, Shared).GetPartsTaggedPattern(tagPattern);
         }
 
         /// <summary>
@@ -303,22 +239,12 @@ namespace kOS.Suffixed
         /// <returns></returns>
         private ListValue GetAllTaggedParts()
         {
-            IEnumerable<global::Part> partsWithName = Vessel.parts
-                .Where(p => p.Modules.OfType<KOSNameTag>()
-                .Any(tag => !String.Equals(tag.nameTag, "", StringComparison.CurrentCultureIgnoreCase)));
-
-            return PartValueFactory.Construct(partsWithName, Shared);
+            return PartValueFactory.Construct(Vessel.rootPart, Shared).GetAllTaggedParts();
         }
 
         private ListValue GetModulesNamed(StringValue modName)
         {
-            // This is slow - maybe there should be a faster lookup string hash, but
-            // KSP's data model seems to have not implemented it:
-            IEnumerable<PartModule> modules = Vessel.parts
-                .SelectMany(p => p.Modules.Cast<PartModule>()
-                .Where(pMod => String.Equals(pMod.moduleName, modName, StringComparison.CurrentCultureIgnoreCase)));
-
-            return PartModuleFieldsFactory.Construct(modules, Shared);
+            return PartValueFactory.Construct(Vessel.rootPart, Shared).GetModulesNamed(modName);
         }
 
         private ListValue GetPartsInGroup(StringValue groupName)

--- a/src/kOS/kOS.csproj
+++ b/src/kOS/kOS.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>kOS</RootNamespace>
     <AssemblyName>kOS</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -21,6 +21,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">


### PR DESCRIPTION
Fixes #2817 

To do this I moved the searching code into PartValue,
and then made the existing Vessel searches into just special cases
of the Part search in which the starting part is the vessel's root part.

Thus they are both served by the same code.

On an unrelated note this also includes changes to .csproj files
to bring kOS up to .Net 4.5.  This isn't part of the fix, but
my dev environment is that way now so I can compile against my own
ClickThroughBlocker DLL and it's too hard to keep pulling that part
out of my PRs so I'll just go ahead and update the main repo to that
when this merges.