### PR TITLE
Fix documentation for writejson

### DIFF
--- a/doc/source/commands/files.rst
+++ b/doc/source/commands/files.rst
@@ -395,9 +395,9 @@ Usage example::
     L:ADD("key1", "value1").
     L:ADD("key2", NESTED).
 
-    NESTED:ADD("nestedvalue").
+    NESTED:PUSH("nestedvalue").
 
-    WRITEJSON(l, "output.json").
+    WRITEJSON(L, "output.json").
 
 READJSON(PATH)
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
Queues use `:push` instead of `:add`.

The variable `L` is referenced in the example in upper
case except for one place which is now also up-cased for
consistency.

Closes #2829.