### PR TITLE
Fixes #2838 with a little button in the toolbar window.

### DIFF
--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -439,7 +439,14 @@ namespace kOS.Module
 
         public void ForcePAWRefresh()
         {
-            part?.PartActionWindow?.UpdateWindow();
+            // Thanks to https://github.com/blowfishpro for finding this API call for me:
+            UIPartActionWindow paw = UIPartActionController.Instance?.GetItem(part, false);
+
+            if (paw != null)
+            {
+                paw.ClearList();
+                paw.displayDirty = true;
+            }
         }
 
         private IEnumerable<VolumePath> BootDirectoryFiles()

--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -38,6 +38,8 @@ namespace kOS.Module
 
         public MessageQueue Messages { get; private set; }
 
+        private static bool bootListDirty;
+
         public string Tag
         {
             get
@@ -337,10 +339,16 @@ namespace kOS.Module
 
                 SafeHouse.Logger.Log(string.Format("OnStart: {0} {1}", state, ProcessorMode));
                 InitObjects();
-            } catch (Exception e)
+            }
+            catch (Exception e)
             {
                 SafeHouse.Logger.LogException(e);
             }
+        }
+
+        public static void SetBootListDirty()
+        {
+            bootListDirty = true;
         }
 
         private void InitUI()
@@ -415,6 +423,9 @@ namespace kOS.Module
             options.options = availableOptions.ToArray();
             options.display = availableDisplays.ToArray();
 
+            bootListDirty = false;
+            ForcePAWRefresh();
+
             //populate diskSpaceUI selector
             diskSpaceUI = diskSpace.ToString();
             field = Fields["diskSpaceUI"];
@@ -424,6 +435,11 @@ namespace kOS.Module
             sizeOptions[1] = (baseDiskSpace * 2).ToString();
             sizeOptions[2] = (baseDiskSpace * 4).ToString();
             options.options = sizeOptions;
+        }
+
+        public void ForcePAWRefresh()
+        {
+            part?.PartActionWindow?.UpdateWindow();
         }
 
         private IEnumerable<VolumePath> BootDirectoryFiles()
@@ -695,6 +711,10 @@ namespace kOS.Module
         {
             if (HighLogic.LoadedScene == GameScenes.EDITOR && EditorLogic.fetch != null)
             {
+                if (bootListDirty)
+                {
+                    InitUI();
+                }
                 if (diskSpace != Convert.ToInt32(diskSpaceUI))
                 {
                     diskSpace = Convert.ToInt32(diskSpaceUI);

--- a/src/kOS/Screen/KOSToolbarWindow.cs
+++ b/src/kOS/Screen/KOSToolbarWindow.cs
@@ -718,6 +718,11 @@ namespace kOS.Screen
                                 "There are either no kOS CPU's\n" +
                                 "in this universe, or there are\n " +
                                 "but they are all \"on rails\".", panelSkin.label);
+
+            if (HighLogic.LoadedSceneIsEditor)
+            {
+                DrawRereadBootButton();
+            }
             CountEndVertical();
 
             GUILayout.EndScrollView();
@@ -799,6 +804,27 @@ namespace kOS.Screen
                                              ((partTag == null) ? "" : partTag.nameTag)
                                             );
             GUILayout.Box(new GUIContent(labelText, "This is the currently highlighted part on the vessel"), partNameStyle);
+        }
+
+        private void DrawRereadBootButton()
+        {
+            CountBeginVertical();
+            GUILayout.Box(" "); // just putting a bar above the button and text.
+            CountBeginHorizontal();
+            bool clicked = GUILayout.Button("Reread\nBoot\nFolder", panelSkin.button);
+            GUILayout.Label(
+                "If you added new files to the archive\n" +
+                "boot folder after entering this\n" +
+                "Editor scene, they won't show up in the\n" +
+                "part window unless you click here.\n", panelSkin.label);
+
+            if (clicked)
+            {
+                kOSProcessor.SetBootListDirty();
+            }
+            CountEndHorizontal();
+            GUILayout.Box(" "); // just putting a bar below the button and text.
+            CountEndVertical();
         }
 
         public void BeginHoverHousekeeping()


### PR DESCRIPTION
Fixes #2838 

In the end I went with the quick and simple solution of putting the button in the toolbar window.

It still doesn't force the PAW to re-read the value if you have it open when you click the button, but if you close the PAW and re-open it, it has the new list.