### PR TITLE
Fixes #2836 turning nodeRef into a property

### DIFF
--- a/src/kOS/Suffixed/Node.cs
+++ b/src/kOS/Suffixed/Node.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
@@ -11,7 +11,7 @@ namespace kOS.Suffixed
     {
         private static readonly Dictionary<ManeuverNode, Node> nodeLookup;
 
-        private ManeuverNode nodeRef;
+        public ManeuverNode NodeRef { get; private set; }
         private Vessel vesselRef;
         private readonly SharedObjects shared;
         private double time;
@@ -36,7 +36,7 @@ namespace kOS.Suffixed
         private Node(Vessel v, ManeuverNode existingNode, SharedObjects shareObj)
             : this(shareObj)
         {
-            nodeRef = existingNode;
+            NodeRef = existingNode;
             vesselRef = v;
 
             nodeLookup.Add(existingNode, this);
@@ -106,8 +106,8 @@ namespace kOS.Suffixed
 
             AddSuffix(new[] {"OBT", "ORBIT"}, new Suffix<OrbitInfo>(() =>
             {
-                if (nodeRef == null) throw new Exception("Node must be added to flight plan first");
-                return new OrbitInfo(nodeRef.nextPatch, shared);
+                if (NodeRef == null) throw new Exception("Node must be added to flight plan first");
+                return new OrbitInfo(NodeRef.nextPatch, shared);
             }));
 
         }
@@ -119,7 +119,7 @@ namespace kOS.Suffixed
 
         public void AddToVessel(Vessel v)
         {
-            if (nodeRef != null) throw new Exception("Node has already been added");
+            if (NodeRef != null) throw new Exception("Node has already been added");
 
             string careerReason;
             if (! Career.CanMakeNodes(out careerReason))
@@ -132,41 +132,41 @@ namespace kOS.Suffixed
                     "A KSP limitation makes it impossible to access the manuever nodes of this vessel at this time. " +
                     "(perhaps it's not the active vessel?)");
 
-            nodeRef = v.patchedConicSolver.AddManeuverNode(time);
+            NodeRef = v.patchedConicSolver.AddManeuverNode(time);
 
             UpdateNodeDeltaV();
 
             v.patchedConicSolver.UpdateFlightPlan();
 
-            nodeLookup.Add(nodeRef, this);
+            nodeLookup.Add(NodeRef, this);
         }
 
         public Vector GetBurnVector()
         {
             CheckNodeRef();
 
-            return new Vector(nodeRef.GetBurnVector(vesselRef.GetOrbit()));
+            return new Vector(NodeRef.GetBurnVector(vesselRef.GetOrbit()));
         }
 
 
         public void Remove()
         {
-            if (nodeRef == null) return;
+            if (NodeRef == null) return;
 
             string careerReason;
             if (! Career.CanMakeNodes(out careerReason))
                 throw new KOSLowTechException("use maneuver nodes", careerReason);
 
-            nodeLookup.Remove(nodeRef);
+            nodeLookup.Remove(NodeRef);
 
             if (vesselRef.patchedConicSolver == null)
                 throw new KOSSituationallyInvalidException(
                     "A KSP limitation makes it impossible to access the manuever nodes of this vessel at this time. " +
                     "(perhaps it's not the active vessel?)");
 
-            nodeRef.RemoveSelf();
+            NodeRef.RemoveSelf();
 
-            nodeRef = null;
+            NodeRef = null;
             vesselRef = null;
         }
 
@@ -178,31 +178,31 @@ namespace kOS.Suffixed
 
         private void ToNodeRef()
         {
-            if (nodeRef == null) return;
+            if (NodeRef == null) return;
 
-            if (nodeRef.attachedGizmo == null)
+            if (NodeRef.attachedGizmo == null)
             {
                 // Copy the logic from OnGizmoUpdated, excluding the two calls to attachedGizmo
-                nodeRef.DeltaV = new Vector3d(radialOut, normal, prograde);
-                nodeRef.UT = time;
-                nodeRef.solver.UpdateFlightPlan();
+                NodeRef.DeltaV = new Vector3d(radialOut, normal, prograde);
+                NodeRef.UT = time;
+                NodeRef.solver.UpdateFlightPlan();
             }
             else
             {
-                nodeRef.OnGizmoUpdated(new Vector3d(radialOut, normal, prograde), time);
+                NodeRef.OnGizmoUpdated(new Vector3d(radialOut, normal, prograde), time);
             }
         }
 
         private void UpdateNodeDeltaV()
         {
-            if (nodeRef == null) return;
+            if (NodeRef == null) return;
             var dv = new Vector3d(radialOut, normal, prograde);
-            nodeRef.DeltaV = dv;
+            NodeRef.DeltaV = dv;
         }
 
         private void CheckNodeRef()
         {
-            if (nodeRef == null)
+            if (NodeRef == null)
             {
                 throw new Exception("Must attach node first");
             }
@@ -211,12 +211,12 @@ namespace kOS.Suffixed
         private void FromNodeRef()
         {
             // If this node is attached, and the values on the attached node have changed, I need to reflect that
-            if (nodeRef == null) return;
+            if (NodeRef == null) return;
 
-            time = nodeRef.UT;
-            radialOut = nodeRef.DeltaV.x;
-            normal = nodeRef.DeltaV.y;
-            prograde = nodeRef.DeltaV.z;
+            time = NodeRef.UT;
+            radialOut = NodeRef.DeltaV.x;
+            normal = NodeRef.DeltaV.y;
+            prograde = NodeRef.DeltaV.z;
         }
     }
 }


### PR DESCRIPTION
Fixes #2836 

The new property has a public get but a private set.

Because of coding standards on the project, the
name had to be changed to uppercase (NodeRef)
instead of lowercase (nodeRef) when it became a
property, so watch out for that when you use this.

Also be aware that the property can be null for
nodes that have not been added to the vessel's
flight plan yet, or are for a vessel that is not
currently the active vessel.  Any use of this
property should check to see if it's null.