### PR TITLE
Fixes #2824 making primitives now be serializable

### DIFF
--- a/src/kOS.Safe/Encapsulation/BooleanValue.cs
+++ b/src/kOS.Safe/Encapsulation/BooleanValue.cs
@@ -1,4 +1,5 @@
-﻿using kOS.Safe.Exceptions;
+using kOS.Safe.Exceptions;
+using kOS.Safe.Serialization;
 using System;
 using System.Reflection;
 
@@ -7,13 +8,26 @@ namespace kOS.Safe.Encapsulation
     [kOS.Safe.Utilities.KOSNomenclature("Boolean")]
     public class BooleanValue : PrimitiveStructure, IConvertible
     {
-        private readonly bool internalValue;
+        // internalValue is *almost* immutable.
+        // It is supposed to be immutable (readonly keyword here) except that
+        // it can't be and also fit the design pattern kOS uses for Serializable structures.
+        // That pattern is to load from a dump by creating an instance with a dummy
+        // constructor first, then populate it with LoadDump().  To populate it with LoadDump(),
+        // the internal representation cannot be readonly.  Populating from a dump should be the
+        // ONLY place the immutability rule is violated.
+        private bool internalValue;
 
         public bool Value { get { return internalValue; } }
 
         public BooleanValue(bool value)
         {
             internalValue = value;
+            InitializeSuffixes();
+        }
+
+        private BooleanValue()
+        {
+            internalValue = false;
             InitializeSuffixes();
         }
 
@@ -236,6 +250,26 @@ namespace kOS.Safe.Encapsulation
         ulong IConvertible.ToUInt64(IFormatProvider provider)
         {
             throw new KOSCastException(typeof(BooleanValue), typeof(ulong));
+        }
+
+        // Required for all IDumpers for them to work, but can't enforced by the interface because it's static:
+        public static BooleanValue CreateFromDump(SafeSharedObjects shared, Dump d)
+        {
+            var newObj = new BooleanValue();
+            newObj.LoadDump(d);
+            return newObj;
+        }
+        public override Dump Dump()
+        {
+            DumpWithHeader dump = new DumpWithHeader();
+
+            dump.Add("value", internalValue);
+
+            return dump;
+        }
+        public override void LoadDump(Dump dump)
+        {
+            internalValue = Convert.ToBoolean(dump["value"]);
         }
     }
 }

--- a/src/kOS.Safe/Encapsulation/PrimitiveStructure.cs
+++ b/src/kOS.Safe/Encapsulation/PrimitiveStructure.cs
@@ -1,9 +1,10 @@
-﻿using System;
+using kOS.Safe.Serialization;
+using System;
 
 namespace kOS.Safe.Encapsulation
 {
     [kOS.Safe.Utilities.KOSNomenclature("Structure", KOSToCSharp = false)]
-    public abstract class PrimitiveStructure : Structure
+    public abstract class PrimitiveStructure : SerializableStructure
     {
         public abstract object ToPrimitive();
     }

--- a/src/kOS.Safe/Encapsulation/ScalarDoubleValue.cs
+++ b/src/kOS.Safe/Encapsulation/ScalarDoubleValue.cs
@@ -1,3 +1,6 @@
+using System;
+using kOS.Safe.Serialization;
+
 namespace kOS.Safe.Encapsulation
 {
     [kOS.Safe.Utilities.KOSNomenclature("Scalar", KOSToCSharp = false)]
@@ -19,7 +22,11 @@ namespace kOS.Safe.Encapsulation
         {
             get { return (double)Value != 0d; }
         }
+        // All serializable structures need a default constructor even if it's not public:
+        private ScalarDoubleValue()
+        {
 
+        }
         public ScalarDoubleValue(double value)
         {
             Value = value;
@@ -38,6 +45,26 @@ namespace kOS.Safe.Encapsulation
         public static ScalarDoubleValue MaxValue()
         {
             return new ScalarDoubleValue(double.MaxValue);
+        }
+
+        // Required for all IDumpers for them to work, but can't enforced by the interface because it's static:
+        public static ScalarDoubleValue CreateFromDump(SafeSharedObjects shared, Dump d)
+        {
+            var newObj = new ScalarDoubleValue();
+            newObj.LoadDump(d);
+            return newObj;
+        }
+        public override Dump Dump()
+        {
+            DumpWithHeader dump = new DumpWithHeader();
+
+            dump.Add("value", Value);
+
+            return dump;
+        }
+        public override void LoadDump(Dump dump)
+        {
+            Value = Convert.ToDouble(dump["value"]);
         }
     }
 }

--- a/src/kOS.Safe/Encapsulation/ScalarIntValue.cs
+++ b/src/kOS.Safe/Encapsulation/ScalarIntValue.cs
@@ -1,4 +1,7 @@
-﻿namespace kOS.Safe.Encapsulation
+using kOS.Safe.Serialization;
+using System;
+
+namespace kOS.Safe.Encapsulation
 {
     [kOS.Safe.Utilities.KOSNomenclature("Scalar", KOSToCSharp = false)]
     public class ScalarIntValue : ScalarValue
@@ -23,6 +26,13 @@
             get { return (int)Value != 0; }
         }
 
+        // All serializable structures need a default constructor, but it can
+        // be private to prevent it from being used externally:
+        private ScalarIntValue()
+        {
+
+        }
+
         public ScalarIntValue(int value)
         {
             Value = value;
@@ -43,5 +53,24 @@
             return new ScalarIntValue(int.MaxValue);
         }
 
+        // Required for all IDumpers for them to work, but can't enforced by the interface because it's static:
+        public static ScalarIntValue CreateFromDump(SafeSharedObjects shared, Dump d)
+        {
+            var newObj = new ScalarIntValue();
+            newObj.LoadDump(d);
+            return newObj;
+        }
+        public override Dump Dump()
+        {
+            DumpWithHeader dump = new DumpWithHeader();
+
+            dump.Add("value", Value);
+
+            return dump;
+        }
+        public override void LoadDump(Dump dump)
+        {
+            Value = Convert.ToInt32(dump["value"]);
+        }
     }
 }

--- a/src/kOS.Safe/Encapsulation/ScalarValue.cs
+++ b/src/kOS.Safe/Encapsulation/ScalarValue.cs
@@ -1,4 +1,5 @@
-﻿using kOS.Safe.Exceptions;
+using kOS.Safe.Exceptions;
+using kOS.Safe.Serialization;
 using System;
 using System.Globalization;
 using System.Reflection;


### PR DESCRIPTION
Fixes #2824 
Note that BooleanValue and StringValue had immutable inner values
and while they still look that way to a kOS script I had to
change them to no longer being readonly in the C# code because
of how Serialization works in the model kOS is using.
(The way you load from a JSON is to first construct an empty
instance, then populate it with a LoadDump() call.  The variables
couldn't be left as ``readonly`` and still support that model.)

It's a shame because the LoadDump() is a lot *like* a constructor
in this case, but the C# compiler doesn't know that so it bans
the assignment of readonly variables in it.