### PR TITLE
Changed more TimeSpan mentions to TimeStamp

### DIFF
--- a/Resources/GameData/kOS/kOS.version
+++ b/Resources/GameData/kOS/kOS.version
@@ -11,7 +11,7 @@
   "VERSION": {
     "MAJOR": 1,
     "MINOR": 3,
-    "PATCH": 0,
+    "PATCH": 1,
     "BUILD": 0
   },
   "KSP_VERSION": {

--- a/doc/source/commands/prediction.rst
+++ b/doc/source/commands/prediction.rst
@@ -39,7 +39,7 @@ These return predicted information about the future position and velocity of an 
     :param orbitable: A :struct:`Vessel`, :struct:`Body` or other :struct:`Orbitable` object
     :type orbitable:  :struct:`Orbitable`
     :param time:    Time of prediction
-    :type time:     :struct:`TimeSpan`
+    :type time:     :struct:`TimeStamp` or :struct:`Scalar` universal seconds
     :return:        A position :struct:`Vector` expressed as the coordinates in the :ref:`ship-center-raw-rotation <ship-raw>` frame
 
     Returns a prediction of where the :struct:`Orbitable` will be at some :ref:`universal Time <universal_time>`. If the :struct:`Orbitable` is a :struct:`Vessel`, and the :struct:`Vessel` has planned :ref:`maneuver nodes <maneuver node>`, the prediction assumes they will be executed exactly as planned.
@@ -59,7 +59,7 @@ These return predicted information about the future position and velocity of an 
     :param orbitable: A :struct:`Vessel`, :struct:`Body` or other :struct:`Orbitable` object
     :type orbitable:  :struct:`Orbitable`
     :param time:    Time of prediction
-    :type time:     :struct:`TimeSpan`
+    :type time:     :struct:`TimeStamp` or :struct:`Scalar` universal seconds
     :return: An :ref:`ObitalVelocity <orbitablevelocity>` structure.
 
     Returns a prediction of what the :ref:`Orbitable's <orbitable>` velocity will be at some :ref:`universal Time <universal_time>`. If the :struct:`Orbitable` is a :struct:`Vessel`, and the :struct:`Vessel` has planned :struct:`maneuver nodes <Node>`, the prediction assumes they will be executed exactly as planned.
@@ -98,7 +98,7 @@ These return predicted information about the future position and velocity of an 
     :param orbitable: A :Ref:`Vessel <vessel>`, :struct:`Body` or other :struct:`Orbitable` object
     :type orbitable:  :struct:`Orbitable`
     :param time:    Time of prediction
-    :type time:     :struct:`TimeSpan`
+    :type time:     :struct:`TimeStamp` or :struct:`Scalar` universal seconds
     :return: An :struct:`Orbit` structure.
 
     Returns the :ref:`Orbit patch <orbit>` where the :struct:`Orbitable` object is predicted to be at some :ref:`universal Time <universal_time>`. If the :struct:`Orbitable` is a :struct:`Vessel`, and the :struct:`Vessel` has planned :ref:`maneuver nodes <maneuver node>`, the prediction assumes they will be executed exactly as planned.

--- a/doc/source/structures/communication/message.rst
+++ b/doc/source/structures/communication/message.rst
@@ -35,10 +35,10 @@ Structure
           - Description
 
         * - :attr:`SENTAT`
-          - :struct:`TimeSpan`
+          - :struct:`TimeStamp`
           - date this message was sent at
         * - :attr:`RECEIVEDAT`
-          - :struct:`TimeSpan`
+          - :struct:`TimeStamp`
           - date this message was received at
         * - :attr:`SENDER`
           - :struct:`Vessel` or :struct:`Boolean`
@@ -56,13 +56,13 @@ Structure
 
 .. attribute:: Message:SENTAT
 
-    :type: :struct:`TimeSpan`
+    :type: :struct:`TimeStamp`
 
     Date this message was sent at.
 
 .. attribute:: Message:RECEIVEDAT
 
-    :type: :struct:`TimeSpan`
+    :type: :struct:`TimeStamp`
 
     Date this message was received at.
 

--- a/doc/source/structures/misc/kuniverse.rst
+++ b/doc/source/structures/misc/kuniverse.rst
@@ -323,8 +323,9 @@ KUniverse 4th wall methods
     have passed (25 x 60 x 60).  It doesn't care how that translates into
     minutes, hours, days, and years until showing it on screen to the player.)
 
-    This setting also affects how values from :struct:Timespan calculate
-    the ``:hours``, ``:days``, and ``:years`` suffixes.
+    This setting also affects how values from :struct:`TimeSpan` and
+    :struct:`TimeStamp` calculate the ``:hours``, ``:days``, and ``:years``
+    suffixes.
 
     Note that this setting is not settable.  This decision was made because
     the main stock KSP game only ever changes the setting on the main

--- a/src/kOS.Safe.Test/Properties/AssemblyInfo.cs
+++ b/src/kOS.Safe.Test/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
-[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.1.0")]
+[assembly: AssemblyVersion("1.3.1.0")]

--- a/src/kOS.Safe/Properties/AssemblyInfo.cs
+++ b/src/kOS.Safe/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
-[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.1.0")]
+[assembly: AssemblyVersion("1.3.1.0")]

--- a/src/kOS.Safe/kOS.Safe.csproj
+++ b/src/kOS.Safe/kOS.Safe.csproj
@@ -79,7 +79,6 @@
     <Compile Include="Exceptions\KOSNumberParseException.cs" />
     <Compile Include="Exceptions\KOSObsoletionException.cs" />
     <Compile Include="Exceptions\KOSPatchesObsoletionException.cs" />
-    <Compile Include="Exceptions\KOSTimeStampTimeSpanException.cs" />
     <Compile Include="Exceptions\KOSVolumeOutOfRangeException.cs" />
     <Compile Include="Exceptions\KOSYouShouldNeverSeeThisException.cs" />
     <Compile Include="Compilation\KS\BreakInfo.cs" />

--- a/src/kOS.sln
+++ b/src/kOS.sln
@@ -15,16 +15,16 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{465EC87D-723D-4A6C-B116-9777AC641DE3}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{465EC87D-723D-4A6C-B116-9777AC641DE3}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{465EC87D-723D-4A6C-B116-9777AC641DE3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{465EC87D-723D-4A6C-B116-9777AC641DE3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{465EC87D-723D-4A6C-B116-9777AC641DE3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{465EC87D-723D-4A6C-B116-9777AC641DE3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{590FFDA8-7B44-4BC3-A12A-5FFE2BB7D8FD}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{590FFDA8-7B44-4BC3-A12A-5FFE2BB7D8FD}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{590FFDA8-7B44-4BC3-A12A-5FFE2BB7D8FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{590FFDA8-7B44-4BC3-A12A-5FFE2BB7D8FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{590FFDA8-7B44-4BC3-A12A-5FFE2BB7D8FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{590FFDA8-7B44-4BC3-A12A-5FFE2BB7D8FD}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C9A42A44-DDC8-4D6C-8A16-D7F30F494B46}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{C9A42A44-DDC8-4D6C-8A16-D7F30F494B46}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{C9A42A44-DDC8-4D6C-8A16-D7F30F494B46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C9A42A44-DDC8-4D6C-8A16-D7F30F494B46}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C9A42A44-DDC8-4D6C-8A16-D7F30F494B46}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C9A42A44-DDC8-4D6C-8A16-D7F30F494B46}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/src/kOS/Binding/FlightStats.cs
+++ b/src/kOS/Binding/FlightStats.cs
@@ -28,7 +28,7 @@ namespace kOS.Binding
             // While it would be cleaner to make it JUST a built -in function,
             // the bound variable had to be retained for backward compatibility with scripts
             // that call TIME without parentheses:
-            shared.BindingMgr.AddGetter("TIME", () => new TimeSpan(Planetarium.GetUniversalTime()));
+            shared.BindingMgr.AddGetter("TIME", () => new TimeStamp(Planetarium.GetUniversalTime()));
             shared.BindingMgr.AddGetter("ACTIVESHIP", () => VesselTarget.CreateOrGetExisting(FlightGlobals.ActiveVessel, shared));
             shared.BindingMgr.AddGetter("STATUS", () => shared.Vessel.situation.ToString());
             shared.BindingMgr.AddGetter("STAGE", () => shared.VesselTarget.StageValues);

--- a/src/kOS/Communication/MessageStructure.cs
+++ b/src/kOS/Communication/MessageStructure.cs
@@ -51,8 +51,8 @@ namespace kOS.Communication
 
         private void InitializeSuffixes()
         {
-            AddSuffix("SENTAT", new Suffix<kOS.Suffixed.TimeSpan>(() => new kOS.Suffixed.TimeSpan(Message.SentAt)));
-            AddSuffix("RECEIVEDAT", new Suffix<kOS.Suffixed.TimeSpan>(() => new kOS.Suffixed.TimeSpan(Message.ReceivedAt)));
+            AddSuffix("SENTAT", new Suffix<kOS.Suffixed.TimeStamp>(() => new kOS.Suffixed.TimeStamp(Message.SentAt)));
+            AddSuffix("RECEIVEDAT", new Suffix<kOS.Suffixed.TimeStamp>(() => new kOS.Suffixed.TimeStamp(Message.ReceivedAt)));
             AddSuffix("SENDER", new Suffix<Structure>(GetVesselTarget));
             AddSuffix("HASSENDER", new Suffix<BooleanValue>(GetVesselExists));
             AddSuffix("CONTENT", new Suffix<Structure>(DeserializeContent));

--- a/src/kOS/Communication/VesselConnection.cs
+++ b/src/kOS/Communication/VesselConnection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Communication;
@@ -6,7 +6,6 @@ using UnityEngine;
 using kOS.Safe.Exceptions;
 using kOS.Safe.Serialization;
 using kOS.Suffixed;
-using TimeSpan = kOS.Suffixed.TimeSpan;
 using kOS.Safe.Communication;
 
 namespace kOS.Communication

--- a/src/kOS/Function/FunctionBase.cs
+++ b/src/kOS/Function/FunctionBase.cs
@@ -2,7 +2,6 @@ using kOS.Safe.Exceptions;
 using kOS.Safe.Function;
 using kOS.Suffixed;
 using System;
-using TimeSpan = kOS.Suffixed.TimeSpan;
 
 namespace kOS.Function
 {
@@ -45,9 +44,9 @@ namespace kOS.Function
             throw new KOSCastException(argument.GetType(), typeof(RgbaColor));
         }
 
-        protected TimeSpan GetTimeSpan(object argument)
+        protected TimeStamp GetTimeStamp(object argument)
         {
-            var span = argument as TimeSpan;
+            var span = argument as TimeStamp;
             if (span != null)
             {
                 return span;
@@ -56,11 +55,11 @@ namespace kOS.Function
             {
                 // Convert to double instead of cast in case the identifier is stored
                 // as an encapsulated ScalarValue, preventing an unboxing collision.
-                return new TimeSpan(Convert.ToDouble(argument));
+                return new TimeStamp(Convert.ToDouble(argument));
             }
             catch
             {
-                throw new KOSCastException(argument.GetType(), typeof(TimeSpan));
+                throw new KOSCastException(argument.GetType(), typeof(TimeStamp));
             }
         }
 

--- a/src/kOS/Function/Suffixed.cs
+++ b/src/kOS/Function/Suffixed.cs
@@ -379,7 +379,7 @@ namespace kOS.Function
             int argCount = CountRemainingArgs(shared);
 
             // If zero args, then the default is to assume you want to
-            // make a Timespan of "now":
+            // make a TimeStamp of "now":
             if (argCount == 0)
             {
                 ReturnValue = new kOS.Suffixed.TimeStamp(Planetarium.GetUniversalTime());
@@ -667,7 +667,7 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            var when = GetTimeSpan(PopValueAssert(shared));
+            var when = GetTimeStamp(PopValueAssert(shared));
             var what = GetOrbitable(PopValueAssert(shared));
             AssertArgBottomAndConsume(shared);
 
@@ -680,7 +680,7 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            var when = GetTimeSpan(PopValueAssert(shared));
+            var when = GetTimeStamp(PopValueAssert(shared));
             var what = GetOrbitable(PopValueAssert(shared));
             AssertArgBottomAndConsume(shared);
 
@@ -706,7 +706,7 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            var when = GetTimeSpan(PopValueAssert(shared));
+            var when = GetTimeStamp(PopValueAssert(shared));
             var what = GetOrbitable(PopValueAssert(shared));
             AssertArgBottomAndConsume(shared);
 

--- a/src/kOS/Properties/AssemblyInfo.cs
+++ b/src/kOS/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
-[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.1.0")]
+[assembly: AssemblyVersion("1.3.1.0")]
 [assembly: KSPAssembly("kOS", 1, 3)]

--- a/src/kOS/Screen/ConnectivityInterpreter.cs
+++ b/src/kOS/Screen/ConnectivityInterpreter.cs
@@ -1,4 +1,4 @@
-﻿using kOS.Communication;
+using kOS.Communication;
 using kOS.Safe;
 using kOS.Safe.Screen;
 using kOS.Safe.UserIO;
@@ -189,7 +189,7 @@ namespace kOS.Screen
             if (progressBarSubBuffer.Enabled)
             {
                 var bars = Math.Max((int)((ColumnCount) * elapsed / total), 0);
-                var time = new DateTime(TimeSpan.FromSeconds(total - elapsed + 0.5).Ticks).ToString("H:mm:ss");
+                var time = new DateTime(System.TimeSpan.FromSeconds(total - elapsed + 0.5).Ticks).ToString("H:mm:ss");
                 string statusText = deploymentMessage + new string(' ', ColumnCount - time.Length - deploymentMessage.Length) + time;
                 var barsText = new string('|', bars);
                 DrawStatus(statusText);

--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -80,9 +80,9 @@ namespace kOS.Screen
             
         private bool isLocked;
         /// <summary>How long blinks should last for, for various blinking needs</summary>
-        private readonly TimeSpan blinkDuration = TimeSpan.FromMilliseconds(150);
+        private readonly TimeSpan blinkDuration = System.TimeSpan.FromMilliseconds(150);
         /// <summary>How long to pad between consecutive blinks to ensure they are visibly detectable as distinct blinks.</summary>
-        private readonly TimeSpan blinkCoolDownDuration = TimeSpan.FromMilliseconds(50);
+        private readonly TimeSpan blinkCoolDownDuration = System.TimeSpan.FromMilliseconds(50);
         /// <summary>At what milliseconds-from-epoch timestamp will the current blink be over.</summary>
         private DateTime blinkEndTime;
         /// <summary>text color that changes depending on if the computer is on</summary>
@@ -438,7 +438,7 @@ namespace kOS.Screen
             
             // Throttle it back so the faster Update() rates don't cause pointlessly repeated work:
             // Needs to be no faster than the fastest theoretical typist or script might change the view.
-            if (newTime > lastTelnetIncrementalRepaint + TimeSpan.FromMilliseconds(50)) // = 1/20th second.
+            if (newTime > lastTelnetIncrementalRepaint + System.TimeSpan.FromMilliseconds(50)) // = 1/20th second.
             {
                 lastTelnetIncrementalRepaint = newTime;
                 foreach (TelnetSingletonServer telnet in telnets)
@@ -844,7 +844,7 @@ namespace kOS.Screen
             
             // Throttle it back so the faster Update() rates don't cause pointlessly repeated work:
             // Needs to be no faster than the fastest theoretical typist or script might change the view.
-            if (newTime > lastBufferGet + TimeSpan.FromMilliseconds(50)) // = 1/20th second.
+            if (newTime > lastBufferGet + System.TimeSpan.FromMilliseconds(50)) // = 1/20th second.
             {
                 mostRecentScreen = new ScreenSnapShot(shared.Screen);
                 lastBufferGet = newTime;

--- a/src/kOS/Suffixed/BodyTarget.cs
+++ b/src/kOS/Suffixed/BodyTarget.cs
@@ -149,12 +149,12 @@ namespace kOS.Suffixed
             return new OrbitableVelocity(Body, Shared);
         }
 
-        public override Vector GetPositionAtUT(TimeSpan timeStamp)
+        public override Vector GetPositionAtUT(TimeStamp timeStamp)
         {
             return new Vector(Body.getPositionAtUT(timeStamp.ToUnixStyleTime()) - Shared.Vessel.CoMD);
         }
 
-        public override OrbitableVelocity GetVelocitiesAtUT(TimeSpan timeStamp)
+        public override OrbitableVelocity GetVelocitiesAtUT(TimeStamp timeStamp)
         {
             CelestialBody parent = Body.KOSExtensionGetParentBody();
             if (parent == null) // only if Body is Sun and therefore has no parent, then do more complex work instead because KSP didn't provide a way itself

--- a/src/kOS/Suffixed/Node.cs
+++ b/src/kOS/Suffixed/Node.cs
@@ -38,7 +38,7 @@ namespace kOS.Suffixed
         {
         }
 
-            public Node(kOS.Suffixed.TimeSpan span, double radialOut, double normal, double prograde, SharedObjects sharedObj)
+        public Node(kOS.Suffixed.TimeSpan span, double radialOut, double normal, double prograde, SharedObjects sharedObj)
             : this(sharedObj)
         {
             this.time = Planetarium.GetUniversalTime() + span.ToUnixStyleTime();

--- a/src/kOS/Suffixed/OrbitInfo.cs
+++ b/src/kOS/Suffixed/OrbitInfo.cs
@@ -59,8 +59,8 @@ namespace kOS.Suffixed
                                                                    ));
             AddSuffix("EPOCH", new Suffix<ScalarValue>(() => orbit.epoch));
             AddSuffix("TRANSITION", new Suffix<StringValue>(() => orbit.patchEndTransition.ToString()));
-            AddSuffix("POSITION", new Suffix<Vector>(() => GetPositionAtUT( new TimeSpan(Planetarium.GetUniversalTime() ) )));
-            AddSuffix("VELOCITY", new Suffix<OrbitableVelocity>(() => GetVelocityAtUT( new TimeSpan(Planetarium.GetUniversalTime() ) )));
+            AddSuffix("POSITION", new Suffix<Vector>(() => GetPositionAtUT( new TimeStamp(Planetarium.GetUniversalTime() ) )));
+            AddSuffix("VELOCITY", new Suffix<OrbitableVelocity>(() => GetVelocityAtUT( new TimeStamp(Planetarium.GetUniversalTime() ) )));
             AddSuffix("NEXTPATCH", new Suffix<OrbitInfo>(GetNextPatch));
             AddSuffix("HASNEXTPATCH", new Suffix<BooleanValue>(GetHasNextPatch));
             AddSuffix("NEXTPATCHETA", new Suffix<ScalarValue>(() => GetETA().GetEndTransition()));  // deprecated alias for :ETA:TRANSITION
@@ -94,7 +94,7 @@ namespace kOS.Suffixed
         /// </summary>
         /// <param name="timeStamp">The universal time to query for</param>
         /// <returns></returns>
-        public Vector GetPositionAtUT( TimeSpan timeStamp )
+        public Vector GetPositionAtUT( TimeStamp timeStamp )
         {
             return new Vector( orbit.getPositionAtUT( timeStamp.ToUnixStyleTime() ) - Shared.Vessel.CoMD );
         }
@@ -107,7 +107,7 @@ namespace kOS.Suffixed
         /// </summary>
         /// <param name="timeStamp">The universal time to query for</param>
         /// <returns></returns>
-        public OrbitableVelocity GetVelocityAtUT( TimeSpan timeStamp )
+        public OrbitableVelocity GetVelocityAtUT( TimeStamp timeStamp )
         {
             var orbVel = new Vector( orbit.getOrbitalVelocityAtUT( timeStamp.ToUnixStyleTime() ) );
             // For some weird reason orbit returns velocities with Y and Z swapped, so flip them back:

--- a/src/kOS/Suffixed/Orbitable.cs
+++ b/src/kOS/Suffixed/Orbitable.cs
@@ -74,7 +74,7 @@ namespace kOS.Suffixed
         ///   </a>
         ///   coordinate reference frame.
         /// </returns>
-        public abstract Vector GetPositionAtUT( TimeSpan timeStamp );
+        public abstract Vector GetPositionAtUT( TimeStamp timeStamp );
 
         /// <summary>
         ///   Subclasses must override this method to return the OrbitableVelocity of this object at some
@@ -91,7 +91,7 @@ namespace kOS.Suffixed
         ///   </a>
         ///   coordinate reference frame.
         /// </returns>
-        public abstract OrbitableVelocity GetVelocitiesAtUT( TimeSpan timeStamp );
+        public abstract OrbitableVelocity GetVelocitiesAtUT( TimeStamp timeStamp );
 
         /// <summary>
         ///   Return the Orbit that the object will be in at some point in the future.

--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -80,7 +80,7 @@ namespace kOS.Suffixed
         /// <param name="timeStamp">The time to predict for.  Although the intention is to
         ///   predict for a future time, it could be used to predict for a past time.</param>
         /// <returns>The position as a user-readable Vector in Shared.Vessel-origin raw rotation coordinates.</returns>
-        public override Vector GetPositionAtUT(TimeSpan timeStamp)
+        public override Vector GetPositionAtUT(TimeStamp timeStamp)
         {
             string blockingTech;
             if (!Career.CanMakeNodes(out blockingTech))
@@ -118,7 +118,7 @@ namespace kOS.Suffixed
         /// <param name="timeStamp">The time to predict for.  Although the intention is to
         ///   predict for a future time, it could be used to predict for a past time.</param>
         /// <returns>The orbit/surface velocity pair as a user-readable Vector in raw rotation coordinates.</returns>
-        public override OrbitableVelocity GetVelocitiesAtUT(TimeSpan timeStamp)
+        public override OrbitableVelocity GetVelocitiesAtUT(TimeStamp timeStamp)
         {
             string blockingTech;
             if (!Career.CanMakeNodes(out blockingTech))

--- a/src/kOS/UserIO/TelnetSingletonServer.cs
+++ b/src/kOS/UserIO/TelnetSingletonServer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Net.Sockets;
@@ -478,7 +478,7 @@ namespace kOS.UserIO
                     // we'll use the terminal type request as a make-do version of a keepalive.  It should force the
                     // telnet client to send some sort of bytes back to us as it answers the terminal type request:
                     TelnetAskForTerminalType();
-                    keepAliveSendTimeStamp = DateTime.Now + TimeSpan.FromSeconds(HUNG_CHECK_INTERVAL);
+                    keepAliveSendTimeStamp = DateTime.Now + System.TimeSpan.FromSeconds(HUNG_CHECK_INTERVAL);
 
                     // This will get set to true when we receive any bytes at all from the client,
                     // whether they're the answer to our query, or something else like user typing.
@@ -508,7 +508,7 @@ namespace kOS.UserIO
                         // This is blocking, so the rawStream.DataAvailable check is vital to prevent hang:
                         rawStream.Read(rawReadBuffer, 0, rawReadBuffer.Length);
                         // But still remember the traffic counts as keepalive proof, even if we ignore it:
-                        keepAliveSendTimeStamp = DateTime.Now + TimeSpan.FromSeconds(HUNG_CHECK_INTERVAL);
+                        keepAliveSendTimeStamp = DateTime.Now + System.TimeSpan.FromSeconds(HUNG_CHECK_INTERVAL);
                     }
                     flushPendingInput = false;
                 }
@@ -519,7 +519,7 @@ namespace kOS.UserIO
                     // As long as some input came recently, no matter what it is, we don't need to bother sending the keepalive:
                     lock (keepAliveAccess)
                         gotSomeRecentTraffic = true;
-                    keepAliveSendTimeStamp = DateTime.Now + TimeSpan.FromSeconds(HUNG_CHECK_INTERVAL);
+                    keepAliveSendTimeStamp = DateTime.Now + System.TimeSpan.FromSeconds(HUNG_CHECK_INTERVAL);
                     
                     // Process the input bytes that arrived:
                     char[] scrapedBytes = Encoding.UTF8.GetChars(TelnetProtocolScrape(rawReadBuffer, numRead));

--- a/src/kOS/UserIO/TelnetWelcomeMenu.cs
+++ b/src/kOS/UserIO/TelnetWelcomeMenu.cs
@@ -81,7 +81,7 @@ namespace kOS.UserIO
             // Regularly check to see if the CPU list has changed while the user was sitting
             // on the menu.  If so, reprint it:
             // Querying the list of CPU's can be a little expensive, so don't do it too often:
-            if (DateTime.Now > lastMenuQueryTime + TimeSpan.FromMilliseconds(1000))
+            if (DateTime.Now > lastMenuQueryTime + System.TimeSpan.FromMilliseconds(1000))
             {
                 if (forceMenuReprint)
                     telnetServer.Write((char)UnicodeCommand.CLEARSCREEN); // if we HAVE to reprint - do so on a clear screen.


### PR DESCRIPTION
Fixes #2850 - the places that should have been made
into TimeStamps have been changed.

To make things clear, the places where ``TimeSpan`` meant .Net's ``System.TimeSpan`` not kOS's ``kOS.Suffixed.TimeSpan`` have been given the fully qualified name ``System.TimeSpan`` just so the code is clear which one when you read it.