### PR TITLE
Fixes 2868 too much onconfirm

### DIFF
--- a/src/kOS/Suffixed/Widget/Button.cs
+++ b/src/kOS/Suffixed/Widget/Button.cs
@@ -1,4 +1,4 @@
-﻿using kOS.Safe.Encapsulation;
+using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Execution;
 using UnityEngine;
@@ -176,13 +176,22 @@ namespace kOS.Suffixed.Widget
             // Toggles stay pressed until clicked again.
             // one-shot buttons release as soon as the click is noticed by the script.
             if (IsToggle) {
+                myId = GUIUtility.GetControlID(FocusType.Passive);
+                string myIdString = myId.ToString();
+                GUI.SetNextControlName(myIdString);
                 bool newpressed = GUILayout.Toggle(PressedVisible, VisibleContent(), ReadOnlyStyle);
                 if (IsExclusive && !newpressed) return; // stays pressed
+                if (newpressed != pressed) // if it just toggled on or toggled off 
+                    GUI.FocusControl(myIdString);
                 SetPressedVisible(newpressed);
             } else {
+                myId = GUIUtility.GetControlID(FocusType.Passive);
+                string myIdString = myId.ToString();
+                GUI.SetNextControlName(myIdString);
                 if (GUILayout.Toggle(PressedVisible, VisibleContent(), ReadOnlyStyle)) {
                     if (!PressedVisible) {
                         PressedVisible = true;
+                        GUI.FocusControl(myIdString);
                         Communicate(() => Pressed = true);
                     }
                 }

--- a/src/kOS/Suffixed/Widget/Label.cs
+++ b/src/kOS/Suffixed/Widget/Label.cs
@@ -88,6 +88,8 @@ namespace kOS.Suffixed.Widget
         public override void DoGUI()
         {
             ScheduleTextUpdate();
+            myId = GUIUtility.GetControlID(FocusType.Passive);
+            GUI.SetNextControlName(myId.ToString());
             GUILayout.Label(content_visible, ReadOnlyStyle);
         }
 

--- a/src/kOS/Suffixed/Widget/PopupMenu.cs
+++ b/src/kOS/Suffixed/Widget/PopupMenu.cs
@@ -186,17 +186,26 @@ namespace kOS.Suffixed.Widget
 
         public Rect popupRect;
         private Vector2 rememberScrollSpot = new Vector2();
+        private string nameFmt = "{0}_{1}";
+        private string indexedName;
         public void DoPopupGUI()
         {
             rememberScrollSpot = GUILayout.BeginScrollView(rememberScrollSpot, popupStyle.ReadOnly);
             GUILayout.BeginVertical(popupStyle.ReadOnly);
             for (int i=0; i<list.Count; ++i) {
+
+                // Might be some time savings by storing these Id names and not recalculating them each GUI pass,
+                // but for now this is good enough to see if this idea works:
+                myId = GUIUtility.GetControlID(FocusType.Passive);
+                GUI.SetNextControlName(myId.ToString());
+
                 if (GUILayout.Button(GetItemString(list[i]), itemStyle.ReadOnly)) {
                     int newindex = i;
                     Communicate(() => Index = newindex);
                     SetVisibleText(GetItemString(list[i]));
                     PopDown();
                     Communicate(() => changed = true);
+                    GUI.FocusControl(indexedName);
                 }
             }
             GUILayout.EndVertical();

--- a/src/kOS/Suffixed/Widget/Slider.cs
+++ b/src/kOS/Suffixed/Widget/Slider.cs
@@ -1,4 +1,4 @@
-﻿using kOS.Safe.Encapsulation;
+using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Execution;
 using UnityEngine;
@@ -51,12 +51,16 @@ namespace kOS.Suffixed.Widget
         public override void DoGUI()
         {
             float newvalue;
+            myId = GUIUtility.GetControlID(FocusType.Passive);
+            string myIdString = myId.ToString();
+            GUI.SetNextControlName(myIdString);
             if (horizontal)
                 newvalue = GUILayout.HorizontalSlider(valueVisible, min, max, ReadOnlyStyle, thumbStyle.ReadOnly);
             else
                 newvalue = GUILayout.VerticalSlider(valueVisible, min, max, ReadOnlyStyle, thumbStyle.ReadOnly);
             if (newvalue != valueVisible) {
                 valueVisible = newvalue;
+                GUI.FocusControl(myIdString);
                 Communicate(() => Value = newvalue);
             }
         }

--- a/src/kOS/Suffixed/Widget/Spacing.cs
+++ b/src/kOS/Suffixed/Widget/Spacing.cs
@@ -1,4 +1,4 @@
-﻿using kOS.Safe.Encapsulation;
+using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
 using UnityEngine;
 
@@ -22,6 +22,7 @@ namespace kOS.Suffixed.Widget
 
         public override void DoGUI()
         {
+            GUI.SetNextControlName(myId.ToString());
             if (amount < 0)
                 GUILayout.FlexibleSpace();
             else

--- a/src/kOS/Suffixed/Widget/Widget.cs
+++ b/src/kOS/Suffixed/Widget/Widget.cs
@@ -30,6 +30,8 @@ namespace kOS.Suffixed.Widget
         /// </summary>
         protected bool guiCaused;
 
+        protected int myId;
+
         // The WidgetStyle is cheap as it only creates a new GUIStyle if it is
         // actually changed, otherwise it just refers to the one in the GUI:SKIN.
         private WidgetStyle copyOnWriteStyle;


### PR DESCRIPTION
Fixes #2868 - I hope.

As of this writing there is still testing going on (testing all kinds of GUI interactions is long and can't be automated well).    But I'm making the PR anyway so others can try this and report if it fixes it for them in their GUIs.

See the full explanation of the fix in the comment for this commit: https://github.com/KSP-KOS/KOS/pull/2872/commits/458795a74e93db27897250c5dc215537bebcf435