### PR TITLE
Add ReactionWheel partmodule handling

### DIFF
--- a/doc/source/structures/vessels/reactionwheel.rst
+++ b/doc/source/structures/vessels/reactionwheel.rst
@@ -1,0 +1,76 @@
+.. _reactionwheel:
+
+Reaction Wheel
+======
+
+Some of the Parts returned by :ref:`LIST PARTS <list command>` will be a Reaction Wheel. It is also possible to get just the Reaction Wheel parts by executing ``LIST ReactionWheels``, for example::
+
+    LIST ReactionWheels IN myVariable.
+    FOR wheel IN myVariable {
+        print "A reaction wheel exists that is currently " + wheel:WHEELSTATE.
+    }.
+
+.. structure:: Reaction Wheel
+
+    .. list-table::
+        :header-rows: 1
+        :widths: 1 1 2
+
+        * - Suffix
+          - Type (units)
+          - Description
+
+        * - All suffixes of :struct:`Part`
+          -
+          - :struct:`RCS` objects are a type of :struct:`Part`
+
+
+        * - :attr:`AUTHORITYLIMITER`
+          - :ref:`scalar <scalar>` (%)
+          - The authority limit for the reaction wheel.
+        * - :attr:`MAXTORQUE`
+          - :ref:`Vector <vector>` (kN)
+          - A vector representing the maximum amount of force that can be applied over the Pitch, Yaw and Roll axis.
+        * - :attr:`WHEELSTATE`
+          - :ref:`String <string>`
+          - The status of the reaction wheel: ACTIVE, DISABLED or BROKEN.
+        * - :attr:`TORQUERESPONSESPEED`
+          - :ref:`scalar <scalar>`
+          - 
+
+.. note::
+
+    Reaction wheels always apply their torque at the ships center of mass. The center of mass of a ship can be found using the :struct:`Vessel <Vessel>`:position parameter.
+
+.. note::
+
+    A :struct:`ReactionWheel` is a type of :struct:`Part`, and therefore can use all the suffixes of :struct:`Part`.
+
+.. attribute:: ReactionWheel:AUTHORITYLIMITER
+
+    :access: Get/Set
+    :type: :ref:`scalar <scalar>` (%)
+    
+    The authority limit of the reaction wheel.
+    
+.. attribute:: ReactionWheel:MAXTORQUE
+
+    :access: Get
+    :type: :ref:`Vector <vector>`
+        
+    A vector representing the amount of force that can be applied over the three axis: V(maxPitchTorque, maxYawTorque, maxRollTorque).
+    
+.. attribute:: ReactionWheel:WHEELSTATE
+
+    :access: Get
+    :type: :ref:`String <string>`
+        
+    The status of the reaction wheel. One of: ACTIVE, DISABLED or BROKEN.
+    
+.. attribute:: ReactionWheel:TORQUERESPONSESPEED
+
+    :access: Get
+    :type: :ref:`scalar <scalar>`
+        
+    Unknown
+    

--- a/src/kOS/Function/BuildList.cs
+++ b/src/kOS/Function/BuildList.cs
@@ -36,6 +36,7 @@ namespace kOS.Function
                 case "parts":
                 case "engines":
                 case "rcs":
+                case "reactionwheels":
                 case "sensors":
                 case "elements":
                 case "dockingports":

--- a/src/kOS/Function/PrintList.cs
+++ b/src/kOS/Function/PrintList.cs
@@ -66,6 +66,10 @@ namespace kOS.Function
                     list = GetRCSList(shared);
                     break;
 
+                case "reactionwheels":
+                    list = GetReactionWheelList(shared);
+                    break;
+
                 case "sensors":
                     list = GetSensorList(shared);
                     break;
@@ -283,6 +287,27 @@ namespace kOS.Function
                 {
                     var rcs = module as ModuleRCS;
                     if (rcs != null)
+                    {
+                        list.AddItem(part.ConstructID(), part.partInfo.name);
+                    }
+                }
+            }
+
+            return list;
+        }
+
+        private kList GetReactionWheelList(SharedObjects shared)
+        {
+            var list = new kList();
+            list.AddColumn("ID", 12, ColumnAlignment.Left);
+            list.AddColumn("Name", 28, ColumnAlignment.Left);
+
+            foreach (Part part in shared.Vessel.Parts)
+            {
+                foreach (PartModule module in part.Modules)
+                {
+                    var wheel = module as ModuleReactionWheel;
+                    if (wheel != null)
                     {
                         list.AddItem(part.ConstructID(), part.partInfo.name);
                     }

--- a/src/kOS/Suffixed/Part/ReactionWheelValue.cs
+++ b/src/kOS/Suffixed/Part/ReactionWheelValue.cs
@@ -1,0 +1,56 @@
+using kOS.Safe;
+using kOS.Safe.Encapsulation;
+using kOS.Safe.Encapsulation.Suffixes;
+using kOS.Safe.Exceptions;
+using kOS.Safe.Utilities;
+using kOS.Suffixed.PartModuleField;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using UnityEngine;
+using System;
+
+namespace kOS.Suffixed.Part
+{
+    [kOS.Safe.Utilities.KOSNomenclature("ReactionWheel")]
+    public class ReactionWheelValue : PartValue
+    {
+        private readonly ModuleReactionWheel module;
+
+        /// <summary>
+        /// Do not call! VesselTarget.ConstructPart uses this, would use `friend VesselTarget` if this was C++!
+        /// </summary>
+        internal ReactionWheelValue(SharedObjects shared, global::Part part, PartValue parent, DecouplerValue decoupler, ModuleReactionWheel module)
+            : base(shared, part, parent, decoupler)
+        {
+            this.module = module;
+            RegisterInitializer(RCSInitializeSuffixes);
+        }
+        private void RCSInitializeSuffixes()
+        {
+            AddSuffix("AUTHORITYLIMITER", new SetSuffix<ScalarValue>(() => module.authorityLimiter, value => module.authorityLimiter = Math.Max(Math.Min(value, 0), 100), "Sets the authority limiter for this reaction wheel."));
+            AddSuffix("WHEELSTATE", new Suffix<StringValue>(() => module.wheelState.ToString().ToUpper(), "The status of the reaction wheel: ACTIVE, DISABLED or BROKEN."));
+            AddSuffix("MAXTORQUE", new Suffix<Vector>(() => new Vector(module.PitchTorque, module.YawTorque, module.RollTorque), "A vector representing max torque force over (pitch, yaw, roll)."));
+            AddSuffix("TORQUERESPONSESPEED", new Suffix<ScalarValue>(() => module.torqueResponseSpeed));
+        }
+
+        public static ListValue PartsToList(IEnumerable<global::Part> parts, SharedObjects sharedObj)
+        {
+            var toReturn = new ListValue();
+            var vessel = VesselTarget.CreateOrGetExisting(sharedObj);
+            foreach (var part in parts)
+            {
+                foreach (var module in part.Modules)
+                {
+                    if (module is ModuleReactionWheel)
+                    {
+                        toReturn.Add(vessel[part]);
+                        // Only add each part once
+                        break;
+                    }
+                }
+            }
+            return toReturn;
+        }
+    }
+}

--- a/src/kOS/Suffixed/VesselTarget.Parts.cs
+++ b/src/kOS/Suffixed/VesselTarget.Parts.cs
@@ -118,6 +118,7 @@ namespace kOS.Suffixed
             // gather all potential modules and then select from those valid.
             IEngineStatus engine = null;
             ModuleRCS rcs = null;
+            ModuleReactionWheel torqueWheel = null;
             PartValue separator = null;
             ModuleEnviroSensor sensor = null;
 
@@ -130,6 +131,10 @@ namespace kOS.Suffixed
                 else if (module is ModuleRCS)
                 {
                     rcs = module as ModuleRCS;
+                }
+                else if (module is ModuleReactionWheel)
+                {
+                    torqueWheel = module as ModuleReactionWheel;
                 }
                 else if (module is IStageSeparator)
                 {
@@ -177,6 +182,8 @@ namespace kOS.Suffixed
                 self = new EngineValue(Shared, part, parent, decoupler);
             else if (rcs != null)
                 self = new RCSValue(Shared, part, parent, decoupler, rcs);
+            else if (torqueWheel != null)
+                self = new ReactionWheelValue(Shared, part, parent, decoupler, torqueWheel);
             else if (separator != null)
                 self = separator;
             else if (sensor != null)

--- a/src/kOS/Utilities/VesselUtils.cs
+++ b/src/kOS/Utilities/VesselUtils.cs
@@ -86,6 +86,10 @@ namespace kOS.Utilities
                     list = RCSValue.PartsToList(partList, sharedObj);
                     break;
 
+                case "REACTIONWHEELS":
+                    list = ReactionWheelValue.PartsToList(partList, sharedObj);
+                    break;
+
                 case "SENSORS":
                     list = SensorValue.PartsToList(partList, sharedObj);
                     break;

--- a/src/kOS/kOS.csproj
+++ b/src/kOS/kOS.csproj
@@ -172,6 +172,7 @@
     <Compile Include="Suffixed\LoadDistanceValue.cs" />
     <Compile Include="Suffixed\Part\DecouplerValue.cs" />
     <Compile Include="Suffixed\Part\LaunchClampValue.cs" />
+    <Compile Include="Suffixed\Part\ReactionWheelValue.cs" />
     <Compile Include="Suffixed\Part\RCSValue.cs" />
     <Compile Include="Suffixed\ResourceTransferValue.cs" />
     <Compile Include="Screen\DelegateDialog.cs" />


### PR DESCRIPTION
Added documentation but haven't been able to run the compile on it so I'm unsure whether I did the links right.

Adds support for reading out the torque of reaction wheels to enable players to tune their own steering managers.

Code has manually been tested in-game.