### PR TITLE
Don't crash when printing a recursive structure

### DIFF
--- a/doc/source/commands/serialization.rst
+++ b/doc/source/commands/serialization.rst
@@ -30,7 +30,7 @@ It is **important** to remember that any data that you supply to :ref:`WRITEJSON
 
   It's not possible to serialize structures that loop on themselves. Only `Directed Acyclical Graphs <https://en.wikipedia.org/wiki/Directed_acyclic_graph>`_ are supported.
   
-  An example of a looping structure is:
+  An example of a looping structure is::
   
       SET a TO LIST().
 	  SET b TO LIST(a).

--- a/doc/source/commands/serialization.rst
+++ b/doc/source/commands/serialization.rst
@@ -25,3 +25,14 @@ They allow to transform data structures into JSON objects and store them in a fi
 It serializes messages currently stored on message queues to ConfigNode (KSP data format) and adds them to KSP save files.
 
 It is **important** to remember that any data that you supply to :ref:`WRITEJSON` and :meth:`Connection:SENDMESSAGE` must be serializable.
+
+.. note::
+
+  It's not possible to serialize structures that loop on themselves. Only `Directed Acyclical Graphs <https://en.wikipedia.org/wiki/Directed_acyclic_graph>`_ are supported.
+  
+  An example of a looping structure is:
+  
+      SET a TO LIST().
+	  SET b TO LIST(a).
+	  a:ADD(b).
+	  WRITEJSON(a, "test"). // <-- This will fail

--- a/src/kOS.Safe/Serialization/SafeSerializationMgr.cs
+++ b/src/kOS.Safe/Serialization/SafeSerializationMgr.cs
@@ -43,7 +43,7 @@ namespace kOS.Safe.Serialization
             if (seenList.Contains(value))
             {
                 if (!allowTruncatedRecursion)
-                    throw new KOSSerializationException("Trying to serialize a structure that loops on itself. Unable to serialize non-DAG structures.");
+                    throw new KOSSerializationException("Trying to serialize a structure that loops on itself. Only Directed Acyclical Graphs are supported.");
                 return "...recurse...";
             }
 

--- a/src/kOS.Safe/Serialization/SafeSerializationMgr.cs
+++ b/src/kOS.Safe/Serialization/SafeSerializationMgr.cs
@@ -40,7 +40,7 @@ namespace kOS.Safe.Serialization
         {
             var valueDumper = value as IDumper;
 
-            if (seenList.Contains(value))
+            if (!(value is string) && seenList.Contains(value))
             {
                 if (!allowTruncatedRecursion)
                     throw new KOSSerializationException("Trying to serialize a structure that loops on itself. Only Directed Acyclical Graphs are supported.");


### PR DESCRIPTION
Fixes #1598

    local foo to lexicon().
    set foo["self"] to foo.
    
    print foo.

Will now print `"...recurse..."` for the `self` value instead of crashing KSP. Other serializers will end with an exception instead of a crash.