### PR TITLE
Fixes #2899 terrain raycast now ingores parts.

### DIFF
--- a/src/kOS.Safe/Exceptions/KOSYouShouldNeverSeeThisException.cs
+++ b/src/kOS.Safe/Exceptions/KOSYouShouldNeverSeeThisException.cs
@@ -5,7 +5,7 @@ namespace kOS.Safe.Exceptions
 {
     public class KOSYouShouldNeverSeeThisException : KOSException
     {
-        public KOSYouShouldNeverSeeThisException(string message) : base("This is an error endusers should never see, if you see this please report it to the kOS devs:\r\n    " + message)
+        public KOSYouShouldNeverSeeThisException(string message) : base("This is an error end users should never see. If you see this please report it on the kOS github:\r\n    " + message)
         {
         }
     }

--- a/src/kOS/Screen/Interpreter.cs
+++ b/src/kOS/Screen/Interpreter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using kOS.Execution;

--- a/src/kOS/Suffixed/GeoCoordinates.cs
+++ b/src/kOS/Suffixed/GeoCoordinates.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
+using kOS.Safe.Exceptions;
 using kOS.Utilities;
 using kOS.Serialization;
 using kOS.Safe.Serialization;
@@ -176,9 +177,11 @@ namespace kOS.Suffixed
                 // a point a bit below it, to aim down to the terrain:
                 Vector3d worldRayCastStop = Body.GetWorldSurfacePosition( Latitude, Longitude, alt+POINT_AGL );
                 RaycastHit hit;
-                if (Physics.Raycast(worldRayCastStart, (worldRayCastStop - worldRayCastStart), out hit, float.MaxValue, 1<<TERRAIN_MASK_BIT ))
+                if (RaycastForTerrain(worldRayCastStart, worldRayCastStop, out hit))
                 {
                     // Ensure hit is on the topside of planet, near the worldRayCastStart, not on the far side.
+                    // Note this check is *probably* unnecessary but I'm not 100% sure.  (Probably unnecessary
+                    // because the other side of the planet isn't going to have colliders loaded).
                     if (Mathf.Abs(hit.distance) < 3000)
                     {
                         // Okay a hit was found, use it instead of PQS alt:
@@ -187,6 +190,49 @@ namespace kOS.Suffixed
                 }
             }
             return alt;
+        }
+
+        static double tinySkipDistance = 0.0001d;
+
+        /// <summary>Check to find terrain, adding extra masking logic to deal with KSP having put some
+        /// objects on the terrain layer which weren't really terrain.</summary>
+        private bool RaycastForTerrain(Vector3d worldRayCastStart, Vector3d worldRayCastStop, out RaycastHit hit, int recurseSofar = 0)
+        {
+            Vector3d aimVector = worldRayCastStop - worldRayCastStart;
+            Vector3d originalStart = worldRayCastStart;
+
+            // The sane way to do this would be to just use a layermask that only hits terrain.
+            // The problem with trying to do that is KSP's Breaking Ground DLC's rover scanner arms have a
+            // phantom spherical collider on the terrain layer even though they're really not terrain.
+            // See my note on Squad bugtracker issue 26938, https://bugs.kerbalspaceprogram.com/issues/26938#note-3)
+            // To fix that, this contains some extra logic that says if a terrain layer hit turns out to really be
+            // a vessel part, it should skip past it and keep looking.
+            int remainingAttempts = 200;
+            while (Physics.Raycast(worldRayCastStart, aimVector, out hit, float.MaxValue, 1 << TERRAIN_MASK_BIT))
+            {
+                global::Part partHit = hit.collider?.transform?.root?.gameObject?.GetComponent<global::Part>();
+                if (partHit == null)
+                {
+                    // Not a Part, so let's assume its a genuine terrain hit.
+
+                    // Return the hit distance from the caller's original start spot, not the temporary one
+                    // we may have moved it to:
+                    hit.distance = (float)(hit.point - originalStart).magnitude;
+                    return true;
+                }
+                // Hit was a Part, so it doesn't count.  Go again starting from just past that hit:
+                worldRayCastStart += hit.point + tinySkipDistance * aimVector.normalized;
+                if (--remainingAttempts == 0)
+                {
+                    // The majority of the time this loop should only need one iteration. If the
+                    // scene contains any of the few offending parts that use terrain layermask, it will
+                    // need at most one more iteration per offending part in the scene.  Anything more than
+                    // just a few iterations you can count on one hand and the algorithm is probably failing.
+                    throw new KOSYouShouldNeverSeeThisException(
+                        "kOS's RaycastForTerrain() is probably stuck in an infinite loop. It's being aborted to prevent it from freezing KSP.");
+                }
+            }
+            return false;
         }
 
         /// <summary>

--- a/src/kOS/Suffixed/GeoCoordinates.cs
+++ b/src/kOS/Suffixed/GeoCoordinates.cs
@@ -196,7 +196,7 @@ namespace kOS.Suffixed
 
         /// <summary>Check to find terrain, adding extra masking logic to deal with KSP having put some
         /// objects on the terrain layer which weren't really terrain.</summary>
-        private bool RaycastForTerrain(Vector3d worldRayCastStart, Vector3d worldRayCastStop, out RaycastHit hit, int recurseSofar = 0)
+        private bool RaycastForTerrain(Vector3d worldRayCastStart, Vector3d worldRayCastStop, out RaycastHit hit)
         {
             Vector3d aimVector = worldRayCastStop - worldRayCastStart;
             Vector3d originalStart = worldRayCastStart;
@@ -221,7 +221,7 @@ namespace kOS.Suffixed
                     return true;
                 }
                 // Hit was a Part, so it doesn't count.  Go again starting from just past that hit:
-                worldRayCastStart += hit.point + tinySkipDistance * aimVector.normalized;
+                worldRayCastStart = hit.point + tinySkipDistance * aimVector.normalized;
                 if (--remainingAttempts == 0)
                 {
                     // The majority of the time this loop should only need one iteration. If the


### PR DESCRIPTION
Fixes #2899

The fix I went with was to detect whether or not a raycast hit
is inside a Part.  If it is, then start a new raycast just past
the hit and keep looking.

The solution involved writing a wrapper around Raycast that
includes this extra logic, such that it could be lifted and
put in a utility library later if any other classes need to
use it.

Using the same example script and craft as in the issue #2899, with this change it now looks like this:
![screenshot26](https://user-images.githubusercontent.com/5216848/111303421-7f702c80-8622-11eb-87fa-bc6f1c40a526.png)
