### PR TITLE
Make printed structures slightly more readable

### DIFF
--- a/src/kOS.Safe/Encapsulation/QueueValue.cs
+++ b/src/kOS.Safe/Encapsulation/QueueValue.cs
@@ -37,6 +37,12 @@ namespace kOS.Safe.Encapsulation
             InnerEnumerable.Enqueue(val);
         }
 
+        public override Dump Dump()
+        {
+            Dump result = base.Dump();
+            result.Annotations.Add(0, "<-- front");
+            return result;
+        }
         public override void LoadDump(Dump dump)
         {
             InnerEnumerable.Clear();

--- a/src/kOS.Safe/Encapsulation/StackValue.cs
+++ b/src/kOS.Safe/Encapsulation/StackValue.cs
@@ -42,6 +42,12 @@ namespace kOS.Safe.Encapsulation
             InnerEnumerable.Push(val);
         }
 
+        public override Dump Dump()
+        {
+            Dump result = base.Dump();
+            result.Annotations.Add(0, "<-- top");
+            return result;
+        }
         public override void LoadDump(Dump dump)
         {
             InnerEnumerable.Clear();

--- a/src/kOS.Safe/Serialization/Dump.cs
+++ b/src/kOS.Safe/Serialization/Dump.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace kOS.Safe
@@ -8,14 +8,37 @@ namespace kOS.Safe
         public const string Items = "items";
         public const string Entries = "entries";
 
+        public DumpKeyType KeyType { get
+            {
+                if (ContainsKey(Items))
+                    return DumpKeyType.List;
+                if (ContainsKey(Entries))
+                    return DumpKeyType.KeyValue;
+                if (ContainsKey("value"))
+                    return DumpKeyType.Value;
+                return DumpKeyType.Default;
+            }
+        }
+        public Dictionary<object, string> Annotations { get; private set; }
+
         public Dump()
         {
+            Annotations = new Dictionary<object, string>();
         }
 
         public Dump(IDictionary<object, object> dictionary) : base(dictionary)
         {
+            Annotations = new Dictionary<object, string>();
         }
 
+    }
+
+    public enum DumpKeyType
+    {
+        Default = 0,
+        KeyValue,
+        List,
+        Value,
     }
 
 }

--- a/src/kOS.Safe/Serialization/TerminalFormatter.cs
+++ b/src/kOS.Safe/Serialization/TerminalFormatter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Text;
 using System.Collections.Generic;
 using kOS.Safe.Encapsulation;
 using System.Linq;
@@ -7,7 +8,8 @@ namespace kOS.Safe.Serialization
 {
     public class TerminalFormatter : IFormatWriter
     {
-        private static int INDENT_SPACES = 2;
+        private static string INDENT = "  ";
+        private static int MAX_DEPTH = 2;
         private static readonly TerminalFormatter instance;
 
         public static TerminalFormatter Instance
@@ -30,102 +32,200 @@ namespace kOS.Safe.Serialization
 
         public string Write(Dump value)
         {
-            string header = "";
-
-            var withHeader = value as DumpWithHeader;
-            if (withHeader != null)
-            {
-                header = withHeader.Header + Environment.NewLine;
-            }
-
-            return header + WriteIndented(value);
+            StringBuilder result = new StringBuilder(1024);
+            WriteInternal(value, result);
+            return result.ToString();
         }
 
-        public string WriteIndented(Dump dump, int level = 0)
+        private void WriteInternal(object o, StringBuilder builder, int level = 0)
         {
-            IDictionary<object, object> printedDump;
 
-            if (dump.Count == 1 && dump.ContainsKey(Dump.Items)) {
-                // special handling for enumerables
-                List<object> list = dump[Dump.Items] as List<object>;
-                printedDump = list.Select((x, i) => new { Item = x, Index = (object)i })
-                    .ToDictionary(x => x.Index, x => x.Item);
-            } else if (dump.Count == 1 && dump.ContainsKey(Dump.Entries)) {
-                // special handling for lexicons
-                List<object> list = dump[Dump.Entries] as List<object>;
-
-                printedDump = new Dictionary<object, object>();
-
-                for (int i = 0; 2 * i < list.Count; i++)
+            if (o == null)
+            {
+                builder.Append("<null>");
+                return;
+            }
+            if (o is bool || o is int || o is double || o is float)
+            {
+                builder.Append(o.ToString());
+                return;
+            }
+            if (o is string)
+            {
+                builder.Append("\"");
+                string[] lines = ((string)o).Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
+                builder.Append(EscapeString(lines[0]));
+                foreach (var line in lines.Skip(1))
                 {
-                    printedDump[list[2 * i]] = list[2 * i + 1];
+                    builder.Append(Environment.NewLine);
+                    WriteIndentation(builder, level);
+                    builder.Append(EscapeString(line));
                 }
-            } else {
-                printedDump = dump;
+                builder.Append("\"");
+                return;
+            }
+            if (o is Dump)
+            {
+                Dump d = (Dump)o;
+
+                if (d is DumpWithHeader)
+                {
+                    builder.Append(((DumpWithHeader)d).Header);
+                }
+
+                Dictionary<object, object> reconstructedDict = d;
+                switch (d.KeyType)
+                {
+                    case DumpKeyType.List:
+                        IEnumerable<object> enumerable = d[Dump.Items] as IEnumerable<object>;
+                        if (enumerable == null)
+                        {
+                            builder.Append(" <empty>");
+                            return;
+                        }
+
+                        if (level > MAX_DEPTH)
+                        {
+                            builder.Append("<list truncated>");
+                            return;
+                        }
+
+                        WriteInternalEnumerable(enumerable, builder, level, d.Annotations);
+                        return;
+                    case DumpKeyType.Value:
+                        WriteInternal(d["value"], builder, level);
+                        return;
+                    case DumpKeyType.KeyValue:
+                        var items = d[Dump.Entries] as IEnumerable<object>;
+                        if (items == null)
+                        {
+                            builder.Append(" <null>");
+                            return;
+                        }
+                        var keys = items.Where((item, index) => index % 2 == 0).ToList();
+                        var values = items.Where((item, index) => index % 2 == 1).ToList();
+                        if (keys.Count != values.Count)
+                        {
+                            builder.Append(" <broken>");
+                            return;
+                        }
+                        reconstructedDict = new Dictionary<object, object>();
+                        for (int i = 0; i < keys.Count; i++)
+                            reconstructedDict[keys[i]] = values[i];
+                        break;
+                }
+
+                if (level > MAX_DEPTH)
+                {
+                    builder.Append("<truncated>");
+                    return;
+                }
+
+                foreach(var key in reconstructedDict.Keys)
+                {
+                    builder.Append(Environment.NewLine);
+                    WriteIndentation(builder, level);
+                    WriteKey(key, builder);
+                    builder.Append(": ");
+                    if (d.Annotations.ContainsKey(key)) {
+                        WriteAnnotated(reconstructedDict[key], builder, level + 1, d.Annotations[key]);
+                    } else {
+                        WriteInternal(reconstructedDict[key], builder, level + 1);
+                    }
+
+                }
+                return;
+            }
+            if (o is IEnumerable<object>)
+            {
+                if (level > MAX_DEPTH)
+                {
+                    builder.Append("List of ");
+                    builder.Append(((IEnumerable<object>)o).Count().ToString());
+                    builder.Append(" items...");
+                    return;
+                }
+                WriteInternalEnumerable((IEnumerable<object>)o, builder, level);
+                return;
             }
 
-            return WriteIndentedDump(printedDump, level);
+
+            // Fall back to type name
+            builder.Append("<");
+            builder.Append(o.GetType().Name);
+            builder.Append(">");
         }
 
-        public string WriteIndentedDump(IDictionary<object, object> dump, int level)
+        private void WriteInternalEnumerable(IEnumerable<object> list, StringBuilder builder, int level, Dictionary<object, string> annotations = null)
         {
-            var result = new List<string>();
-
-            foreach (KeyValuePair<object, object> entry in dump)
+            int i = 0;
+            foreach (object o in list)
             {
-                var line = string.Empty.PadLeft(level * INDENT_SPACES);
-                var value = entry.Value;
-                string valueString;
-
-                var objects = value as Dump;
-                if (objects != null)
+                builder.Append(Environment.NewLine);
+                WriteIndentation(builder, level);
+                builder.Append("- ");
+                if (annotations != null && annotations.ContainsKey(i))
                 {
-                    string header = Environment.NewLine;
-
-                    var withHeader = value as DumpWithHeader;
-                    if (withHeader != null)
-                    {
-                        header = withHeader.Header + Environment.NewLine;
-                    }
-
-                    valueString = header + WriteIndented(objects, level + 1);
-                } else
-                {
-                    valueString = value.ToString();
+                    WriteAnnotated(o, builder, level + 1, annotations[i]);
+                } else {
+                    WriteInternal(o, builder, level + 1);
                 }
+                ++i;
+            }
+        }
 
-                if (entry.Key is string || entry.Key is StringValue)
-                {
-                    line += string.Format("[\"{0}\"] = ", entry.Key);
-                } else if (entry.Key is Dump)
-                {
-                    string header = Environment.NewLine;
+        private string EscapeString(string s)
+        {
+            return s.
+                Replace(Environment.NewLine, "\\n").
+                Replace("\"", "\"\"");
+        }
 
-                    var withHeader = entry.Key as DumpWithHeader;
-                    if (withHeader != null)
-                    {
-                        header = withHeader.Header + Environment.NewLine;
-                    }
+        private void WriteIndentation(StringBuilder builder, int level)
+        {
+            while (level > 0)
+            {
+                builder.Append(INDENT);
+                --level;
+            }
+        }
 
-                    string keyString = header + WriteIndented(entry.Key as Dump, level + 1);
-                    line += string.Format("[{0}] = ", keyString);
-                } else
-                {
-                    line += string.Format("[{0}] = ", entry.Key.ToString());
-                }
-
-                if (entry.Value is string)
-                {
-                    line += string.Format("\"{0}\"", valueString);
-                } else
-                {
-                    line += string.Format("{0}", valueString);
-                }
-
-                result.Add(line);
+        // Keys are constrained to one line
+        private void WriteKey(object key, StringBuilder builder)
+        {
+            if (key is string)
+            {
+                builder.Append(EscapeString((string)key));
+                return;
+            }
+            StringBuilder recursive = new StringBuilder(128);
+            WriteInternal(key, builder, 0);
+            string result = recursive.ToString();
+            if (!result.Contains(Environment.NewLine))
+            {
+                builder.Append(result);
+                return;
             }
 
-            return String.Join(Environment.NewLine, result.ToArray());
+            builder.Append(result.Split(new string[] { Environment.NewLine }, StringSplitOptions.None)[0]);
+            builder.Append("... truncated");
+        }
+
+        private void WriteAnnotated(object o, StringBuilder builder, int level, string annotation)
+        {
+            StringBuilder recursive = new StringBuilder(1024);
+            WriteInternal(o, recursive, level);
+            string[] lines = recursive.ToString().Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
+
+            builder.Append(lines[0]);
+            builder.Append(" // ");
+            builder.Append(annotation);
+
+            foreach(var line in lines.Skip(1))
+            {
+                builder.Append(Environment.NewLine);
+                builder.Append(line);
+            }
         }
     }
 }


### PR DESCRIPTION
Could be a possible solution for #2894

Example output with the same script as #2909:
![image](https://user-images.githubusercontent.com/296972/112734752-fa511580-8f47-11eb-84fa-7c68b6e8bd9f.png)
