### PR TITLE
Fixes 2870 kOS cargo slot fields

### DIFF
--- a/Resources/GameData/kOS/Parts/KOSCherryLight/part.cfg
+++ b/Resources/GameData/kOS/Parts/KOSCherryLight/part.cfg
@@ -41,5 +41,10 @@ PART
         resourceAmount = 0.02
         animationName = Rotation
     }
+    MODULE
+    {
+        name = ModuleCargoPart
+        packedVolume = 100
+    }
 
 }

--- a/Resources/GameData/kOS/Parts/kOSMachine0m/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSMachine0m/part.cfg
@@ -72,5 +72,10 @@ MODULE
 	animationName = flickerStart
 }
 
+MODULE
+{
+        name = ModuleCargoPart
+        packedVolume = 60
+}
 
 }

--- a/Resources/GameData/kOS/Parts/kOSMachine0m/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSMachine0m/part.cfg
@@ -1,81 +1,81 @@
 PART
 {
-// --- general parameters ---
-name = KR-2042
-module = Part
-author = SMA and Peter Goddard
+    // --- general parameters ---
+    name = KR-2042
+    module = Part
+    author = SMA and Peter Goddard
 
-// --- asset parameters ---
-mesh = model/model.mu
-scale = 1
-rescaleFactor = 1
+    // --- asset parameters ---
+    mesh = model/model.mu
+    scale = 1
+    rescaleFactor = 1
 
-// --- node definitions ---
-// definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z, connector node size
-node_stack_bottom = 0.0, -0.081, 0.0, 0.0, -1.0, 0.0, 0
-node_stack_top = 0.0, -0.003, 0.0, 0.0, 1.0, 0.0, 0
+    // --- node definitions ---
+    // definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z, connector node size
+    node_stack_bottom = 0.0, -0.081, 0.0, 0.0, -1.0, 0.0, 0
+    node_stack_top = 0.0, -0.003, 0.0, 0.0, 1.0, 0.0, 0
 
 
-// --- Tech tree ---
-TechRequired = precisionEngineering
+    // --- Tech tree ---
+    TechRequired = precisionEngineering
 
-// --- editor parameters ---
-cost = 1200
-entryCost = 6800
-category = Control
-subcategory = 0
-title = KR-2042 b Scriptable Control System
-manufacturer = Compotronix
-description = Would you trust life and limb to a mindless autopilot, powered by untested software you hastily wrote yourself? Spacefaring kerbals would!
-bulkheadProfiles = size0
+    // --- editor parameters ---
+    cost = 1200
+    entryCost = 6800
+    category = Control
+    subcategory = 0
+    title = KR-2042 b Scriptable Control System
+    manufacturer = Compotronix
+    description = Would you trust life and limb to a mindless autopilot, powered by untested software you hastily wrote yourself? Spacefaring kerbals would!
+    bulkheadProfiles = size0
 
-// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
-attachRules = 1,0,1,0,0
+    // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
+    attachRules = 1,0,1,0,0
 
-// --- standard part parameters ---
-mass = 0.08
-dragModelType = default
-maximum_drag = 0.2
-minimum_drag = 0.2
-angularDrag = 2
-crashTolerance = 9
-maxTemp = 1500
+    // --- standard part parameters ---
+    mass = 0.08
+    dragModelType = default
+    maximum_drag = 0.2
+    minimum_drag = 0.2
+    angularDrag = 2
+    crashTolerance = 9
+    maxTemp = 1500
 
-MODULE
-{
-	name = kOSProcessor
-	diskSpace = 5000
-	ECPerBytePerSecond = 0
-	ECPerInstruction = 0.000004
-}
+    MODULE
+    {
+        name = kOSProcessor
+        diskSpace = 5000
+        ECPerBytePerSecond = 0
+        ECPerInstruction = 0.000004
+    }
 
-RESOURCE
-{
-	name = ElectricCharge
-	amount = 5
-	maxAmount = 5
-}
+    RESOURCE
+    {
+        name = ElectricCharge
+        amount = 5
+        maxAmount = 5
+    }
 
-MODULE
-{
-	name = ModuleLight
-	lightName = PowerLight
-	lightR = 0
-	lightG = 0.1
-	lightB = 0
-}
+    MODULE
+    {
+        name = ModuleLight
+        lightName = PowerLight
+        lightR = 0
+        lightG = 0.1
+        lightB = 0
+    }
 
-MODULE
-{
-	name = kOSLightModule
-	resourceAmount = 0.02
-	animationName = flickerStart
-}
+    MODULE
+    {
+        name = kOSLightModule
+        resourceAmount = 0.02
+        animationName = flickerStart
+    }
 
-MODULE
-{
+    MODULE
+    {
         name = ModuleCargoPart
         packedVolume = 60
-}
+    }
 
 }

--- a/Resources/GameData/kOS/Parts/kOSMachine1m/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSMachine1m/part.cfg
@@ -41,18 +41,24 @@ angularDrag = 2
 crashTolerance = 9
 maxTemp = 2000
 
-MODULE
-{
-	name = kOSProcessor
-	diskSpace = 10000
-	ECPerBytePerSecond = 0
-	ECPerInstruction = 0.000004
-}
+    MODULE
+    {
+            name = kOSProcessor
+            diskSpace = 10000
+            ECPerBytePerSecond = 0
+            ECPerInstruction = 0.000004
+    }
 
-RESOURCE
-{
-	name = ElectricCharge
-	amount = 5
-	maxAmount = 5
-}
+    RESOURCE
+    {
+            name = ElectricCharge
+            amount = 5
+            maxAmount = 5
+    }
+
+    MODULE
+    {
+        name = ModuleCargoPart
+        packedVolume = 650
+    }
 }

--- a/Resources/GameData/kOS/Parts/kOSMachine1m/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSMachine1m/part.cfg
@@ -1,59 +1,59 @@
 PART
 {
-// --- general parameters ---  V2~ fixed collision mesh
-name = kOSMachine1m
-module = Part
-author = KevinLaity / Peter Goddard
+    // --- general parameters ---  V2~ fixed collision mesh
+    name = kOSMachine1m
+    module = Part
+    author = KevinLaity / Peter Goddard
 
-// --- asset parameters ---
-mesh = model/model.mu
-scale = 1
-rescaleFactor = 0.99999999999
-iconCenter = 0, 3, 0
+    // --- asset parameters ---
+    mesh = model/model.mu
+    scale = 1
+    rescaleFactor = 0.99999999999
+    iconCenter = 0, 3, 0
 
-// --- node definitions ---
-node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
-node_stack_bottom = 0.0, -0.173, 0.0, 0.0, -1.0, 0.0
-node_stack_top = 0.0, 0.173, 0.0, 0.0, 1.0, 0.0
+    // --- node definitions ---
+    node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
+    node_stack_bottom = 0.0, -0.173, 0.0, 0.0, -1.0, 0.0
+    node_stack_top = 0.0, 0.173, 0.0, 0.0, 1.0, 0.0
 
-// --- Tech tree ---
-TechRequired = flightControl
+    // --- Tech tree ---
+    TechRequired = flightControl
 
-// --- editor parameters ---
-cost = 1200
-entryCost = 4200
-category = Control
-subcategory = 0
-title = CX-4181 Scriptable Control System
-manufacturer = Compotronix
-description = Would you trust life and limb to a mindless autopilot, powered by untested software you hastily wrote yourself? Spacefaring kerbals would!
-bulkheadProfiles = size1
+    // --- editor parameters ---
+    cost = 1200
+    entryCost = 4200
+    category = Control
+    subcategory = 0
+    title = CX-4181 Scriptable Control System
+    manufacturer = Compotronix
+    description = Would you trust life and limb to a mindless autopilot, powered by untested software you hastily wrote yourself? Spacefaring kerbals would!
+    bulkheadProfiles = size1
 
-// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
-attachRules = 1,0,1,1,0
+    // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
+    attachRules = 1,0,1,1,0
 
-// --- standard part parameters ---
-mass = 0.12
-dragModelType = default
-maximum_drag = 0.2
-minimum_drag = 0.2
-angularDrag = 2
-crashTolerance = 9
-maxTemp = 2000
+    // --- standard part parameters ---
+    mass = 0.12
+    dragModelType = default
+    maximum_drag = 0.2
+    minimum_drag = 0.2
+    angularDrag = 2
+    crashTolerance = 9
+    maxTemp = 2000
 
     MODULE
     {
-            name = kOSProcessor
-            diskSpace = 10000
-            ECPerBytePerSecond = 0
-            ECPerInstruction = 0.000004
+        name = kOSProcessor
+        diskSpace = 10000
+        ECPerBytePerSecond = 0
+        ECPerInstruction = 0.000004
     }
 
     RESOURCE
     {
-            name = ElectricCharge
-            amount = 5
-            maxAmount = 5
+        name = ElectricCharge
+        amount = 5
+        maxAmount = 5
     }
 
     MODULE

--- a/Resources/GameData/kOS/Parts/kOSMachineRad/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSMachineRad/part.cfg
@@ -71,4 +71,9 @@ RESOURCE
 	amount = 10
 	maxAmount = 10
 }
+MODULE
+{
+        name = ModuleCargoPart
+        packedVolume = 200
+}
 }

--- a/Resources/GameData/kOS/Parts/kOSMachineRad/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSMachineRad/part.cfg
@@ -1,79 +1,77 @@
 PART
 {
-// --- general parameters ---
-name = kOSMachineRad
-module = Part
-author = Peter Goddard
+    // --- general parameters ---
+    name = kOSMachineRad
+    module = Part
+    author = Peter Goddard
 
-// --- asset parameters ---
-mesh = model/model.mu
-scale = 1
-rescaleFactor = 1
-iconCenter = 0, 0, 0
+    // --- asset parameters ---
+    mesh = model/model.mu
+    scale = 1
+    rescaleFactor = 1
+    iconCenter = 0, 0, 0
 
-// --- node definitions ---
-node_attach = 0.0, 0.0, 0.0, 1, 0, 0
+    // --- node definitions ---
+    node_attach = 0.0, 0.0, 0.0, 1, 0, 0
 
-// --- Tech tree ---
-TechRequired = unmannedTech
+    // --- Tech tree ---
+    TechRequired = unmannedTech
 
-// --- editor parameters ---
-cost = 2200
-entryCost = 4200
-category = Control
-subcategory = 0
-title = CompoMax Radial Tubeless
-manufacturer = Squalid-State Devices Inc.
-description = Would you trust life and limb to a mindless autopilot, powered by untested software you hastily wrote yourself? Spacefaring kerbals would!
-bulkheadProfiles = srf
+    // --- editor parameters ---
+    cost = 2200
+    entryCost = 4200
+    category = Control
+    subcategory = 0
+    title = CompoMax Radial Tubeless
+    manufacturer = Squalid-State Devices Inc.
+    description = Would you trust life and limb to a mindless autopilot, powered by untested software you hastily wrote yourself? Spacefaring kerbals would!
+    bulkheadProfiles = srf
 
-// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
-attachRules = 0,1,0,0,1
+    // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
+    attachRules = 0,1,0,0,1
 
-// --- standard part parameters ---
-mass = 0.03
-dragModelType = default
-maximum_drag = 0.0
-minimum_drag = 0.0
-angularDrag = 0
-crashTolerance = 6
-maxTemp = 1500
+    // --- standard part parameters ---
+    mass = 0.03
+    dragModelType = default
+    maximum_drag = 0.0
+    minimum_drag = 0.0
+    angularDrag = 0
+    crashTolerance = 6
+    maxTemp = 1500
 
-
-MODULE
-{
-	name = kOSProcessor
-	diskSpace = 60000
-	ECPerBytePerSecond = 0
-	ECPerInstruction = 0.000004
-}
-MODULE
-{
-  name = ModuleDeployableSolarPanel
-  sunTracking = false
-  raycastTransformName = suncatcher
-  pivotName = suncatcher
-  isBreakable = false
-  resourceName = ElectricCharge
-  chargeRate = 0.5
-  powerCurve
-  {
-    key = 206000000000 0 0 0
-    key = 13599840256 1 0 0
-    key = 68773560320 0.5 0 0
-    key = 0 10 0 0
-  }
-}
-}
-RESOURCE
-{
-	name = ElectricCharge
-	amount = 10
-	maxAmount = 10
-}
-MODULE
-{
+    MODULE
+    {
+        name = kOSProcessor
+        diskSpace = 60000
+        ECPerBytePerSecond = 0
+        ECPerInstruction = 0.000004
+    }
+    RESOURCE
+    {
+        name = ElectricCharge
+        amount = 10
+        maxAmount = 10
+    }
+    MODULE
+    {
         name = ModuleCargoPart
         packedVolume = 200
-}
+    }
+    MODULE
+    {
+        name = ModuleDeployableSolarPanel
+        sunTracking = false
+        raycastTransformName = suncatcher
+        pivotName = suncatcher
+        isBreakable = false
+        resourceName = ElectricCharge
+        chargeRate = 0.5
+        powerCurve
+        {
+            key = 206000000000 0 0 0
+            key = 13599840256 1 0 0
+            key = 68773560320 0.5 0 0
+            key = 0 10 0 0
+        }
+    }
 }

--- a/Resources/GameData/kOS/Parts/kOSkal9000/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSkal9000/part.cfg
@@ -58,4 +58,9 @@ MODULE
 	resourceAmount = 0.02
 	animationName = KAL9000Lives
 }
+MODULE
+{
+        name = ModuleCargoPart
+        packedVolume = 50
+}
 }

--- a/Resources/GameData/kOS/Parts/kOSkal9000/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSkal9000/part.cfg
@@ -1,66 +1,66 @@
 PART
 {
-// --- general parameters ---
-name = KAL9000
-module = Part
-author = Peter Goddard and kOS Crew
+    // --- general parameters ---
+    name = KAL9000
+    module = Part
+    author = Peter Goddard and kOS Crew
 
-// --- asset parameters ---
-mesh = model/model.mu
-scale = 1
-rescaleFactor = 1
+    // --- asset parameters ---
+    mesh = model/model.mu
+    scale = 1
+    rescaleFactor = 1
 
-// --- node definitions ---
-node_attach = 0.01, 0.0, 0.0, 1, 0, 0, 0
+    // --- node definitions ---
+    node_attach = 0.01, 0.0, 0.0, 1, 0, 0, 0
 
-// --- Tech tree ---
-TechRequired = automation
+    // --- Tech tree ---
+    TechRequired = automation
 
-// --- editor parameters ---
-cost = 1200
-entryCost = 6800
-category = Control
-subcategory = 0
-title = KAL9000 Scriptable Control System
-manufacturer = Squalid State Devices
-description = Mildly Malevolent artificial entity, use caution on EVA's
-bulkheadProfiles = srf
+    // --- editor parameters ---
+    cost = 1200
+    entryCost = 6800
+    category = Control
+    subcategory = 0
+    title = KAL9000 Scriptable Control System
+    manufacturer = Squalid State Devices
+    description = Mildly Malevolent artificial entity, use caution on EVA's
+    bulkheadProfiles = srf
 
-// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
-attachRules = 0,1,0,0,0
+    // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
+    attachRules = 0,1,0,0,0
 
-// --- standard part parameters ---
-mass = 0.0005
-dragModelType = default
-maximum_drag = 0
-minimum_drag = 0
-angularDrag = 0
-crashTolerance = 9
-maxTemp = 1500
+    // --- standard part parameters ---
+    mass = 0.0005
+    dragModelType = default
+    maximum_drag = 0
+    minimum_drag = 0
+    angularDrag = 0
+    crashTolerance = 9
+    maxTemp = 1500
 
-MODULE
-{
-	name = kOSProcessor
-	diskSpace = 255000
-}
-MODULE
-{
-	name = ModuleLight
-	lightName = PowerLight
-	lightR = 0.5
-	lightG = 0
-	lightB = 0
-}
+    MODULE
+    {
+        name = kOSProcessor
+        diskSpace = 255000
+    }
+    MODULE
+    {
+        name = ModuleLight
+        lightName = PowerLight
+        lightR = 0.5
+        lightG = 0
+        lightB = 0
+    }
 
-MODULE
-{
-	name = kOSLightModule
-	resourceAmount = 0.02
-	animationName = KAL9000Lives
-}
-MODULE
-{
+    MODULE
+    {
+        name = kOSLightModule
+        resourceAmount = 0.02
+        animationName = KAL9000Lives
+    }
+    MODULE
+    {
         name = ModuleCargoPart
         packedVolume = 50
-}
+    }
 }


### PR DESCRIPTION
This edits the Part.cfg files so they have the fields KSP uses for the inventory system of KSP 1.11.x.

Not sure if this will cause kOS to no longer run on KSP 1.10.  Must test this on next kOS release.