### PR TITLE
Pidloop improvements

### DIFF
--- a/src/kOS.Safe.Test/Structure/PIDLoopTest.cs
+++ b/src/kOS.Safe.Test/Structure/PIDLoopTest.cs
@@ -53,5 +53,66 @@ namespace kOS.Safe.Test.Structure
 
             Assert.AreEqual(new double[] {0, 10, 11, 11, 11, 5, 0, 0, 0, 0}, output);
         }
+
+        [Test]
+        public void CanNoneAntiWindUp()
+        {
+            var pidLoop = new PIDLoop(0, 1, 0, 11, 0);
+            pidLoop.AntiWindupMode = "NONE";
+            double[] outputs = new double[10];
+
+            for (var i = 0; i < input.Length; i++)
+            {
+                outputs[i] = pidLoop.Update(i, input[i]);
+            }
+
+            Assert.AreEqual(new double[] {0, 10, 11, 11, 11, 11, 11, 11, 11, 10}, outputs);
+        }
+
+        [Test]
+        public void CanClampingAntiWindUp()
+        {
+            var pidLoop = new PIDLoop(0, 1, 0, 11, 0);
+            pidLoop.AntiWindupMode = "CLAMPING";
+            double[] outputs = new double[10];
+
+            for (var i = 0; i < input.Length; i++)
+            {
+                outputs[i] = pidLoop.Update(i, input[i]);
+            }
+
+            Assert.AreEqual(new double[] {0, 10, 11, 11, 11, 11, 8, 2, 0, 0}, outputs);
+        }
+
+        [Test]
+        public void CanBackCalculationAntiWindUp()
+        {
+            var pidLoop = new PIDLoop(0, 1, 0, 11, 0);
+            pidLoop.AntiWindupMode = "BACK-CALC";
+            double[] outputs = new double[10];
+
+            for (var i = 0; i < input.Length; i++)
+            {
+                outputs[i] = pidLoop.Update(i, input[i]);
+            }
+
+            Assert.AreEqual(new double[] {0, 10, 11, 11, 11, 5, 0, 0, 0, 0}, outputs);
+        }
+        
+        [Test]
+        public void CanBackCalculationWithK2AntiWindUp()
+        {
+            var pidLoop = new PIDLoop(0, 1, 0, 11, 0);
+            pidLoop.AntiWindupMode = "BACK-CALC";
+            pidLoop.KBackCalc = 2;
+            double[] outputs = new double[10];
+
+            for (var i = 0; i < input.Length; i++)
+            {
+                outputs[i] = pidLoop.Update(i, input[i]);
+            }
+
+            Assert.AreEqual(new double[] {0, 10, 11, 11, 11, 0, 0, 0, 0, 0}, outputs);
+        }
     }
 }

--- a/src/kOS.Safe.Test/Structure/PIDLoopTest.cs
+++ b/src/kOS.Safe.Test/Structure/PIDLoopTest.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using kOS.Safe.Encapsulation;
+using NUnit.Framework;
+
+namespace kOS.Safe.Test.Structure
+{
+    [TestFixture]
+    public class PIDLoopTest
+    {
+
+        private double[] input;
+
+        [SetUp]
+        public void Setup()
+        {
+            input = new double[] {-10, -10, -10, -10, 6, 6, 6, 6, 6, 6};
+        }
+         
+        [Test]
+        public void CanCorrectlyReactToSineWaveInput()
+        {
+            var pidLoop = new PIDLoop(1, 1, 1);
+            double[] sineWaveInput = {0, -4.207, -4.547, -0.706, 3.784, 4.795, 1.397, -3.285, -4.947, -2.060};
+            double[] output = new double[10];
+            double[] pTermOutput = new double[10];
+            double[] iTermOutput = new double[10];
+            double[] dTermOutput = new double[10];
+
+            for (var i = 0; i < sineWaveInput.Length; i++)
+            {
+                output[i] = Math.Round((double) pidLoop.Update(i, sineWaveInput[i]), 2);
+                pTermOutput[i] = Math.Round(pidLoop.PTerm, 2);
+                iTermOutput[i] = Math.Round(pidLoop.ITerm, 2);
+                dTermOutput[i] = Math.Round(pidLoop.DTerm, 2);
+            }
+
+            Assert.AreEqual(new double[] {0, 4.21, 4.55, 0.71, -3.78, -4.80, -1.40, 3.28, 4.95, 2.06}, pTermOutput, "Proportional part is incorrect");
+            Assert.AreEqual(new double[] {0, 0, 4.21, 8.75, 9.46, 5.68, 0.88, -0.52, 2.77, 7.72}, iTermOutput, "Integral part is incorrect");
+            Assert.AreEqual(new double[] {0, 4.21, 0.34, -3.84, -4.49, -1.01, 3.40, 4.68, 1.66, -2.89}, dTermOutput, "Derivative part is incorrect");
+            Assert.AreEqual(new double[] {0, 8.41, 9.09, 5.62, 1.19, -0.13, 2.88, 7.45, 9.38, 6.89}, output, "PID output is incorrect");
+        }
+
+        [Test]
+        public void CanAntiWindUp()
+        {
+            var pidLoop = new PIDLoop(0, 1, 0, 11, 0);
+            double[] output = new double[10];
+
+            for (var i = 0; i < input.Length; i++)
+            {
+                output[i] = pidLoop.Update(i, input[i]);
+            }
+
+            Assert.AreEqual(new double[] {0, 10, 11, 11, 11, 5, 0, 0, 0, 0}, output);
+        }
+    }
+}

--- a/src/kOS.Safe/Encapsulation/PIDLoop.cs
+++ b/src/kOS.Safe/Encapsulation/PIDLoop.cs
@@ -80,6 +80,7 @@ namespace kOS.Safe.Encapsulation
                 DTerm = source.DTerm,
                 ExtraUnwind = source.ExtraUnwind,
                 ChangeRate = source.ChangeRate,
+                lastIError = source.lastIError,
                 unWinding = source.unWinding
             };
             return newLoop;
@@ -119,6 +120,7 @@ namespace kOS.Safe.Encapsulation
 
         public double ChangeRate { get; set; }
 
+        private double lastIError;
         private bool unWinding;
 
         public PIDLoop()
@@ -198,7 +200,11 @@ namespace kOS.Safe.Encapsulation
             double pTerm = error * Kp;
             double iTerm = 0;
             double dTerm = 0;
-            if (LastSampleTime < sampleTime)
+            if (LastSampleTime == double.MaxValue)
+            {
+                lastIError = error * Ki;
+            }
+            else if (LastSampleTime < sampleTime)
             {
                 double dt = sampleTime - LastSampleTime;
                 if (Ki != 0)
@@ -219,7 +225,8 @@ namespace kOS.Safe.Encapsulation
                             unWinding = false;
                         }
                     }
-                    iTerm = ITerm + error * dt * Ki;
+                    iTerm = ITerm + lastIError * dt;
+                    lastIError = error * Ki;
                 }
                 ChangeRate = (input - Input) / dt;
                 if (Kd != 0)


### PR DESCRIPTION
This PR contains several improvements, fixes and unit tests for PIDLoop. Related issues: #2919, #2920, #2921.

These changes should not affect existing kOS scripts and I tried my best to preserve current PIDLoop behavior (minus bugs).

### Motivation
Several months ago I decided to start learning how PID controllers work. I've been using MATLAB to model simple things for KSP and that was a very fun experience: model something in MATLAB and make it work in KSP. After some time playing with MATLAB and KSP I noticed that PIDLoop in some cases works differently than PID controller in MATLAB, so I thought that it's a nice challenge for me - to understand why.

The first problem (#2919) I found was that integration in kOS PIDLoop skips the first error value. I fixed it in the first commit by using correct Forward Euler method [1] for integration. This change has almost zero impact on kOS PIDs, but still it was important for me to fix it before moving forward.

In the second commit I added simple unit tests to make sure I don't break anything during my next improvements and refactoring. I wasn't able to put unit tests before any changes due to the bug I had to fix in the first commit.

The second problem (#2921) is related to kOS PIDLoop anti-windup method. PIDLoop has a different and a bit simpler method than methods which can be found in MATLAB. This makes modeling anything complex in MATLAB near impossible. The third commit addresses this problem and adds additional anti-windup methods: clamping and back-calculation. [2] If anti-windup method is not set explicitly PIDLoop will work without any changes - using the currently implemented method.

ANTIWINDUPMODE (StringValue) is added to PIDLoop with these values:
NONE - output saturation (min/max limits) is applied, but anti-windup is not used;
CLAMPING - clamping algorithm (see [2]);
BACK-CALC - back-calculation algorithm (see [2]);
DEFAULT or any other value - currently implemented anti-windup method.

For the back-calculation algorithm a coefficient KBACKCALC (ScalarValue) is added. See [2] for details.

The diagram below shows the difference between these methods (telemetry for the diagram was gathered in KSP - vertical speed stabilization to 10, then to 0, using four J-20 "Juno" engines).
<img width="1277" alt="antiwindup" src="https://user-images.githubusercontent.com/4571520/114315308-1687b180-9b07-11eb-8250-047676277839.png">

Besides new anti-windup methods I have refactored the PIDLoop Update method, removed obsolete variables and tried to make it more clean.

The third problem (#2920) is a bug in the derivative part: currently, PIDLoop calculates it based on input, but an error should be used instead. The fourth commit contains a fix for that.

If you think these fixes/changes may be helpful for kOS, I can work on documentation and add it as a separate commit to the PR (although I'm not a native speaker, so someone will need to check it :) ). If needed I can break the PR down into several PRs.

### References
[1] https://www.sciencedirect.com/topics/engineering/forward-euler
[2] https://www.matec-conferences.org/articles/matecconf/pdf/2017/26/matecconf_imane2017_05013.pdf