### PR TITLE
Culls out RCS thruster transforms for other part variants

### DIFF
--- a/src/kOS/Control/SteeringManager.cs
+++ b/src/kOS/Control/SteeringManager.cs
@@ -667,7 +667,6 @@ namespace kOS.Control
             rawTorque.x = (rawTorque.x + PitchTorqueAdjust) * PitchTorqueFactor;
             rawTorque.z = (rawTorque.z + YawTorqueAdjust) * YawTorqueFactor;
             rawTorque.y = (rawTorque.y + RollTorqueAdjust) * RollTorqueFactor;
-
             controlTorque = rawTorque + adjustTorque;
             //controlTorque = Vector3d.Scale(rawTorque, adjustTorque);
             //controlTorque = rawTorque;
@@ -717,6 +716,14 @@ namespace kOS.Control
                     for (int i = rcs.thrusterTransforms.Count-1; i >= 0; --i)
                     {
                         Transform rcsTransform = rcs.thrusterTransforms[i];
+
+                        // Fixes github issue #2912:  As of KSP 1.11.x, RCS parts now use part variants.  To keep kOS
+                        // from counting torque as if the superset of all variant nozzles were present, the ones not
+                        // currently active have to be culled out here, since KSP isn't culling them out itself when
+                        // it populates ModuleRCS.thrusterTransforms:
+                        if (!rcsTransform.gameObject.activeInHierarchy)
+                            continue;
+
                         Vector3 rcsPosFromCoM = rcsTransform.position - Vessel.CurrentCoM;
                         Vector3 rcsThrustDir = rcs.useZaxis ? -rcsTransform.forward : rcsTransform.up;
                         float powerFactor = rcs.thrusterPower * rcs.thrustPercentage * 0.01f;


### PR DESCRIPTION
Fixes #2912.

The problem only exists in KSP 1.11 and up.  In KSP 1.10.x and
earlier, it was working.

The problem was caused by the introduction of RCS part variants
that came with KSP 1.11.x.  Restock happened to exacerbate the
problem because it has more part variants, but even the part
variants that come with stock are enough to trigger the problem.

The problem is that kOS's replacement for GetPotentialTorque()
was adding up the superset of all the part variants' thruster
nozzles, not just the nozzles that actually exist in the current
part variant.  You'd think that KSP would  cull out the nozzles
for other part variants when it builds the
ModuleRCS.thrusterTransforms list, but it doesn't seem to do that,
so we have to cull them ourselves when iterating over that list.