### PR TITLE
Fix #2726 Volume inherits invalid name from Part Tag

### DIFF
--- a/doc/source/general/volumes.rst
+++ b/doc/source/general/volumes.rst
@@ -115,6 +115,8 @@ the volumes using the same names::
 
 If a kOS processor has a name tag set, then that processor's volume
 will have its name initially set to the value of the name tag.
+If the tag contains characters that would not be allowed in the volume's name 
+they will be removed, exept spaces which are replaced with underscore instead.
 
 Archive
 -------

--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -17,6 +17,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
+
 using kOS.Safe.Execution;
 using UnityEngine;
 using kOS.Safe.Encapsulation;
@@ -478,6 +480,8 @@ namespace kOS.Module
             return result;
         }
 
+        private static Regex VolumeNameRemoveChars = new Regex("[/\\\\<>:\"|?*]*", RegexOptions.Compiled);
+
         public void InitObjects()
         {
             if (objectsInitialized)
@@ -526,7 +530,13 @@ namespace kOS.Module
 
                 if (!string.IsNullOrEmpty(Tag))
                 {
-                    HardDisk.Name = Tag;
+                    // Tag could contain characters that are not allowed.
+                    var tmpTag = VolumeNameRemoveChars.Replace(Tag, "");
+
+                    if( !string.IsNullOrWhiteSpace(tmpTag))
+                    {
+                        HardDisk.Name = tmpTag.Replace(' ', '_');
+                    }
                 }
 
                 var path = BootFilePath;


### PR DESCRIPTION
Fix #2726  by removing invalid characters from the volume name before it is set based on the Core's tag. Spaces are replaced with underscore instead.

