### PR TITLE
Change bounds creation to use colliders instead. #2942

### DIFF
--- a/src/kOS/Suffixed/Part/PartValue.cs
+++ b/src/kOS/Suffixed/Part/PartValue.cs
@@ -9,6 +9,8 @@ using System.Text.RegularExpressions;
 using System.Linq;
 using System.Collections.Generic;
 using kOS.Safe.Compilation.KS;
+using kOS.Safe.Utilities;
+
 using UnityEngine;
 
 namespace kOS.Suffixed.Part
@@ -150,7 +152,8 @@ namespace kOS.Suffixed.Part
                         }
                         default:
                         {
-                            throw new Exception("Unknown CapsuleCollider direction: " + capsuleCollider.direction);
+                            SafeHouse.Logger.LogWarning($"Unknown CapsuleCollider direction: {capsuleCollider.direction} collider #{colliderIndex} of '{Part}' will be skipped.");
+                            continue;
                         }
                     }
                 }
@@ -165,7 +168,8 @@ namespace kOS.Suffixed.Part
                 }
                 else
                 {
-                    throw new Exception("Unknown Collider type: " + collider.GetType().FullName);
+                    SafeHouse.Logger.LogWarning($"Unknown Collider type: '{collider.GetType().FullName}' collider #{colliderIndex} of Part: '{Part}' will be skipped.");
+                    continue;
                 }
 
                 // Part meshes could be scaled as well as rotated (the mesh might describe a

--- a/src/kOS/Suffixed/Part/PartValue.cs
+++ b/src/kOS/Suffixed/Part/PartValue.cs
@@ -92,11 +92,16 @@ namespace kOS.Suffixed.Part
 
             Bounds unionBounds = new Bounds();
 
-            MeshFilter[] meshes = Part.GetComponentsInChildren<MeshFilter>();
-            for (int meshIndex = 0; meshIndex < meshes.Length; ++meshIndex)
+            Collider[] colliders = Part.GetComponentsInChildren<Collider>();
+            for (int colliderIndex = 0; colliderIndex < colliders.Length; ++colliderIndex)
             {
-                MeshFilter mesh = meshes[meshIndex];
-                Bounds bounds = mesh.mesh.bounds;
+                Collider collider = colliders[colliderIndex];
+
+                // Colliders that are triggers should be ignored.
+                // They merely fire an event when they intersect with something, but have no physics effect.
+                if (collider.isTrigger) continue;
+
+                Bounds bounds = collider.bounds;
 
                 // Part meshes could be scaled as well as rotated (the mesh might describe a
                 // part that's 1 meter wide while the real part is 2 meters wide, and has a scale of 2x
@@ -113,7 +118,7 @@ namespace kOS.Suffixed.Part
                         for (int signZ = -1; signZ <= 1; signZ += 2) // -1, then +1
                         {
                             Vector3 corner = center + new Vector3(signX * bounds.extents.x, signY * bounds.extents.y, signZ * bounds.extents.z);
-                            Vector3 worldCorner = mesh.transform.TransformPoint(corner);
+                            Vector3 worldCorner = collider.transform.TransformPoint(corner);
                             Vector3 partCorner = rotateYToZ * Part.transform.InverseTransformPoint(worldCorner);
 
                             // Stretches the bounds we're making (which started at size zero in all axes),

--- a/src/kOS/kOS.csproj
+++ b/src/kOS/kOS.csproj
@@ -90,6 +90,10 @@
     <Reference Include="UnityEngine.UnityWebRequestWWWModule">
       <HintPath>..\..\Resources\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
     </Reference>
+    <Reference Include="UnityEngine.VehiclesModule">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Resources\UnityEngine.VehiclesModule.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AddOns\ActionGroupsExtended\ActionGroupsExtendedAPI.cs" />


### PR DESCRIPTION
Changes the way a part's Bounds are computed from using the part's meshes to using colliders.
Colliders that are triggers are excluded.

Fixes #2942

See #2905 for additional information.