### PR TITLE
Fix "language" typo

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -35,7 +35,7 @@ What it does
 
 **kOS** introduces a few new parts that each contain a simulated
 computer capable of running programs written in its own scripting
-langauge called **kerboscript**.  The computer has powerful
+language called **kerboscript**.  The computer has powerful
 smarts built in to the hardware that allow it to do complex 
 spacecraft operations in one command, thus making it possible to
 make complex programs with only a few lines of script text.

--- a/doc/source/language/user_functions.rst
+++ b/doc/source/language/user_functions.rst
@@ -330,7 +330,7 @@ If you do, you will get seemingly "random" errors.  The reasons
 for this are complex, but the short version is because the
 memory the script files' pseudo-machine language instructions
 live in and the memory the interpreter's pseudo-machine
-langauge instructions live in are two different things.
+language instructions live in are two different things.
 
 The effect you may see if you attempt this is merely
 an "Unknown Identifer" error, or worse yet, it may end

--- a/doc/source/structures/misc/config.rst
+++ b/doc/source/structures/misc/config.rst
@@ -124,7 +124,7 @@ Configuration of kOS
 
     Configures the ``InstructionsPerUpdate`` setting.
 
-    This is the number of kRISC psuedo-machine-langauge instructions that each kOS CPU will attempt to execute from the main program per :ref:`physics update tick <cpu hardware>`.
+    This is the number of kRISC psuedo-machine-language instructions that each kOS CPU will attempt to execute from the main program per :ref:`physics update tick <cpu hardware>`.
 
     This value is constrained to stay within the range [50..2000]. If you set it to a value outside that range, it will reset itself to remain in that range.
 

--- a/src/kOS.Safe/Compilation/CompiledObject-doc.md
+++ b/src/kOS.Safe/Compilation/CompiledObject-doc.md
@@ -29,7 +29,7 @@ if you are thinking in terms of List&lt;Opcode&gt;, then you're thinking
 of what this document is calling *kRISC*
 
 The purpose of CompiledObject.cs is to convert between the kRISC and
-the Machine Langauge (ML) formats of storing the same thing.
+the Machine Language (ML) formats of storing the same thing.
 
 At What Level of the script compilation?
 ----------------------------------------

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -426,7 +426,7 @@ namespace kOS.Safe.Compilation
         }
         
         /// <summary>
-        /// Return the list of member Properties that are part of what gets stored to machine langauge
+        /// Return the list of member Properties that are part of what gets stored to machine language
         /// for this opcode.
         /// </summary>
         /// <returns></returns>


### PR DESCRIPTION
I noticed this on the front page while reading the docs, a quick search highlighted a few places where the same typo is made.

Only changes documentation, no actual code, so no functionality changes.

#2959 