### PR TITLE
Only use expensive stopwatches while profiling

### DIFF
--- a/src/kOS.Safe/Execution/CPU.cs
+++ b/src/kOS.Safe/Execution/CPU.cs
@@ -1542,16 +1542,21 @@ namespace kOS.Safe.Execution
                 {
                     opcode.ProfileTicksElapsed += instructionWatch.ElapsedTicks;
                     opcode.ProfileExecutionCount++;
-                    
                 }
-                // Add the time this took to the exeuction stats for current priority level:
-                if (! executionStats.ContainsKey(CurrentPriority))
-                    executionStats[CurrentPriority] = new ExecutionStatBlock();
-                executionStats[CurrentPriority].LogOneInstruction(instructionWatch.ElapsedTicks);
+                if (doProfiling || SafeHouse.Config.ShowStatistics)
+                {
+                    // Add the time this took to the exeuction stats for current priority level:
+                    if (! executionStats.ContainsKey(CurrentPriority))
+                        executionStats[CurrentPriority] = new ExecutionStatBlock();
+                    executionStats[CurrentPriority].LogOneInstruction(instructionWatch.ElapsedTicks);
+                }
 
                 // start the *next* instruction's timer right after this instruction ended
                 instructionWatch.Reset();
-                instructionWatch.Start();
+                if (doProfiling || SafeHouse.Config.ShowStatistics)
+                {
+                    instructionWatch.Start();
+                }
 
                 if (opcode.AbortProgram)
                 {


### PR DESCRIPTION
After profiling I noticed that 7% of the time is being spent on tracking how long each instruction takes:
![without-optim](https://user-images.githubusercontent.com/296972/122109803-11ecbb80-ce1e-11eb-9a19-61fab9c7aaca.png)

This patch disables profiling unless it is explicitly enabled by the user:
![with-optim](https://user-images.githubusercontent.com/296972/122109809-13b67f00-ce1e-11eb-9094-f6d7d4f7aea0.png)