### PR TITLE
Culls out thruster transforms for other part variants from the RCS THRUSTVECTORS suffix

### DIFF
--- a/src/kOS/Suffixed/Part/RCSValue.cs
+++ b/src/kOS/Suffixed/Part/RCSValue.cs
@@ -110,8 +110,11 @@ namespace kOS.Suffixed.Part
             var toReturn = new ListValue();
             foreach (Transform t in module.thrusterTransforms)
             {
-                // RCS thrusts along up. Possibly useZAxis property means it thrusts along forward?
-                toReturn.Add(new Vector(t.up));
+                if (t.gameObject.activeInHierarchy)
+                {
+                    // RCS thrusts along up. Possibly useZAxis property means it thrusts along forward?
+                    toReturn.Add(new Vector(t.up));
+                }
             }
             return toReturn;
         }


### PR DESCRIPTION
Replicated the same changes made in #2923 to fix #2973.