### PR TITLE
Change Voice.Volume to be a persistent volume for the Voice itself. Fix #2976

### DIFF
--- a/src/kOS/Sound/Voice.cs
+++ b/src/kOS/Sound/Voice.cs
@@ -14,9 +14,15 @@ namespace kOS.Sound
         public float Frequency { get; set; }
 
         /// <summary>
-        /// Value from 0.0f to 1.0f for the current *overall* volume (which gets adjusted by ADSR envelope settings).
+        /// Value from 0.0f to 1.0f for the volume of this <see cref="Voice"/>.
+        /// The final volume is computed by multiplying this value with <see cref="soundVolume"/> as specified by <see cref="BeginProceduralSound"/> and the ADSR envelope.
         /// </summary>
         public float Volume { get; set; }
+
+        /// <summary>
+        /// Value from 0.0f to 1.0f for the sound being played, as it is specified by <see cref="BeginProceduralSound"/>.
+        /// </summary>
+        private float soundVolume { get;set;}
 
         /// <summary>
         /// Duration in seconds of the "Attack" part of the sound envelope this voice is currently using.
@@ -102,7 +108,7 @@ namespace kOS.Sound
             SetWave(waveGen); // update the wave even if called for a rest note
             if (frequency > 0)
             {
-                Volume = volume;
+                soundVolume = volume;
                 noteAttackStart = Time.unscaledTime;
                 noteReleaseStart = Time.unscaledTime + duration;
                 needNoteInit = true;
@@ -126,7 +132,7 @@ namespace kOS.Sound
         {
             if (frequency > 0)
             {
-                Volume = volume;
+                soundVolume = volume;
                 noteAttackStart = Time.unscaledTime;
                 noteReleaseStart = Time.unscaledTime + duration;
                 needNoteInit = true;
@@ -267,7 +273,7 @@ namespace kOS.Sound
                     }
                 }
             }
-            source.volume = GameSettings.UI_VOLUME * Volume * envelopeVolume;
+            source.volume = GameSettings.UI_VOLUME * Volume * soundVolume * envelopeVolume;
         }
 
         /// <summary>Called whenever a new note starts, to get the AudioSource and ProceduralSoundWave


### PR DESCRIPTION
Voice.Volume is now independent of the currently playing Note's volume.
This is done by adding a private variable to hold the volume as it was specified by the sound or note being played, leaving Voice.Volume to be the volume for the Voice itself.
Both volume values are multiplied together to get the final volume for the sound.

Fixes #2976 

Example script:
```
Local v0 to GetVoice(0).
Set v0:loop to False.

Local softNote is Note(440, 1, 1, 0.5).
Local loudNote is Note(440, 1, 1, 1).

Local Function PlayNotes
{
	Print("Playing soft note...").
	v0:Play(softNote).
	wait softNote:duration.
	Print("Voice volume is now: " + v0:Volume).

	Print("Playing loud note...").
	v0:Play(loudNote).
	wait loudNote:duration.
	Print("Voice volume is now: " + v0:Volume).
}

Until false {
	Set v0:volume to 1.
	Print("Set Voice:Volume to: " + v0:Volume).

	PlayNotes().

	set v0:volume to 0.5.
	Print("Set Voice:Volume to: " + v0:Volume).

	PlayNotes().

	wait 0.5.
}
```
