### PR TITLE
Fixes #3002 ModuleCargoPart breaks PAW.

### DIFF
--- a/Resources/GameData/kOS/Parts/KOSCherryLight/part-mm.cfg
+++ b/Resources/GameData/kOS/Parts/KOSCherryLight/part-mm.cfg
@@ -1,0 +1,23 @@
+// --------------------------------------------
+
+// Only define a ModuleCargoPart for this part if the KSP version is high
+// enough that it's safe to do so. 
+//
+// ModuleCargoPart was first meant to be used by modders starting in
+// KSP v1.11.0, but a broken incomplete version of a class with that
+// same name secretly existed in earlier versions of KSP's DLL. So
+// if you unconditionally add it in the Part.cfg regardless of
+// KSP version you'll invoke that earlier broken version of the
+// class and that makes the part's PAW fail to open in the VAB/SPH.
+//
+// The Size2LFB_v2 engine was first added to stock in KSP v1.11.0.
+// That's being used here as a kludgy proxy test for the KSP version
+// because ModuleManager hasn't added a KSP version check feature yet.
+@PART[Cherry Light]:FOR[kOS]:NEEDS[Squad/Parts/Engine/Size2LFB_v2]
+{
+    %MODULE[ModuleCargoPart]
+    {
+       %name = ModuleCargoPart
+       %packedVolume = 100
+    }
+}

--- a/Resources/GameData/kOS/Parts/KOSCherryLight/part.cfg
+++ b/Resources/GameData/kOS/Parts/KOSCherryLight/part.cfg
@@ -41,10 +41,5 @@ PART
         resourceAmount = 0.02
         animationName = Rotation
     }
-    MODULE
-    {
-        name = ModuleCargoPart
-        packedVolume = 100
-    }
-
+    
 }

--- a/Resources/GameData/kOS/Parts/kOSMachine0m/part-mm.cfg
+++ b/Resources/GameData/kOS/Parts/kOSMachine0m/part-mm.cfg
@@ -1,0 +1,23 @@
+// --------------------------------------------
+
+// Only define a ModuleCargoPart for this part if the KSP version is high
+// enough that it's safe to do so. 
+//
+// ModuleCargoPart was first meant to be used by modders starting in
+// KSP v1.11.0, but a broken incomplete version of a class with that
+// same name secretly existed in earlier versions of KSP's DLL. So
+// if you unconditionally add it in the Part.cfg regardless of
+// KSP version you'll invoke that earlier broken version of the
+// class and that makes the part's PAW fail to open in the VAB/SPH.
+//
+// The Size2LFB_v2 engine was first added to stock in KSP v1.11.0.
+// That's being used here as a kludgy proxy test for the KSP version
+// because ModuleManager hasn't added a KSP version check feature yet.
+@PART[KR-2042]:FOR[kOS]:NEEDS[Squad/Parts/Engine/Size2LFB_v2]
+{
+    %MODULE[ModuleCargoPart]
+    {
+       %name = ModuleCargoPart
+       %packedVolume = 60
+    }
+}

--- a/Resources/GameData/kOS/Parts/kOSMachine0m/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSMachine0m/part.cfg
@@ -73,10 +73,4 @@ PART
         animationName = flickerStart
     }
 
-    MODULE
-    {
-        name = ModuleCargoPart
-        packedVolume = 60
-    }
-
 }

--- a/Resources/GameData/kOS/Parts/kOSMachine1m/part-mm.cfg
+++ b/Resources/GameData/kOS/Parts/kOSMachine1m/part-mm.cfg
@@ -1,0 +1,24 @@
+// Module Manager config addendum for this part
+// --------------------------------------------
+
+// Only define a ModuleCargoPart for this part if the KSP version is high
+// enough that it's safe to do so. 
+//
+// ModuleCargoPart was first meant to be used by modders starting in
+// KSP v1.11.0, but a broken incomplete version of a class with that
+// same name secretly existed in earlier versions of KSP's DLL. So
+// if you unconditionally add it in the Part.cfg regardless of
+// KSP version you'll invoke that earlier broken version of the
+// class and that makes the part's PAW fail to open in the VAB/SPH.
+//
+// The Size2LFB_v2 engine was first added to stock in KSP v1.11.0.
+// That's being used here as a kludgy proxy test for the KSP version
+// because ModuleManager hasn't added a KSP version check feature yet.
+@PART[kOSMachine1m]:FOR[kOS]:NEEDS[Squad/Parts/Engine/Size2LFB_v2]
+{
+    %MODULE[ModuleCargoPart]
+    {
+       %name = ModuleCargoPart
+       %packedVolume = 650
+    }
+}

--- a/Resources/GameData/kOS/Parts/kOSMachine1m/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSMachine1m/part.cfg
@@ -57,9 +57,4 @@ PART
         maxAmount = 5
     }
 
-    MODULE
-    {
-        name = ModuleCargoPart
-        packedVolume = 650
-    }
 }

--- a/Resources/GameData/kOS/Parts/kOSMachineRad/part-mm.cfg
+++ b/Resources/GameData/kOS/Parts/kOSMachineRad/part-mm.cfg
@@ -1,0 +1,23 @@
+// --------------------------------------------
+
+// Only define a ModuleCargoPart for this part if the KSP version is high
+// enough that it's safe to do so. 
+//
+// ModuleCargoPart was first meant to be used by modders starting in
+// KSP v1.11.0, but a broken incomplete version of a class with that
+// same name secretly existed in earlier versions of KSP's DLL. So
+// if you unconditionally add it in the Part.cfg regardless of
+// KSP version you'll invoke that earlier broken version of the
+// class and that makes the part's PAW fail to open in the VAB/SPH.
+//
+// The Size2LFB_v2 engine was first added to stock in KSP v1.11.0.
+// That's being used here as a kludgy proxy test for the KSP version
+// because ModuleManager hasn't added a KSP version check feature yet.
+@PART[kOSMachineRad]:FOR[kOS]:NEEDS[Squad/Parts/Engine/Size2LFB_v2]
+{
+    %MODULE[ModuleCargoPart]
+    {
+       %name = ModuleCargoPart
+       %packedVolume = 200
+    }
+}

--- a/Resources/GameData/kOS/Parts/kOSMachineRad/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSMachineRad/part.cfg
@@ -55,11 +55,6 @@ PART
     }
     MODULE
     {
-        name = ModuleCargoPart
-        packedVolume = 200
-    }
-    MODULE
-    {
         name = ModuleDeployableSolarPanel
         sunTracking = false
         raycastTransformName = suncatcher

--- a/Resources/GameData/kOS/Parts/kOSkal9000/part-mm.cfg
+++ b/Resources/GameData/kOS/Parts/kOSkal9000/part-mm.cfg
@@ -1,0 +1,23 @@
+// --------------------------------------------
+
+// Only define a ModuleCargoPart for this part if the KSP version is high
+// enough that it's safe to do so. 
+//
+// ModuleCargoPart was first meant to be used by modders starting in
+// KSP v1.11.0, but a broken incomplete version of a class with that
+// same name secretly existed in earlier versions of KSP's DLL. So
+// if you unconditionally add it in the Part.cfg regardless of
+// KSP version you'll invoke that earlier broken version of the
+// class and that makes the part's PAW fail to open in the VAB/SPH.
+//
+// The Size2LFB_v2 engine was first added to stock in KSP v1.11.0.
+// That's being used here as a kludgy proxy test for the KSP version
+// because ModuleManager hasn't added a KSP version check feature yet.
+@PART[KAL9000]:FOR[kOS]:NEEDS[Squad/Parts/Engine/Size2LFB_v2]
+{
+    %MODULE[ModuleCargoPart]
+    {
+       %name = ModuleCargoPart
+       %packedVolume = 50
+    }
+}

--- a/Resources/GameData/kOS/Parts/kOSkal9000/part.cfg
+++ b/Resources/GameData/kOS/Parts/kOSkal9000/part.cfg
@@ -59,9 +59,4 @@ PART
         resourceAmount = 0.02
         animationName = KAL9000Lives
     }
-    MODULE
-    {
-        name = ModuleCargoPart
-        packedVolume = 50
-    }
 }


### PR DESCRIPTION
Fixes #3002

The fix was to only apply the ModuleCargoPart if the KSP version
is high enough to be safe, using ModuleManager to do it.

Note that ModuleManager still doesn't have a KSP version check filter,
so I had to indirectly check the version by looking to see if a known part
definition exists for a part that didn't exist prior to KSP 1.11.x.
That's an ugly kludge, but it does seem to be what all the other
modders who ran into this same problem did.