### PR TITLE
Fixes #3005 - now safe to use a setsuffix of a locked thing

### DIFF
--- a/kerboscript_tests/user_functions/functest34.ks
+++ b/kerboscript_tests/user_functions/functest34.ks
@@ -1,0 +1,57 @@
+//
+// Test SETSUFFIX on the left side of a SET.
+//
+
+// as a function:
+function aaa {
+  return ship.
+}
+set aaa:name to "A".
+set aaa():name to aaa:name + "B".
+set aaa:name to aaa:name + "C".
+if aaa:name = "ABC" {
+  print "SUCCESS: " + aaa:name + " = " + "ABC".
+} else {
+  print "FAILURE: " + aaa:name + " <> " + "ABC".
+}
+
+// as a lock:
+lock bbb to ship.
+set bbb:name to "A".
+set bbb():name to bbb:name + "B".
+set bbb:name to bbb:name + "C".
+if bbb:name = "ABC" {
+  print "SUCCESS: " + bbb:name + " = " + "ABC".
+} else {
+  print "FAILURE: " + bbb:name + " <> " + "ABC".
+}
+
+//
+// Test when it's a longer chain of suffixes:
+// Using SKID because it's a thing with settable suffixes:
+// 
+local VoiceLex is LEX(
+  "the_voices",
+  LEX(
+    "v0",
+    GetVoice(0),
+    "v1",
+    GetVoice(1)
+  )
+).
+// Using lex keys as suffix names to make a chain:
+set GetVoice(0):wave to "sine".
+set VoiceLex:the_voices:v0:wave to "triangle".
+if voicelex:the_voices:v0:wave = "triangle" {
+  print "SUCCESS: wave should be triangle and is " + voicelex:the_voices:v0:wave.
+} else {
+  print "FAILURE: wave should be triangle but is " + voicelex:the_voices:v0:wave.
+}
+// Using lex keys as array indeces to make a chain:
+set GetVoice(1):wave to "sine".
+set VoiceLex["the_voices"]["v1"]:wave to "sawtooth".
+if voicelex["the_voices"]["v1"]:wave = "sawtooth" {
+  print "SUCCESS: wave should be sawtooth and is " + voicelex["the_voices"]["v1"]:wave.
+} else {
+  print "FAILURE: wave should be sawtooth but is " + voicelex["the_voices"]["v1"]:wave.
+}

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -1744,7 +1744,7 @@ namespace kOS.Safe.Compilation.KS
 
                 bool remember = identifierIsSuffix;
                 identifierIsSuffix = (nodeIndex > 0);
-
+                bool suffixTrailersExist = node.Nodes.Count > 1;
                 ParseNode suffixTerm;
                 if (nodeIndex == 0)
                     suffixTerm = node.Nodes[nodeIndex];
@@ -1764,7 +1764,7 @@ namespace kOS.Safe.Compilation.KS
                 {
                     firstIdentifier = GetIdentifierText(suffixTerm);
                     UserFunction userFuncObject = GetUserFunctionWithScopeWalk(firstIdentifier, node);
-                    if (userFuncObject != null && !compilingSetDestination)
+                    if (userFuncObject != null && (suffixTrailersExist || !compilingSetDestination))
                     {
                         firstIdentifier = userFuncObject.ScopelessPointerIdentifier;
                         isUserFunc = true;

--- a/src/kOS.Safe/Encapsulation/KOSDelegate.cs
+++ b/src/kOS.Safe/Encapsulation/KOSDelegate.cs
@@ -1,4 +1,4 @@
-﻿using kOS.Safe.Encapsulation.Suffixes;
+using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Exceptions;
 using kOS.Safe.Execution;
 using System.Collections.Generic;


### PR DESCRIPTION
Fixes #3005 - The discussion of the problem is long, see the issue #3005.

There was logic in the compiler that handled this situation:

When in the context of compiling the lefthand side of a SET assignment,
if that lefthand side is a function name, it should suppress the "invoke
even when no parentheses are present" logic, like so:

```
  set x to { return 1. }. // x is now a delegate function.
  print x. // Should call x() the function, even with the () missing.
  set x to 3. // Should NOT call x() when replacing x with a 3.
```
The problem was that this same logic that tries to handle that was
partly firing off when the 'x' in question was followed by a suffix,
when that should not be happening in that case:
```
  set x to { return ship. }.
  set x:name to "hello". // Here x() DOES need to be called, to return
                         // SHIP, which then gets its suffix :name set.

```
It was partially skipping half the work of setting up for the function
call because it failed to realize one was coming.  The part it skipped
was the part that inserts the KOSArgMarker on the stack before the call
happens.