### PR TITLE
Prevent clobbering built-ins.

### DIFF
--- a/kerboscript_tests/user_functions/functest34.ks
+++ b/kerboscript_tests/user_functions/functest34.ks
@@ -1,0 +1,57 @@
+//
+// Test SETSUFFIX on the left side of a SET.
+//
+
+// as a function:
+function aaa {
+  return ship.
+}
+set aaa:name to "A".
+set aaa():name to aaa:name + "B".
+set aaa:name to aaa:name + "C".
+if aaa:name = "ABC" {
+  print "SUCCESS: " + aaa:name + " = " + "ABC".
+} else {
+  print "FAILURE: " + aaa:name + " <> " + "ABC".
+}
+
+// as a lock:
+lock bbb to ship.
+set bbb:name to "A".
+set bbb():name to bbb:name + "B".
+set bbb:name to bbb:name + "C".
+if bbb:name = "ABC" {
+  print "SUCCESS: " + bbb:name + " = " + "ABC".
+} else {
+  print "FAILURE: " + bbb:name + " <> " + "ABC".
+}
+
+//
+// Test when it's a longer chain of suffixes:
+// Using SKID because it's a thing with settable suffixes:
+// 
+local VoiceLex is LEX(
+  "the_voices",
+  LEX(
+    "v0",
+    GetVoice(0),
+    "v1",
+    GetVoice(1)
+  )
+).
+// Using lex keys as suffix names to make a chain:
+set GetVoice(0):wave to "sine".
+set VoiceLex:the_voices:v0:wave to "triangle".
+if voicelex:the_voices:v0:wave = "triangle" {
+  print "SUCCESS: wave should be triangle and is " + voicelex:the_voices:v0:wave.
+} else {
+  print "FAILURE: wave should be triangle but is " + voicelex:the_voices:v0:wave.
+}
+// Using lex keys as array indeces to make a chain:
+set GetVoice(1):wave to "sine".
+set VoiceLex["the_voices"]["v1"]:wave to "sawtooth".
+if voicelex["the_voices"]["v1"]:wave = "sawtooth" {
+  print "SUCCESS: wave should be sawtooth and is " + voicelex["the_voices"]["v1"]:wave.
+} else {
+  print "FAILURE: wave should be sawtooth but is " + voicelex["the_voices"]["v1"]:wave.
+}

--- a/src/kOS.Safe.Test/Execution/BaseIntegrationTest.cs
+++ b/src/kOS.Safe.Test/Execution/BaseIntegrationTest.cs
@@ -84,7 +84,9 @@ namespace kOS.Safe.Test.Execution
             {
                 LoadProgramsInSameAddressSpace = false,
                 IsCalledFromRun = false,
-                FuncManager = shared.FunctionManager
+                FuncManager = shared.FunctionManager,
+                BindManager = shared.BindingMgr,
+                AllowClobberBuiltins = SafeHouse.Config.AllowClobberBuiltIns
             });
             cpu.Boot();
 

--- a/src/kOS.Safe.Test/Execution/Config.cs
+++ b/src/kOS.Safe.Test/Execution/Config.cs
@@ -242,6 +242,18 @@ namespace kOS.Safe.Test
             }
         }
 
+        public bool AllowClobberBuiltIns
+        {
+            get
+            {
+                return false;
+            }
+
+            set
+            {
+            }
+        }
+
         public IList<ConfigKey> GetConfigKeys()
         {
             return new List<ConfigKey>();

--- a/src/kOS.Safe/Binding/IBindingManager.cs
+++ b/src/kOS.Safe/Binding/IBindingManager.cs
@@ -11,6 +11,7 @@ namespace kOS.Safe.Binding
         void AddSetter(string name, BindingSetDlg dlg);
         void AddSetter(IEnumerable<string> names, BindingSetDlg dlg);
         bool HasGetter(string name);
+        bool HasSetter(string name);
         void MarkVolatile(string name);
         void PreUpdate();
         void PostUpdate();

--- a/src/kOS.Safe/Compilation/CompilerOptions.cs
+++ b/src/kOS.Safe/Compilation/CompilerOptions.cs
@@ -1,4 +1,6 @@
 using kOS.Safe.Function;
+using kOS.Safe.Binding;
+
 namespace kOS.Safe.Compilation
 {
     public class CompilerOptions
@@ -13,7 +15,9 @@ namespace kOS.Safe.Compilation
         /// will not be one.
         /// </summary>
         public bool IsCalledFromRun { get; set; }
+        public bool AllowClobberBuiltins { get; set; }
         public IFunctionManager FuncManager { get; set; }
+        public IBindingManager BindManager { get; set; }
         public CompilerOptions()
         {
             LoadDefaults();
@@ -23,12 +27,24 @@ namespace kOS.Safe.Compilation
         {
             LoadProgramsInSameAddressSpace = false;
             FuncManager = null;
+            BindManager = null;
             IsCalledFromRun = true;
+            AllowClobberBuiltins = false;
         }
         
-        public bool BuiltInExists(string identifier)
+        public bool BuiltInFunctionExists(string identifier)
         {
-            return (FuncManager == null ) ? false : FuncManager.Exists(identifier);
+            return FuncManager != null && FuncManager.Exists(identifier);
+        }
+
+        public bool BoundGetVariableExists(string identifier)
+        {
+            return BindManager != null && BindManager.HasGetter(identifier);
+        }
+
+        public bool BoundSetVariableExists(string identifier)
+        {
+            return BindManager != null && BindManager.HasSetter(identifier);
         }
     }
 }

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -1644,7 +1644,7 @@ namespace kOS.Safe.Compilation.KS
 
             if (isDirect)
             {
-                if (options.FuncManager.Exists(directName)) // if the name is a built-in, then add the "()" after it.
+                if (options.BuiltInExists(directName)) // if the name is a built-in, then add the "()" after it.
                     directName += "()";
                 AddOpcode(new OpcodeCall(directName));
             }
@@ -1702,7 +1702,7 @@ namespace kOS.Safe.Compilation.KS
         {
             if (isDirect)
             {
-                if (options.FuncManager.Exists(directName)) // if the name is a built-in, then make a BuiltInDelegate
+                if (options.BuiltInExists(directName)) // if the name is a built-in, then make a BuiltInDelegate
                 {
                     AddOpcode(new OpcodePush(new KOSArgMarkerType()));
                     AddOpcode(new OpcodePush(directName));

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -1744,7 +1744,7 @@ namespace kOS.Safe.Compilation.KS
 
                 bool remember = identifierIsSuffix;
                 identifierIsSuffix = (nodeIndex > 0);
-
+                bool suffixTrailersExist = node.Nodes.Count > 1;
                 ParseNode suffixTerm;
                 if (nodeIndex == 0)
                     suffixTerm = node.Nodes[nodeIndex];
@@ -1764,7 +1764,7 @@ namespace kOS.Safe.Compilation.KS
                 {
                     firstIdentifier = GetIdentifierText(suffixTerm);
                     UserFunction userFuncObject = GetUserFunctionWithScopeWalk(firstIdentifier, node);
-                    if (userFuncObject != null && !compilingSetDestination)
+                    if (userFuncObject != null && (suffixTrailersExist || !compilingSetDestination))
                     {
                         firstIdentifier = userFuncObject.ScopelessPointerIdentifier;
                         isUserFunc = true;

--- a/src/kOS.Safe/Compilation/KS/UserFunction.cs
+++ b/src/kOS.Safe/Compilation/KS/UserFunction.cs
@@ -178,5 +178,10 @@ namespace kOS.Safe.Compilation.KS
         {
             return systemLocks.Contains(ScopelessIdentifier.ToLower());
         }
+
+        static public bool IsSystemLock(string name)
+        {
+            return systemLocks.Contains(name.ToLower());
+        }
     }
 }

--- a/src/kOS.Safe/Compilation/Script.cs
+++ b/src/kOS.Safe/Compilation/Script.cs
@@ -23,41 +23,6 @@ namespace kOS.Safe.Compilation
         /// <param name="startLineNum">Assuming scriptText is a subset of some bigger buffer, line 1 of scripttext
         /// corresponds to line (what) of the more global something, for reporting numbers on errors.</param>
         /// <param name="scriptText">The text to be compiled.</param>
-        /// <returns>The CodeParts made from the scriptText</returns>
-        public virtual List<CodePart> Compile(GlobalPath filePath, int startLineNum, string scriptText)
-        {
-            return Compile(filePath, startLineNum, scriptText, string.Empty);
-        }
-
-        /// <summary>
-        /// Compile source text into compiled codeparts.
-        /// </summary>
-        /// <param name="filePath">The name that should get reported to the user on
-        /// runtime errors in this compiled code. Even if the text is not from an
-        /// actual file this should still be a pseudo-filename for reporting, for
-        /// example "(commandline)" or "(socket stream)"
-        /// </param>
-        /// <param name="startLineNum">Assuming scriptText is a subset of some bigger buffer, line 1 of scripttext
-        /// corresponds to line (what) of the more global something, for reporting numbers on errors.</param>
-        /// <param name="scriptText">The text to be compiled.</param>
-        /// <param name="contextId">The name of the runtime context (i.e. "interpreter").</param>
-        /// <returns>The CodeParts made from the scriptText</returns>
-        public virtual List<CodePart> Compile(GlobalPath filePath, int startLineNum, string scriptText, string contextId)
-        {
-            return Compile(filePath, startLineNum, scriptText, contextId, new CompilerOptions());
-        }
-
-        /// <summary>
-        /// Compile source text into compiled codeparts.
-        /// </summary>
-        /// <param name="filePath">The name that should get reported to the user on
-        /// runtime errors in this compiled code. Even if the text is not from an
-        /// actual file this should still be a pseudo-filename for reporting, for
-        /// example "(commandline)" or "(socket stream)"
-        /// </param>
-        /// <param name="startLineNum">Assuming scriptText is a subset of some bigger buffer, line 1 of scripttext
-        /// corresponds to line (what) of the more global something, for reporting numbers on errors.</param>
-        /// <param name="scriptText">The text to be compiled.</param>
         /// <param name="contextId">The name of the runtime context (i.e. "interpreter").</param>
         /// <param name="options">settings for the compile</param>
         /// <returns>The CodeParts made from the scriptText</returns>

--- a/src/kOS.Safe/Encapsulation/IConfig.cs
+++ b/src/kOS.Safe/Encapsulation/IConfig.cs
@@ -23,6 +23,7 @@ namespace kOS.Safe.Encapsulation
         double TerminalBrightness {get; set; }
         int TerminalDefaultWidth { get; set; }
         int TerminalDefaultHeight { get; set; }
+        bool AllowClobberBuiltIns { get; set; }
         bool SuppressAutopilot { get; set; }
 
 

--- a/src/kOS.Safe/Encapsulation/KOSDelegate.cs
+++ b/src/kOS.Safe/Encapsulation/KOSDelegate.cs
@@ -1,4 +1,4 @@
-﻿using kOS.Safe.Encapsulation.Suffixes;
+using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Exceptions;
 using kOS.Safe.Execution;
 using System.Collections.Generic;

--- a/src/kOS.Safe/Execution/CPU.cs
+++ b/src/kOS.Safe/Execution/CPU.cs
@@ -203,6 +203,8 @@ namespace kOS.Safe.Execution
                     {
                         LoadProgramsInSameAddressSpace = true,
                         FuncManager = shared.FunctionManager,
+                        BindManager = shared.BindingMgr,
+                        AllowClobberBuiltins = SafeHouse.Config.AllowClobberBuiltIns,
                         IsCalledFromRun = false
                     };
 

--- a/src/kOS.Safe/Function/Misc.cs
+++ b/src/kOS.Safe/Function/Misc.cs
@@ -97,7 +97,12 @@ namespace kOS.Safe.Function
                 shared.Cpu.StartCompileStopwatch();
                 shared.ScriptHandler.ClearContext("program");
                 //string filePath = shared.VolumeMgr.GetVolumeRawIdentifier(shared.VolumeMgr.CurrentVolume) + "/" + fileName;
-                var options = new CompilerOptions { LoadProgramsInSameAddressSpace = true, FuncManager = shared.FunctionManager };
+                var options = new CompilerOptions
+                {
+                    LoadProgramsInSameAddressSpace = true,
+                    FuncManager = shared.FunctionManager,
+                    BindManager = shared.BindingMgr, AllowClobberBuiltins = Utilities.SafeHouse.Config.AllowClobberBuiltIns
+                };
                 var programContext = shared.Cpu.SwitchToProgramContext();
 
                 List<CodePart> codeParts;
@@ -207,7 +212,13 @@ namespace kOS.Safe.Function
             if (shared.ScriptHandler != null)
             {
                 shared.Cpu.StartCompileStopwatch();
-                var options = new CompilerOptions { LoadProgramsInSameAddressSpace = true, FuncManager = shared.FunctionManager };
+                var options = new CompilerOptions
+                {
+                    LoadProgramsInSameAddressSpace = true,
+                    FuncManager = shared.FunctionManager,
+                    AllowClobberBuiltins = Utilities.SafeHouse.Config.AllowClobberBuiltIns,
+                    BindManager = shared.BindingMgr
+                };
                 // add this program to the address space of the parent program,
                 // or to a file to save:
                 if (justCompiling)

--- a/src/kOS/Binding/BindingManager.cs
+++ b/src/kOS/Binding/BindingManager.cs
@@ -119,7 +119,20 @@ namespace kOS.Binding
         
         public bool HasGetter(string name)
         {
-            return variables.ContainsKey(name);
+            BoundVariable boundVar;
+            if (variables.TryGetValue(name, out boundVar))
+                if (boundVar.Get != null)
+                    return true;
+            return false;
+        }
+
+        public bool HasSetter(string name)
+        {
+            BoundVariable boundVar;
+            if (variables.TryGetValue(name, out boundVar))
+                if (boundVar.Set != null)
+                    return true;
+            return false;
         }
 
         /// <summary>

--- a/src/kOS/Module/kOSCustomParameters.cs
+++ b/src/kOS/Module/kOSCustomParameters.cs
@@ -102,6 +102,14 @@ namespace kOS.Module
                                          "paragraph-length descriptions that this enables.")]
         public bool verboseExceptions = true;
 
+        [GameParameters.CustomParameterUI("Allow clobbering built-ins",
+                                         toolTip = "True if scripts' variable and function names are allowed to hide or clobber kOS's\n" +
+                                         "built-in variables and functions, like THROTTLE, SHIP, PRINT(), and so on. This setting\n " +
+                                         "can be overridden per-script with the @CLOBBERBUILTINS compiler directive.\n" +
+                                         "(This should only be turned on if you need it for backward compatibilty to run older\n" +
+                                         "scripts written prior to kOS v1.4.x, from before kOS was enforcing this check.)")]
+        public bool clobberBuiltIns = false;
+
         [GameParameters.CustomParameterUI("Only use Blizzy toolbar", 
                                          toolTip = "If you have the \"Blizzy Toolbar\" mod installed, only put the kOS\n" +
                                          "button on it instead of both it and the stock toolbar.")]

--- a/src/kOS/Screen/Interpreter.cs
+++ b/src/kOS/Screen/Interpreter.cs
@@ -7,6 +7,7 @@ using kOS.Safe.Execution;
 using kOS.Safe.Screen;
 using kOS.Safe.UserIO;
 using kOS.Safe.Persistence;
+using kOS.Safe.Utilities;
 
 namespace kOS.Screen
 {
@@ -137,6 +138,8 @@ namespace kOS.Screen
                 {
                     LoadProgramsInSameAddressSpace = false,
                     FuncManager = Shared.FunctionManager,
+                    BindManager = Shared.BindingMgr,
+                    AllowClobberBuiltins = SafeHouse.Config.AllowClobberBuiltIns,
                     IsCalledFromRun = false
                 };
 

--- a/src/kOS/Screen/KOSToolbarWindow.cs
+++ b/src/kOS/Screen/KOSToolbarWindow.cs
@@ -526,6 +526,7 @@ namespace kOS.Screen
                 {
                     GUILayout.Label(key.Alias + " is a new type this dialog doesn't support.  Contact kOS devs.");
                 }
+
                 GUILayout.BeginHorizontal(GUILayout.ExpandWidth(true));
                 GUILayout.Label(new GUIContent(labelText, toolTipText), panelSkin.label);
                 GUILayout.EndHorizontal();

--- a/src/kOS/Suffixed/Config.cs
+++ b/src/kOS/Suffixed/Config.cs
@@ -24,6 +24,7 @@ namespace kOS.Suffixed
         public bool EnableSafeMode { get { return kOSCustomParameters.Instance.enableSafeMode; } set { kOSCustomParameters.Instance.enableSafeMode = value; } }
         public bool AudibleExceptions { get { return kOSCustomParameters.Instance.audibleExceptions; } set { kOSCustomParameters.Instance.audibleExceptions = value; } }
         public bool VerboseExceptions { get { return kOSCustomParameters.Instance.verboseExceptions; } set { kOSCustomParameters.Instance.verboseExceptions = value; } }
+        public bool AllowClobberBuiltIns { get { return kOSCustomParameters.Instance.clobberBuiltIns; } set { kOSCustomParameters.Instance.clobberBuiltIns = value; } }
         public bool EnableTelnet { get { return GetPropValue<bool>(PropId.EnableTelnet); } set { SetPropValue(PropId.EnableTelnet, value); } }
         public int TelnetPort { get { return GetPropValue<int>(PropId.TelnetPort); } set { SetPropValue(PropId.TelnetPort, value); } }
         public string TelnetIPAddrString { get { return GetPropValue<string>(PropId.TelnetIPAddrString); } set { SetPropValue(PropId.TelnetIPAddrString, value); } }        
@@ -60,6 +61,7 @@ namespace kOS.Suffixed
             AddSuffix("SAFE", new SetSuffix<BooleanValue>(() => EnableSafeMode, value => EnableSafeMode = value));
             AddSuffix("AUDIOERR", new SetSuffix<BooleanValue>(() => AudibleExceptions, value => AudibleExceptions = value));
             AddSuffix("VERBOSE", new SetSuffix<BooleanValue>(() => VerboseExceptions, value => VerboseExceptions = value));
+            AddSuffix("CLOBBERBUILTINS", new SetSuffix<BooleanValue>(() => AllowClobberBuiltIns, value => AllowClobberBuiltIns = value));
             AddSuffix("DEBUGEACHOPCODE", new SetSuffix<BooleanValue>(() => DebugEachOpcode, value => DebugEachOpcode = value));
             AddSuffix("BLIZZY", new SetSuffix<BooleanValue>(() => UseBlizzyToolbarOnly, value => UseBlizzyToolbarOnly = value));
             AddSuffix("BRIGHTNESS", new ClampSetSuffix<ScalarValue>(() => TerminalBrightness, value => TerminalBrightness = value, 0f, 1f, 0.01f));


### PR DESCRIPTION
(TODO: Read through the issues backlog and find issues this is connected to and put the reference number here so this will close them.  There's possibly more than one such issue.)

This implements a compile-time check that makes it illegal for a script (or the interpreter) to create an identifier that clashes with any of the following:

- The built-in variable names (SHIP, NORTH, ALTITUDE, VELOCITY, etc)
- The system locks (THROTTLE, STEERING, etc)
- The built-in function names (PRINT(), HEADING(), V(), R(), etc)

Note that this is a compile-time check, so it detects the problem and complains even if the offending line of script code is never reached and executed.

**The need for this PR is this**:

Once one of these built-in identifiers gets clobbered by the script, it often cannot be accessible again for the rest of that program.  (or the entire interpreter context).

**The danger with this PR is this**:

Because this was never enforced before, There's probably lots of scripts out there that may have accidentally used a name that masked a built-in, like the example below:

```
// R() is the built-in rotation constructor, and this next line
// replaces it with a new user-defined R() "function":
lock r to 1.

// But if the script never tries to use R() from here on,
// it might have worked anyway, blissfully unaware that it wiped out
// a built-in function.
```

This enforcement in this PR, while better practice, would break existing scripts that have things like the situation above, and require having them rename such variables.  If it's a script the user is actively working on, that's no big deal.  If it's a script the user found out on the internet, it is.

