### PR TITLE
Fix a bunch of inconsistencies in the documentation

### DIFF
--- a/doc/KerboscriptLexer.py
+++ b/doc/KerboscriptLexer.py
@@ -4,11 +4,9 @@
 
 import re
 
-from pygments.lexer import RegexLexer, include, bygroups, using, \
-    this, inherit, default, words
-from pygments.util import get_bool_opt
+from pygments.lexer import RegexLexer, words
 from pygments.token import Text, Comment, Operator, Keyword, Name, String, \
-    Number, Punctuation, Error
+    Number, Punctuation
 from sphinx.highlighting import lexers
 
 class KerboscriptLexer(RegexLexer):

--- a/doc/KerboscriptLexer.py
+++ b/doc/KerboscriptLexer.py
@@ -9,6 +9,7 @@ from pygments.lexer import RegexLexer, include, bygroups, using, \
 from pygments.util import get_bool_opt
 from pygments.token import Text, Comment, Operator, Keyword, Name, String, \
     Number, Punctuation, Error
+from sphinx.highlighting import lexers
 
 class KerboscriptLexer(RegexLexer):
    
@@ -66,4 +67,4 @@ class KerboscriptLexer(RegexLexer):
     }
 
 def setup(app):
-    app.add_lexer("kerboscript", KerboscriptLexer())
+    lexers['kerboscript'] = KerboscriptLexer()

--- a/doc/ksdomain.py
+++ b/doc/ksdomain.py
@@ -3,18 +3,15 @@
 import sys
 import re
 
-from docutils import nodes
-from docutils.parsers.rst import directives
-
 from sphinx import addnodes, version_info
 from sphinx.roles import XRefRole
 from sphinx.locale import _
-from sphinx.domains import Domain, ObjType, Index
+from sphinx.domains import Domain, ObjType
 from sphinx.directives import ObjectDescription
 from sphinx.util.nodes import make_refnode
 # ### Next line is deprecated, and it seems to work without it, as per kOS PR #2339 ###
 # from sphinx.util.compat import Directive
-from sphinx.util.docfields import Field, GroupedField, TypedField
+from sphinx.util.docfields import Field, TypedField
 
 ks_sig_re = re.compile(r'''
     (?:

--- a/doc/ksdomain.py
+++ b/doc/ksdomain.py
@@ -8,7 +8,7 @@ from docutils.parsers.rst import directives
 
 from sphinx import addnodes, version_info
 from sphinx.roles import XRefRole
-from sphinx.locale import l_, _
+from sphinx.locale import _
 from sphinx.domains import Domain, ObjType, Index
 from sphinx.directives import ObjectDescription
 from sphinx.util.nodes import make_refnode
@@ -68,8 +68,8 @@ class KOSObject(ObjectDescription):
 
 class KOSGlobal(KOSObject):
     doc_field_types = [
-        Field('access', label=l_('Access'), has_arg=False),
-        Field('type'  , label=l_('Type'  ), has_arg=False),
+        Field('access', label=_('Access'), has_arg=False),
+        Field('type'  , label=_('Type'  ), has_arg=False),
     ]
 
     def handle_signature(self, sig, signode):
@@ -86,13 +86,13 @@ class KOSGlobal(KOSObject):
 
 class KOSFunction(KOSObject):
     doc_field_types = [
-        Field('access', label=l_('Access'), has_arg=False),
-        TypedField('parameter', label=l_('Parameters'),
+        Field('access', label=_('Access'), has_arg=False),
+        TypedField('parameter', label=_('Parameters'),
                    names=('param', 'parameter', 'arg', 'argument'),
                    typerolename='struct', typenames=('paramtype', 'type')),
-        Field('returnvalue', label=l_('Returns'), has_arg=False,
+        Field('returnvalue', label=_('Returns'), has_arg=False,
               names=('returns', 'return')),
-        Field('returntype', label=l_('Return type'), has_arg=False,
+        Field('returntype', label=_('Return type'), has_arg=False,
               names=('rtype','type')),
     ]
 
@@ -114,7 +114,7 @@ class KOSFunction(KOSObject):
 
 class KOSKeyword(KOSObject):
     doc_field_types = [
-        TypedField('parameter', label=l_('Parameters'),
+        TypedField('parameter', label=_('Parameters'),
                    names=('param', 'parameter', 'arg', 'argument'),
                    typerolename='struct', typenames=('paramtype', 'type')),
     ]
@@ -148,8 +148,8 @@ class KOSStructure(KOSObject):
 class KOSAttribute(KOSObject):
 
     doc_field_types = [
-        Field('access', label=l_('Access'), has_arg=False),
-        Field('type'  , label=l_('Type'  ), has_arg=False),
+        Field('access', label=_('Access'), has_arg=False),
+        Field('type'  , label=_('Type'  ), has_arg=False),
     ]
 
     def handle_signature(self, sig, signode):
@@ -185,13 +185,13 @@ class KOSAttribute(KOSObject):
 class KOSMethod(KOSObject):
 
     doc_field_types = [
-        Field('access', label=l_('Access'), has_arg=False),
-        TypedField('parameter', label=l_('Parameters'),
+        Field('access', label=_('Access'), has_arg=False),
+        TypedField('parameter', label=_('Parameters'),
                    names=('param', 'parameter', 'arg', 'argument'),
                    typerolename='obj', typenames=('paramtype', 'type')),
-        Field('returnvalue', label=l_('Returns'), has_arg=False,
+        Field('returnvalue', label=_('Returns'), has_arg=False,
               names=('returns', 'return')),
-        Field('returntype', label=l_('Return type'), has_arg=False,
+        Field('returntype', label=_('Return type'), has_arg=False,
               names=('rtype','type')),
     ]
 
@@ -267,12 +267,12 @@ class KOSDomain(Domain):
     }
 
     object_types = {
-        'global'   : ObjType(l_('global'   ), 'global'),
-        'function' : ObjType(l_('function' ), 'func'  ),
-        'keyword'  : ObjType(l_('keyword'  ), 'key'   ),
-        'structure': ObjType(l_('structure'), 'struct'),
-        'attribute': ObjType(l_('attribure'), 'attr'  ),
-        'method'   : ObjType(l_('method'   ), 'meth'  ),
+        'global'   : ObjType(_('global'   ), 'global'),
+        'function' : ObjType(_('function' ), 'func'  ),
+        'keyword'  : ObjType(_('keyword'  ), 'key'   ),
+        'structure': ObjType(_('structure'), 'struct'),
+        'attribute': ObjType(_('attribure'), 'attr'  ),
+        'method'   : ObjType(_('method'   ), 'meth'  ),
     }
     directives = {
         'global'   : KOSGlobal,

--- a/doc/source/bindings.rst
+++ b/doc/source/bindings.rst
@@ -533,7 +533,7 @@ For Kerbals, it refers to a more arbitrary line in space, pointing at a fixed
 point in the firmament, also known as the "skybox".
 
 OPCODESLEFT
----------
+-----------
 
 This returns the amount of IPU that are left in this physics tick. This means
 that if you receive the value 20, you can run 20 more instructions. After this
@@ -544,7 +544,7 @@ OPCODESLEFT can be used to try to make sure you run a block of code in one
 physics tick. This is useful when working with vectors or when interacting
 with shared message queues. 
 
-To use:
+To use::
 
    // Will always wait the first time, becomes more accurate the second time.
    GLOBAL OPCODESNEEDED TO 1000.

--- a/doc/source/language/variables.rst
+++ b/doc/source/language/variables.rst
@@ -537,12 +537,12 @@ with one of your own names.
 
 .. warning::
     .. versionadded:: 1.4.0.0
-    ** BREAKING CHANGE: **
-    kOS only started enforcing this rule in kOS 1.4.0.0 and up, so old
-    scripts you find on the internet might generate errors because of
-    this new enforcement.  See :attr:`Config:CLOBBERBUILTINS` or
-    :ref:`@CLOBBERBUILTINS <clobberbuiltins>` if you wish to disable
-    this check and get the old behavior back.
+        ** BREAKING CHANGE: **
+        kOS only started enforcing this rule in kOS 1.4.0.0 and up, so old
+        scripts you find on the internet might generate errors because of
+        this new enforcement.  See :attr:`Config:CLOBBERBUILTINS` or
+        :ref:`@CLOBBERBUILTINS <clobberbuiltins>` if you wish to disable
+        this check and get the old behavior back.
 
 For example, because kOS has the built-in function :func:`V(x,y,z)`,
 which makes a vector, you shouldn't make a user defined function

--- a/doc/source/math/basic.rst
+++ b/doc/source/math/basic.rst
@@ -535,7 +535,7 @@ Trigonometric Functions
 
 .. function:: ARCSIN(x)
 
-    :parameter x: (:ref:`scalar <scalar>`)
+    :parameter x: (:struct:`Scalar`)
     :return: (deg) angle whose sine is x
 
     ::
@@ -544,7 +544,7 @@ Trigonometric Functions
 
 .. function:: ARCCOS(x)
 
-    :parameter x: (:ref:`scalar <scalar>`)
+    :parameter x: (:struct:`Scalar`)
     :return: (deg) angle whose cosine is x
 
     ::
@@ -553,7 +553,7 @@ Trigonometric Functions
 
 .. function:: ARCTAN(x)
 
-    :parameter x: (:ref:`scalar <scalar>`)
+    :parameter x: (:struct:`Scalar`)
     :return: (deg) angle whose tangent is x
 
     ::
@@ -562,8 +562,8 @@ Trigonometric Functions
 
 .. function:: ARCTAN2(y,x)
 
-    :parameter y: (:ref:`scalar <scalar>`)
-    :parameter x: (:ref:`scalar <scalar>`)
+    :parameter y: (:struct:`Scalar`)
+    :parameter x: (:struct:`Scalar`)
     :return: (deg) angle whose tangent is :math:`\frac{y}{x}`
 
     ::

--- a/doc/source/math/direction.rst
+++ b/doc/source/math/direction.rst
@@ -139,9 +139,9 @@ Structure
     ========================= ======================= ================================
      Suffix                   Type                    Description
     ========================= ======================= ================================
-     :attr:`PITCH`            :struct:`scalar` (deg)  Rotation around :math:`x` axis
-     :attr:`YAW`              :struct:`scalar` (deg)  Rotation around :math:`y` axis
-     :attr:`ROLL`             :struct:`scalar` (deg)  Rotation around :math:`z` axis
+     :attr:`PITCH`            :struct:`Scalar` (deg)  Rotation around :math:`x` axis
+     :attr:`YAW`              :struct:`Scalar` (deg)  Rotation around :math:`y` axis
+     :attr:`ROLL`             :struct:`Scalar` (deg)  Rotation around :math:`z` axis
      :attr:`FOREVECTOR`       :struct:`Vector`        This Direction's forward vector (z axis after rotation).
      ``VECTOR``               :struct:`Vector`        Alias synonym for :attr:`FOREVECTOR`
      :attr:`TOPVECTOR`        :struct:`Vector`        This Direction's top vector (y axis after rotation).
@@ -222,20 +222,23 @@ You can use math operations on :struct:`Direction` objects as well. The next exa
 
 Supported Direction Operators:
 
-:Direction Multiplied by Direction:
+Direction Multiplied by Direction:
     ``Dir1 * Dir2`` - This operator returns the result of rotating Dir2 by the rotation of Dir1.  Note that the order of operations matters here.  ``Dir1*Dir2`` is not the same as ``Dir2*Dir1``.  Example::
 
-        // A direction pointing along compass heading 330, by rotating NORTH by 30 degrees around UP axis:
+        // A direction pointing along compass heading 330,
+        // by rotating NORTH by 30 degrees around UP axis:
         SET newDir TO ANGLEAXIS(30,SHIP:UP) * NORTH.
 
-:Direction Multiplied by Vector:
+Direction Multiplied by Vector:
     ``Dir * Vec`` - This operator returns the result of rotating the vector by Dir::
 
-        // What would the velocity of your ship be if it was angled 20 degrees to your left?
+        // What would the velocity of your ship be
+        // if it was angled 20 degrees to your left?
         SET Vel to ANGLEAXIS(-20,SHIP:TOPVECTOR) * SHIP:VELOCITY:ORBIT.
-        // At this point Vel:MAG and SHIP:VELOCITY:MAG should be the same, but they don't point the same way
+        // At this point Vel:MAG and SHIP:VELOCITY:MAG should be the same,
+        // but they don't point the same way
 
-:Direction Added to Direction:
+Direction Added to Direction:
     ``Dir1 + Dir2`` - This operator is less reliable because its exact behavior depends on the order of operations of the UnityEngine's X Y and Z axis rotations, and it can result in gimbal lock.
 
     It's supposed to perform a Euler rotation of one direction by another, but it's preferred to use ``Dir*Dir`` instead, as that doesn't experience gimbal lock, and does not require that you know the exact transformation order of Unity.

--- a/doc/source/math/geocoordinates.rst
+++ b/doc/source/math/geocoordinates.rst
@@ -49,40 +49,40 @@ Structure
           - Description
 
         * - :attr:`BODY`
-          - :ref:`body <body>` (m)
+          - :struct:`Body` (m)
 	  - none
           - The celestial body this geocoordinates is on.
         * - :attr:`LAT`
-          - :ref:`scalar <scalar>` (deg)
+          - :struct:`Scalar` (deg)
 	  - none
           - Latitude
         * - :attr:`LNG`
-          - :ref:`scalar <scalar>` (deg)
+          - :struct:`Scalar` (deg)
 	  - none
           - Longitude
         * - :attr:`DISTANCE`
-          - :ref:`scalar <scalar>` (m)
+          - :struct:`Scalar` (m)
 	  - none
           - distance from :ref:`CPU Vessel <cpu vessel>`
         * - :attr:`TERRAINHEIGHT`
-          - :ref:`scalar <scalar>` (m)
+          - :struct:`Scalar` (m)
 	  - none
           - above or below sea level
         * - :attr:`HEADING`
-          - :ref:`scalar <scalar>` (deg)
+          - :struct:`Scalar` (deg)
 	  - none
           - *absolute* heading from :ref:`CPU Vessel <cpu vessel>`
         * - :attr:`BEARING`
-          - :ref:`scalar <scalar>` (deg)
+          - :struct:`Scalar` (deg)
 	  - none
           - *relative* direction from :ref:`CPU Vessel <cpu vessel>`
         * - :attr:`POSITION`
-          - `Vector` (3D Ship-Raw coords)
+          - :struct:`Vector` (3D Ship-Raw coords)
 	  - none
           - Position of the surface point.
         * - :attr:`ALTITUDEPOSITION`
-          - `Vector` (3D Ship-Raw coords)
-	  - :ref:`scalar <scalar>` (altitude above sea level)
+          - :struct:`Vector` (3D Ship-Raw coords)
+	  - :struct:`Scalar` (altitude above sea level)
           - Position of a point above (or below) the surface point, by giving the altitude number.
         * - :attr:`VELOCITY`
           - :struct:`OrbitableVelocity`
@@ -90,7 +90,7 @@ Structure
           - Velocity of the surface at this point (due to the rotation of the planet/moon).
         * - :attr:`ALTITUDEVELOCITY`
           - :struct:`OrbitableVelocity`
-	  - :ref:`scalar <scalar>` (altitude above sea level)
+	  - :struct:`Scalar` (altitude above sea level)
           - Velocity of a point above (or below) the surface point, by giving the altitude number.
 
 .. note::

--- a/doc/source/math/scalar.rst
+++ b/doc/source/math/scalar.rst
@@ -138,4 +138,3 @@ not how many places after the decimal point.  You can't have more than
 roughly 15 significant decimal digits. (It's not exactly 15 because of
 differences between binary and decimal counting, but that gives you
 a rough estimate.)
-

--- a/doc/source/math/vector.rst
+++ b/doc/source/math/vector.rst
@@ -42,19 +42,19 @@ Structure
           - Set
 
         * - :attr:`X`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - yes
           - yes
         * - :attr:`Y`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - yes
           - yes
         * - :attr:`Z`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - yes
           - yes
         * - :attr:`MAG`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - yes
           - yes
         * - :attr:`NORMALIZED`
@@ -62,7 +62,7 @@ Structure
           - yes
           - no
         * - :attr:`SQRMAGNITUDE`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - yes
           - no
         * - :attr:`DIRECTION`
@@ -80,28 +80,28 @@ Structure
 
 .. attribute:: Vector:X
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get/Set
 
     The :math:`x` component of the vector.
 
 .. attribute:: Vector:Y
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get/Set
 
     The :math:`y` component of the vector.
 
 .. attribute:: Vector:Z
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get/Set
 
     The :math:`z` component of the vector.
 
 .. attribute:: Vector:MAG
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get/Set
 
     The magnitude of the vector, as a scalar number, by the Pythagorean Theorem.
@@ -115,7 +115,7 @@ Structure
 
 .. attribute:: Vector:SQRMAGNITUDE
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     The magnitude of the vector, squared. Use instead of ``vec:MAG^2`` if you need to square of the magnitude as this skips the step in the Pythagorean formula where you take the square root in the first place. Taking the square root and then squaring that would introduce floating point error needlessly.
@@ -147,13 +147,13 @@ Operations and Methods
 ======================================================================== =============
 Method / Operator                                                         Return Type
 ======================================================================== =============
- :ref:`* (asterisk) <Vector *>`                                          :struct:`scalar` or :struct:`Vector`
+ :ref:`* (asterisk) <Vector *>`                                          :struct:`Scalar` or :struct:`Vector`
  :ref:`+ (plus)     <Vector +->`                                         :struct:`Vector`
  :ref:`- (minus)    <Vector +->`                                         :struct:`Vector`
  :ref:`- (unary)    <Vector +->`                                         :struct:`Vector`
- :func:`VDOT`, :func:`VECTORDOTPRODUCT`, :ref:`* (asterisk) <Vector *>`  :struct:`scalar`
+ :func:`VDOT`, :func:`VECTORDOTPRODUCT`, :ref:`* (asterisk) <Vector *>`  :struct:`Scalar`
  :func:`VCRS`, :func:`VECTORCROSSPRODUCT`                                :struct:`Vector`
- :func:`VANG`, :func:`VECTORANGLE`                                       :struct:`scalar` (deg)
+ :func:`VANG`, :func:`VECTORANGLE`                                       :struct:`Scalar` (deg)
  :func:`VXCL`, :func:`VECTOREXCLUDE`                                     :struct:`Vector`
 ======================================================================== =============
 
@@ -207,7 +207,7 @@ Method / Operator                                                         Return
     :parameter v1: (:struct:`Vector`)
     :parameter v2: (:struct:`Vector`)
     :return: The `vector dot-product <https://mathinsight.org/dot_product>`__
-    :rtype: :struct:`scalar`
+    :rtype: :struct:`Scalar`
 
     This is the `dot product <https://mathinsight.org/dot_product>`__ of two vectors returning a scalar number. This is the same as :ref:`v1 * v2 <Vector *>`::
 
@@ -256,7 +256,7 @@ Method / Operator                                                         Return
     :parameter v1: (:struct:`Vector`)
     :parameter v2: (:struct:`Vector`)
     :return: Angle between two vectors
-    :rtype: :ref:`scalar <scalar>`
+    :rtype: :struct:`Scalar`
 
     This returns the angle between v1 and v2. It is the same result as:
 

--- a/doc/source/structures/celestial_bodies/atmosphere.rst
+++ b/doc/source/structures/celestial_bodies/atmosphere.rst
@@ -16,67 +16,67 @@ A Structure closely tied to :struct:`Body` A variable of type :struct:`Atmospher
           - Description
 
         * - :attr:`BODY`
-          - :ref:`string <string>`
+          - :struct:`String`
           - Name of the celestial body
         * - :attr:`EXISTS`
-          - :ref:`boolean <boolean>`
+          - :struct:`Boolean`
           - True if this body has an atmosphere
         * - :attr:`OXYGEN`
-          - :ref:`boolean <boolean>`
+          - :struct:`Boolean`
           - True if oxygen is present
         * - :attr:`SCALE` (DEPRECATED)
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Used to find atmospheric density
         * - :attr:`SEALEVELPRESSURE`
-          - :ref:`scalar <scalar>` (atm)
+          - :struct:`Scalar` (atm)
           - pressure at sea level
         * - :meth:`ALTITUDEPRESSURE(altitude)`
-          - :ref:`scalar <scalar>` (atm)
+          - :struct:`Scalar` (atm)
           - pressure at the givel altitude
         * - :attr:`HEIGHT`
-          - :ref:`scalar <scalar>` (m)
+          - :struct:`Scalar` (m)
           - advertised atmospheric height
         * - :attr:`MOLARMASS`
-          - :ref:`scalar <scalar>` (kg/mol)
+          - :struct:`Scalar` (kg/mol)
           - The molecular mass of the atmosphere's gas
         * - :attr:`ADIABATICINDEX`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - The Adiabatic index of the atmosphere's gas
         * - :attr:`ADBIDX`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Short alias for :attr:`ADIABATICINDEX`
         * - :meth:`ALTITUDETEMPERATURE(altitude)`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Estimate of temperature at the given altitude.
         * - :meth:`ALTTEMP(altitude)`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Short alias for :attr:`ALTITUDETEMPERATURE`
 
 
 .. attribute:: Atmosphere:BODY
 
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
     :access: Get only
 
     The Body that this atmosphere is around - as a STRING NAME, not a Body object.
 
 .. attribute:: Atmosphere:EXISTS
 
-    :type: :ref:`boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get only
 
     True if this atmosphere is "real" and not just a dummy placeholder.
 
 .. attribute:: Atmosphere:OXYGEN
 
-    :type: :ref:`boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get only
 
     True if the air has oxygen and could therefore be used by a jet engine's intake.
 
 .. attribute:: Atmosphere:SEALEVELPRESSURE
 
-    :type: :ref:`scalar <scalar>` (atm)
+    :type: :struct:`Scalar` (atm)
     :access: Get only
 
     Pressure at the body's sea level.
@@ -93,7 +93,7 @@ A Structure closely tied to :struct:`Body` A variable of type :struct:`Atmospher
 .. method:: Atmosphere:ALTITUDEPRESSURE(altitude)
 
     :parameter altitude: The altitude above sea level (in meters) you want to know the pressure for.
-    :type: :ref:`scalar <scalar>` (atm)
+    :type: :struct:`Scalar` (atm)
 
     Number of Atm's of atmospheric pressure at the given altitude.
     If you pass in zero, you should get the sea level pressure.
@@ -107,14 +107,14 @@ A Structure closely tied to :struct:`Body` A variable of type :struct:`Atmospher
 
 .. attribute:: Atmosphere:HEIGHT
 
-    :type: :ref:`scalar <scalar>` (m)
+    :type: :struct:`Scalar` (m)
     :access: Get only
 
     The altitude at which the atmosphere is "officially" advertised as ending. (actual ending value differs, see below).
 
 .. attribute:: Atmosphere:MOLARMASS
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :acces: Get only
 
     The Molecular Mass of the gas the atmosphere is composed of.
@@ -123,7 +123,7 @@ A Structure closely tied to :struct:`Body` A variable of type :struct:`Atmospher
 
 .. attribute:: Atmosphere:ADIABATICINDEX
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     The Adiabatic index of the gas the atmosphere is composed of.
@@ -131,14 +131,14 @@ A Structure closely tied to :struct:`Body` A variable of type :struct:`Atmospher
 
 .. attribute:: Atmosphere:ADBIDX
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     A shorthand alias for :attr:ADIABATICINDEX.
 
 .. method:: Atmosphere:ALTITUDETEMPERATURE(altitude)
 
-    :parameter: altitude (:ref:`scalar <scalar>`) the altitude to query temperature at.
+    :parameter: altitude (:struct:`Scalar`) the altitude to query temperature at.
     :access: Get only
 
     Returns an approximate atmosphere temperature on this world at the given altitude.
@@ -154,7 +154,7 @@ Deprecated Suffix
 
 .. attribute:: Atmosphere:SCALE
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     A math constant plugged into a formula to find atmosphere density.

--- a/doc/source/structures/celestial_bodies/body.rst
+++ b/doc/source/structures/celestial_bodies/body.rst
@@ -11,7 +11,7 @@ This is any sort of planet or moon. To get a variable referring to a Body, you c
     // like "Mun" for example.
     SET MY_VAR TO BODY("name").
 
-Bodies are also :ref:`Orbitable<orbitable>`, and as such have all the associated suffixes.
+Bodies are also :struct:`Orbitable`, and as such have all the associated suffixes.
 
 Bodies' names are added to the kerboscript language as variable names as well.
 This means you can use the variable ``Mun`` to mean the same thing as ``BODY("Mun")``,
@@ -72,23 +72,23 @@ All of the main celestial bodies in the game are reserved variable names. The fo
     ================================ ============
          Every Suffix of :struct:`Orbitable`
     ---------------------------------------------
-    :attr:`NAME`                     :ref:`string <string>`
-    :attr:`DESCRIPTION`              :ref:`string <string>`
-    :attr:`MASS`                     :ref:`scalar <scalar>` (kg)
-    :attr:`HASOCEAN`                 :ref:`boolean <boolean>`
-    :attr:`HASSOLIDSURFACE`          :ref:`boolean <boolean>`
+    :attr:`NAME`                     :struct:`String`
+    :attr:`DESCRIPTION`              :struct:`String`
+    :attr:`MASS`                     :struct:`Scalar` (kg)
+    :attr:`HASOCEAN`                 :struct:`Boolean`
+    :attr:`HASSOLIDSURFACE`          :struct:`Boolean`
     :attr:`ORBITINGCHILDREN`         :struct:`List`
-    :attr:`ALTITUDE`                 :ref:`scalar <scalar>` (m)
-    :attr:`ROTATIONPERIOD`           :ref:`scalar <scalar>` (s)
-    :attr:`RADIUS`                   :ref:`scalar <scalar>` (m)
-    :attr:`MU`                       :ref:`scalar <scalar>` (:math:`m^3 s^{−2}`)
+    :attr:`ALTITUDE`                 :struct:`Scalar` (m)
+    :attr:`ROTATIONPERIOD`           :struct:`Scalar` (s)
+    :attr:`RADIUS`                   :struct:`Scalar` (m)
+    :attr:`MU`                       :struct:`Scalar` (:math:`m^3 s^{−2}`)
     :attr:`ATM`                      :struct:`Atmosphere`
     :attr:`ANGULARVEL`               :struct:`Vector` in :ref:`SHIP-RAW <ship-raw>`
     :meth:`GEOPOSITIONOF`            :struct:`GeoCoordinates` given :ref:`SHIP-RAW <ship-raw>` position vector
     :meth:`GEOPOSITIONLATLNG`        :struct:`GeoCoordinates` given latitude and longitude values
-    :attr:`ALTITUDEOF`               :ref:`scalar <scalar>` (m)
-    :attr:`SOIRADIUS`                :ref:`scalar <scalar>` (m)
-    :attr:`ROTATIONANGLE`            :ref:`scalar <scalar>` (deg)
+    :attr:`ALTITUDEOF`               :struct:`Scalar` (m)
+    :attr:`SOIRADIUS`                :struct:`Scalar` (m)
+    :attr:`ROTATIONANGLE`            :struct:`Scalar` (deg)
     ================================ ============
 
 .. note::

--- a/doc/source/structures/collections/enumerable.rst
+++ b/doc/source/structures/collections/enumerable.rst
@@ -26,16 +26,16 @@ Structure
           - :struct:`Iterator`
           - for iterating over the elements in the reverse order
         * - :attr:`LENGTH`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - number of elements in the enumerable
         * - :meth:`CONTAINS(item)`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - check if enumerable contains an item
         * - :attr:`EMPTY`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - check if enumerable is empty
         * - :attr:`DUMP`
-          - :ref:`string <string>`
+          - :struct:`String`
           - verbose dump of all contained elements
 
 
@@ -55,7 +55,7 @@ Structure
 
 .. attribute:: Enumerable:LENGTH
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     Returns the number of elements in the enumerable.
@@ -63,21 +63,20 @@ Structure
 .. method:: Enumerable:CONTAINS(item)
 
     :parameter item: element whose presence in the enumerable should be checked
-    :return: :ref:`Boolean <boolean>`
+    :return: :struct:`Boolean`
 
     Returns true if the enumerable contains an item equal to the one passed as an argument
 
 .. attribute:: Enumerable:EMPTY
 
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get only
 
     Returns true if the enumerable has zero items in it.
 
 .. attribute:: Enumerable:DUMP
 
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
     :access: Get only
 
     Returns a string containing a verbose dump of the enumerable's contents.
-

--- a/doc/source/structures/collections/iterator.rst
+++ b/doc/source/structures/collections/iterator.rst
@@ -3,7 +3,7 @@
 Iterator
 ========
 
-An iterator can be obtained from :attr:`List:ITERATOR` as well as from other places.
+An iterator can be obtained from :attr:`Enumerable:ITERATOR` as well as from other places.
 An ITERATOR is a
 `generic computer programming concept <http://en.wikipedia.org/wiki/Iterator>`__.
 In the general case it's a variable type that allows you to get
@@ -63,13 +63,13 @@ Members
           - n/a
           - (This method has been removed)
         * - :meth:`NEXT`
-          - :ref:`boolean <boolean>`
+          - :struct:`Boolean`
           - Move iterator to the next item
         * - :attr:`ATEND`
-          - :ref:`boolean <boolean>`
+          - :struct:`Boolean`
           - Check if iterator is at the end of the list
         * - :attr:`INDEX`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Current index starting from zero
         * - :attr:`VALUE`
           - varies
@@ -84,21 +84,21 @@ Members
 
 .. method:: Iterator:NEXT
 
-    :returns: :ref:`boolean <boolean>`
+    :returns: :struct:`Boolean`
 
     Call this to move the iterator to the next item in the list. Returns true if there is such an item, or false if no such item exists because it's already at the end of the list.
 
 .. attribute:: Iterator:ATEND
 
     :access: Get only
-    :type: :ref:`boolean <boolean>`
+    :type: :struct:`Boolean`
 
     Returns true if the iterator is at the end of the list and therefore cannot be "NEXTed", false otherwise.
 
 .. attribute:: Iterator:INDEX
 
     :access: Get only
-    :type: :ref:`scalar <scalar>` (integer)
+    :type: :struct:`Scalar` (integer)
 
     Returns the numerical index of how far you are into the list, starting the counting at 0 for the first item in the list. The last item in the list is numbered N-1, where N is the number of items in the list.
 

--- a/doc/source/structures/collections/lexicon.rst
+++ b/doc/source/structures/collections/lexicon.rst
@@ -202,10 +202,10 @@ Structure
           - None
           - append an item to the lexicon
         * - :attr:`CASESENSITIVE`
-          - :ref:`boolean <boolean>`
+          - :struct:`Boolean`
           - changes the behaviour of string based keys. Which are by default case insensitive. Setting this will clear the lexicon.
         * - :attr:`CASE`
-          - :ref:`boolean <boolean>`
+          - :struct:`Boolean`
           - A synonym for `CASESENSITIVE`
         * - :meth:`CLEAR`
           - None
@@ -213,14 +213,14 @@ Structure
         * - :meth:`COPY`
           - :struct:`Lexicon`
           - returns a (shallow) copy of the contents of the lexicon
-        * - :meth:`DUMP`
-          - :ref:`string <string>`
+        * - :attr:`DUMP`
+          - :struct:`String`
           - verbose dump of all contained elements
         * - :meth:`HASKEY(keyvalue)`
-          - :ref:`boolean <boolean>`
+          - :struct:`Boolean`
           - does the lexicon have a key of the given value?
         * - :meth:`HASVALUE(value)`
-          - :ref:`boolean <boolean>`
+          - :struct:`Boolean`
           - does the lexicon have a value of the given value?
         * - :attr:`KEYS`
           - :struct:`List`
@@ -229,12 +229,12 @@ Structure
           - :struct:`List`
           - gives a flat :struct:`List` of the values in the lexicon
         * - :attr:`LENGTH`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - number of pairs in the lexicon
         * - :meth:`REMOVE(keyvalue)`
           - None
           - removes the pair with the given key
-        * - :attr:`HASSUFFIX(name)`
+        * - :meth:`HASSUFFIX(name)`
           - :struct:`Boolean`
           - True if the suffix OR a key with the name, exists.
         * - :attr:`SUFFIXNAMES`
@@ -254,7 +254,7 @@ Structure
 
 .. attribute:: Lexicon:CASESENSITIVE
 
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get or Set
     
     The case sensitivity behaviour of the lexicon when the keys are strings.
@@ -273,7 +273,7 @@ Structure
 
 .. attribute:: Lexicon:CASE
 
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get or Set
      
     Synonym for CASESENSITIVE (see above).
@@ -290,7 +290,7 @@ Structure
     
 .. attribute:: Lexicon:LENGTH
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     Returns the number of pairs in the lexicon.
@@ -309,20 +309,20 @@ Structure
 .. method:: Lexicon:HASKEY(key)
 
     :parameter key: (any type) 
-    :return: :ref:`boolean <boolean>`
+    :return: :struct:`Boolean`
 
     Returns true if the lexicon contains the provided key
     
 .. method:: Lexicon:HASVALUE(key)
 
     :parameter key: (any type) 
-    :return: :ref:`boolean <boolean>`
+    :return: :struct:`Boolean`
 
     Returns true if the lexicon contains the provided value
     
 .. attribute:: Lexicon:DUMP
 
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
     :access: Get only
 
     Returns a string containing a verbose dump of the lexicon's contents.

--- a/doc/source/structures/collections/list.rst
+++ b/doc/source/structures/collections/list.rst
@@ -62,19 +62,19 @@ Structure
           - :struct:`List`
           - new list of given length starting with index
         * - :meth:`JOIN(separator)`
-          - :ref:`string <string>`
+          - :struct:`String`
           - joins all list elements into a string
         * - :meth:`FIND(item)`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - returns the first index of the item within the list
         * - :meth:`INDEXOF(item)`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Alias for :meth:`FIND(item)`
         * - :meth:`FINDLAST(item)`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - returns the last index of the item within the list
         * - :meth:`LASTINDEXOF(item)`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Alias for :meth:`FINDLAST(item)`
 
 .. note::
@@ -125,7 +125,7 @@ Structure
 .. method:: List:JOIN(separator)
 
     :parameter separator: (string) separator that will be inserted between the list items
-    :return: :ref:`string <string>`
+    :return: :struct:`String`
 
     Returns a string created by converting each element of the array to a string, separated by the given separator.
 

--- a/doc/source/structures/collections/range.rst
+++ b/doc/source/structures/collections/range.rst
@@ -72,13 +72,13 @@ Structure
           -
           - :struct:`Range` objects are a type of :struct:`Enumerable`
         * - :attr:`START`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - initial element of the range
         * - :attr:`STOP`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - range limit
         * - :attr:`STEP`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - step size
 
 .. note::
@@ -88,21 +88,21 @@ Structure
 
 .. attribute:: Range:START
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     Returns the initial element of the range.  Must be a round number.
 
 .. attribute:: Range:STOP
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     Returns the range limit.  Must be a round number.
 
 .. attribute:: Range:STEP
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     Returns the step size.  Must be a round number.

--- a/doc/source/structures/gui_widgets/gui.rst
+++ b/doc/source/structures/gui_widgets/gui.rst
@@ -22,10 +22,10 @@ GUI structure
     ===================================== =============================== =============
        Every suffix of :struct:`BOX`.  Note, to add widgets to this window, see the BOX suffixes.
     -----------------------------------------------------------------------------------
-    :attr:`X`                             :struct:`scalar` (pixels)       X-position of the window. Negative values measure from the right.
-    :attr:`Y`                             :struct:`scalar` (pixels)       Y-position of the window. Negative values measure from the bottom.
+    :attr:`X`                             :struct:`Scalar` (pixels)       X-position of the window. Negative values measure from the right.
+    :attr:`Y`                             :struct:`Scalar` (pixels)       Y-position of the window. Negative values measure from the bottom.
     :attr:`DRAGGABLE`                     :struct:`Boolean`               True = user can move window.
-    :attr:`EXTRADELAY`                    :struct:`scalar` (seconds)      Add artificial delay to all communication with this GUI (good for testing before you get into deep space)
+    :attr:`EXTRADELAY`                    :struct:`Scalar` (seconds)      Add artificial delay to all communication with this GUI (good for testing before you get into deep space)
     :attr:`SKIN`                          :struct:`Skin`                  The skin defining the default style of widgets in this GUI.
     :attr:`TOOLTIP`                       :struct:`String`                Current value of hovertext
     :meth:`SHOW`                          none                            Call to make the gui appear
@@ -34,7 +34,7 @@ GUI structure
 
     .. attribute:: X
 
-        :type: :struct:`scalar`
+        :type: :struct:`Scalar`
         :access: Get/Set
 
         This is the X position of upper-left corner of window, in pixels.
@@ -47,7 +47,7 @@ GUI structure
 
     .. attribute:: Y
 
-        :type: :struct:`scalar`
+        :type: :struct:`Scalar`
         :access: Get/Set
 
         This is the Y position of upper-left corner of window, in pixels.
@@ -69,7 +69,7 @@ GUI structure
 
     .. attribute:: EXTRADELAY
 
-        :type: :struct:`scalar`
+        :type: :struct:`Scalar`
         :access: Get/Set
 
         This is the number of extra seconds of delay to add to
@@ -134,4 +134,3 @@ GUI structure
 
         Call this suffix to make the GUI disappear.  (Note this is really just
         :meth:`Widget:Show` but it's mentioned again here.)
-

--- a/doc/source/structures/gui_widgets/label.rst
+++ b/doc/source/structures/gui_widgets/label.rst
@@ -19,9 +19,9 @@ Label
     ===================================== =============================== =============
 		   Every suffix of :struct:`WIDGET`
     -----------------------------------------------------------------------------------
-    :attr:`TEXT`                          :struct:`string`                The text on the label.
-    :attr:`IMAGE`                         :struct:`string`                Filename of an image for the label.
-    :attr:`TOOLTIP`                       :struct:`string`                A tooltip for the label.
+    :attr:`TEXT`                          :struct:`String`                The text on the label.
+    :attr:`IMAGE`                         :struct:`String`                Filename of an image for the label.
+    :attr:`TOOLTIP`                       :struct:`String`                A tooltip for the label.
     ===================================== =============================== =============
 
     .. attribute:: TEXT
@@ -39,7 +39,7 @@ Label
 
     .. attribute:: IMAGE
 
-        :type: :struct:`string`
+        :type: :struct:`String`
         :access: Get/Set
 
         This is the filename of an image file to use in the label's background.
@@ -122,5 +122,3 @@ Examples of usage::
     set mylabel5:text to "This is <color=#ffaa00FF>important</color>.". // orange by hex code, opaque
     set mylabel6:text to "This is <color=#ffaa0080>important</color>.". // orange by hex code, halfway transparent
     
-
-

--- a/doc/source/structures/gui_widgets/popupmenu.rst
+++ b/doc/source/structures/gui_widgets/popupmenu.rst
@@ -39,7 +39,7 @@ PopupMenu
                    Every suffix of :struct:`BUTTON`
     ---------------------------------------------------------------------------------------------
     :attr:`OPTIONS`                       :struct:`List`                            List of options to display.
-    :attr:`OPTIONSUFFIX`                  :struct:`string`                          Name of the suffix used for display names. Default = TOSTRING.
+    :attr:`OPTIONSUFFIX`                  :struct:`String`                          Name of the suffix used for display names. Default = TOSTRING.
     :meth:`ADDOPTION(value)`                                                        Add a value to the end of the list of options.
     :attr:`VALUE`                         Any                                       Returns the current selected value.
     :attr:`INDEX`                         :struct:`Scalar`                          Returns the index of the current selected value.
@@ -165,5 +165,3 @@ PopupMenu
         If this is set too large, it can become possible to make
         the popup menu so large it won't fit on the screen, if you
         give it a lot of items in the options list.
-
-

--- a/doc/source/structures/gui_widgets/scrollbox.rst
+++ b/doc/source/structures/gui_widgets/scrollbox.rst
@@ -25,7 +25,7 @@ Scrollbox
     ===================================== =============================== =============
     Suffix                                Type                            Description
     ===================================== =============================== =============
-                   Every suffix of :struct:`BOX`.  :attr:
+                   Every suffix of :struct:`BOX`.
     -----------------------------------------------------------------------------------
     :attr:`HALWAYS`                       :struct:`Boolean`               Always show the horizontal scrollbar.
     :attr:`VALWAYS`                       :struct:`Boolean`               Always show the vertical scrollbar.
@@ -62,4 +62,3 @@ Scrollbox
         an X/Y pair stored inside a 3D vector).
 
         You can set this value to force the window to scroll to a new position.
-

--- a/doc/source/structures/gui_widgets/slider.rst
+++ b/doc/source/structures/gui_widgets/slider.rst
@@ -20,10 +20,10 @@ Slider
     ===================================== ========================================= =============
                    Every suffix of :struct:`WIDGET`
     ---------------------------------------------------------------------------------------------
-    :attr:`VALUE`                         :struct:`scalar`                          The current value. Initially set to :attr:`MIN`.
+    :attr:`VALUE`                         :struct:`Scalar`                          The current value. Initially set to :attr:`MIN`.
     :attr:`ONCHANGE`                      :struct:`KOSDelegate` (:struct:`Scalar`)  Your function called whenever the :attr:`VALUE` changes.
-    :attr:`MIN`                           :struct:`scalar`                          The minimum value (leftmost on horizontal slider).
-    :attr:`MAX`                           :struct:`scalar`                          The maximum value (bottom on vertical slider).
+    :attr:`MIN`                           :struct:`Scalar`                          The minimum value (leftmost on horizontal slider).
+    :attr:`MAX`                           :struct:`Scalar`                          The maximum value (bottom on vertical slider).
     ===================================== ========================================= =============
 
     .. attribute:: VALUE
@@ -93,5 +93,3 @@ Slider
         (i.e. where numbers normally get larger when you slide to the right,
         inverting MIN and MAX causes the numbers to get larger when you
         slide to the left.)
-
-

--- a/doc/source/structures/gui_widgets/spacing.rst
+++ b/doc/source/structures/gui_widgets/spacing.rst
@@ -16,7 +16,7 @@ Spacing
     ===================================== =============================== =============
 		   Every suffix of :struct:`WIDGET`
     -----------------------------------------------------------------------------------
-    :attr:`AMOUNT`                        :struct:`scalar`                The amount of space, or -1 for flexible spacing.
+    :attr:`AMOUNT`                        :struct:`Scalar`                The amount of space, or -1 for flexible spacing.
     ===================================== =============================== =============
 
     .. attribute:: AMOUNT
@@ -27,5 +27,3 @@ Spacing
         The number of pixels for this spacing to take up.  Whether this
         is horizontal or vertial space depends on whether this is being
         added to a horizontal-layout box or a vertical-layout box.
-
-

--- a/doc/source/structures/gui_widgets/style.rst
+++ b/doc/source/structures/gui_widgets/style.rst
@@ -14,15 +14,15 @@ Style
     ===================================== =============================== =============
     :attr:`HSTRETCH`                      :struct:`Boolean`               Should the widget stretch horizontally? (default depends on widget subclass)
     :attr:`VSTRETCH`                      :struct:`Boolean`               Should the widget stretch vertically?
-    :attr:`WIDTH`                         :struct:`scalar` (pixels)       Fixed width (or 0 if flexible).
-    :attr:`HEIGHT`                        :struct:`scalar` (pixels)       Fixed height (or 0 if flexible).
+    :attr:`WIDTH`                         :struct:`Scalar` (pixels)       Fixed width (or 0 if flexible).
+    :attr:`HEIGHT`                        :struct:`Scalar` (pixels)       Fixed height (or 0 if flexible).
     :attr:`MARGIN`                        :struct:`StyleRectOffset`       Spacing between this and other widgets.
     :attr:`PADDING`                       :struct:`StyleRectOffset`       Spacing between the outside of the widget and its contents (text, etc.).
     :attr:`BORDER`                        :struct:`StyleRectOffset`       Size of the edges in the 9-slice image for BG images in NORMAL, HOVER, etc.
     :attr:`OVERFLOW`                      :struct:`StyleRectOffset`       Extra space added to the area of the background image. Allows the background to go beyond the widget's rectangle.
-    :attr:`ALIGN`                         :struct:`string`                One of "CENTER", "LEFT", or "RIGHT". See note below.
-    :attr:`FONT`                          :struct:`string`                The name of the font of the text on the content or "" if the default.
-    :attr:`FONTSIZE`                      :struct:`scalar`                The size of the text on the content.
+    :attr:`ALIGN`                         :struct:`String`                One of "CENTER", "LEFT", or "RIGHT". See note below.
+    :attr:`FONT`                          :struct:`String`                The name of the font of the text on the content or "" if the default.
+    :attr:`FONTSIZE`                      :struct:`Scalar`                The size of the text on the content.
     :attr:`RICHTEXT`                      :struct:`Boolean`               Set to False to disable rich-text (<i>...</i>, etc.)
     :attr:`NORMAL`                        :struct:`StyleState`            Properties for the widget normally.
     :attr:`ON`                            :struct:`StyleState`            Properties for when the widget is under the mouse and "on".
@@ -33,7 +33,7 @@ Style
     :attr:`ACTIVE_ON`                     :struct:`StyleState`            Properties for when the widget is active and "on".
     :attr:`FOCUSED`                       :struct:`StyleState`            Properties for when the widget has keyboard focus.
     :attr:`FOCUSED_ON`                    :struct:`StyleState`            Properties for when the widget has keyboard focus and is "on".
-    :attr:`BG`                            :struct:`string`                The same as NORMAL:BG. Name of a "9-slice" image file.
+    :attr:`BG`                            :struct:`String`                The same as NORMAL:BG. Name of a "9-slice" image file.
     :attr:`TEXTCOLOR`                     :ref:`Color <colors>`           The same as NORMAL:TEXTCOLOR. The color of the text on the label.
     :attr:`WORDWRAP`                      :struct:`Boolean`               Can labels be broken into multiple lines on word boundaries?
     ===================================== =============================== =============
@@ -54,14 +54,14 @@ Style
 
     .. attribute:: WIDTH
 
-        :type: :struct:`scalar`
+        :type: :struct:`Scalar`
         :access: Get/Set
 
         (pixels)       Fixed width (or 0 if flexible).
 
     .. attribute:: HEIGHT
 
-        :type: :struct:`scalar`
+        :type: :struct:`Scalar`
         :access: Get/Set
 
         (pixels)       Fixed height (or 0 if flexible).
@@ -96,7 +96,7 @@ Style
 
     .. attribute:: ALIGN
 
-        :type: :struct:`string`
+        :type: :struct:`String`
         :access: Get/Set
 
         One of "CENTER", "LEFT", or "RIGHT".
@@ -111,7 +111,7 @@ Style
 
     .. attribute:: FONT
 
-        :type: :struct:`string`
+        :type: :struct:`String`
         :access: Get/Set
 
         The name of the font of the text on the content or "" if the default.
@@ -129,7 +129,7 @@ Style
 
     .. attribute:: FONTSIZE
 
-        :type: :struct:`scalar`
+        :type: :struct:`Scalar`
         :access: Get/Set
 
         The size of the text on the content.
@@ -206,7 +206,7 @@ Style
 
     .. attribute:: BG
 
-        :type: :struct:`string`
+        :type: :struct:`String`
         :access: Get/Set
 
         The same as NORMAL:BG. Name of a "9-slice" image file.

--- a/doc/source/structures/gui_widgets/stylestate.rst
+++ b/doc/source/structures/gui_widgets/stylestate.rst
@@ -14,7 +14,7 @@ StyleState
     ===================================== =============================== =============
     Suffix                                Type                            Description
     ===================================== =============================== =============
-    :attr:`BG`                            :struct:`string`                Name of a "9-slice" image file. See note below.
+    :attr:`BG`                            :struct:`String`                Name of a "9-slice" image file. See note below.
     :attr:`TEXTCOLOR`                     :ref:`Color <colors>`           The color of the text on the label.
     ===================================== =============================== =============
 
@@ -67,5 +67,3 @@ StyleState
         :access: Get/Set
 
         The color of foreground text within this widget when it is in this state.
-
-

--- a/doc/source/structures/gui_widgets/widget.rst
+++ b/doc/source/structures/gui_widgets/widget.rst
@@ -91,7 +91,7 @@ Widget
     .. attribute:: ENABLED
 
         :type: :struct:`Boolean`
-        :access: get/set
+        :access: Get/Set
 
         (This is true by default for all newly created widgets.)
 
@@ -140,7 +140,7 @@ Widget
     .. attribute:: PARENT
 
 	:type: :struct:`Box`
-	:access: :Get-only
+	:access: Get-only
 
 	Widgets can be contained inside Boxes that are contained inside
 	other Boxes, etc.  This suffix tells you which :struct:`Box` contains
@@ -153,10 +153,8 @@ Widget
     .. attribute:: HASPARENT
 
 	:type: :struct:`Boolean`
-	:access: :Get-only
+	:access: Get-only
 
 	If trying to use :attr:`Widget:PARENT` would generate an error because
 	this widget has no parent, then :attr:`HASPARENT` will be false.
 	Otherwise it will be true.
-
-

--- a/doc/source/structures/misc/colors.rst
+++ b/doc/source/structures/misc/colors.rst
@@ -62,16 +62,16 @@ Method 1: Use one of these pre-arranged named colors:
           - Description
 
         * - :R or :RED
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - the red component of the color
         * - :G or :GREEN
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - the green component of the color
         * - :B or :BLUE
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - the blue component of the color
         * - :A or :ALPHA
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - the alpha (how opaque: 1 = opaque, 0 = transparent) component of the color
         * - :HTML or :HEX
           - string
@@ -137,13 +137,13 @@ Examples::
           - Description
 
         * - :H or :HUE
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - the hue component of the color. It is a value from 0.0 to 360.0
         * - :S or :SATURATION
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - the saturation component of the color. It has a value from 0.0 to 1.0
         * - :V or :VALUE
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - the value component of the color. It has a value from 0.0 to 1.0
                   
 

--- a/doc/source/structures/misc/config.rst
+++ b/doc/source/structures/misc/config.rst
@@ -75,6 +75,7 @@ Configuration of kOS
         * - :attr:`CLOBBERBUILTINS`
           - :struct:`Boolean`
           - False
+          - Disallow builtin variable names to be re-declared
         * - :attr:`AUDIOERR`
           - :struct:`Boolean`
           - False

--- a/doc/source/structures/misc/highlight.rst
+++ b/doc/source/structures/misc/highlight.rst
@@ -31,10 +31,10 @@ structure is defined as follows:
           - Description
 
         * - :COLOR
-          - :ref:`color <color>`
+          - :ref:`Color <color>`
           - the color that will be used by the highlight
         * - :ENABLED
-          - :ref:`boolean <boolean>`
+          - :struct:`Boolean`
           - controls the visibility of the highlight
 		
 Example::

--- a/doc/source/structures/misc/loaddistance.rst
+++ b/doc/source/structures/misc/loaddistance.rst
@@ -186,26 +186,26 @@ Each of the above
         - Description
 
       * - :attr:`LOAD`
-        - :ref:`scalar <scalar>`, in meters
+        - :struct:`Scalar` (m)
         - Get/Set
         - The load distance
       * - :attr:`UNLOAD`
-        - :ref:`scalar <scalar>`, in meters
+        - :struct:`Scalar` (m)
         - Get/Set
         - The unload distance
       * - :attr:`UNPACK`
-        - :ref:`scalar <scalar>`, in meters
+        - :struct:`Scalar` (m)
         - Get/Set
         - The unpack distance
       * - :attr:`PACK`
-        - :ref:`scalar <scalar>`, in meters
+        - :struct:`Scalar` (m)
         - Get/Set
         - The pack distance
 
 .. attribute:: SituationLoadDistance:LOAD
 
     :access: Get/Set
-    :type: :ref:`scalar <scalar>`, in meters
+    :type: :struct:`Scalar` (m)
 
     Get or set the load distance.  When another vessel is getting closer
     to you, because you are moving toward it or it is moving toward you,
@@ -219,7 +219,7 @@ Each of the above
 .. attribute:: SituationLoadDistance:UNLOAD
 
     :access: Get/Set
-    :type: :ref:`scalar <scalar>`, in meters
+    :type: :struct:`Scalar` (m)
 
     Get or set the unload distance.  When another vessel is becoming more
     distant as you move away from it, or it moves away from you,
@@ -233,7 +233,7 @@ Each of the above
 .. attribute:: SituationLoadDistance:UNPACK
 
     :access: Get/Set
-    :type: :ref:`scalar <scalar>`, in meters
+    :type: :struct:`Scalar` (m)
 
     Get or set the unpack distance.  When another vessel is getting closer
     to you, because you are moving toward it or it is moving toward you,
@@ -246,7 +246,7 @@ Each of the above
 .. attribute:: SituationLoadDistance:PACK
 
     :access: Get/Set
-    :type: :ref:`scalar <scalar>`, in meters
+    :type: :struct:`Scalar` (m)
 
     Get or set the pack distance.  When another vessel is getting farther
     away from you, because you are moving away from it or it is moving

--- a/doc/source/structures/misc/note.rst
+++ b/doc/source/structures/misc/note.rst
@@ -20,7 +20,7 @@ function, or the built-in SlideNote() function:
 
     ``frequency``
         **Mandatory**: The frequency can be given as either a number or a
-        string.  If it is a number, then it is the frequency in Hertz.
+        string.  If it is a number, then it is the frequency in hertz (Hz).
         If it is a string, then it's using the letter notation
         :ref:`described here <skid_letter_frequency>`.
     ``duration``
@@ -76,12 +76,12 @@ function, or the built-in SlideNote() function:
 
     ``frequency``
         **Mandatory**: This is the frequency the sliding note begins at.
-        If it is a number, then it is the frequency in Hertz.
+        If it is a number, then it is the frequency in hertz (Hz).
         If it is a string, then it's using the letter notation
         :ref:`described here <skid_letter_frequency>`.
     ``endFrequency``
         **Mandatory**: This is the frequency the sliding note ends at.
-        If it is a number, then it is the frequency in Hertz.
+        If it is a number, then it is the frequency in hertz (Hz).
         If it is a string, then it's using the letter notation
         :ref:`described here <skid_letter_frequency>`.
     ``duration``
@@ -124,10 +124,10 @@ function, or the built-in SlideNote() function:
 
         * - :attr:`FREQUENCY`
           - :struct:`Scalar`
-          - initial frequency of the note in Hertz
+          - initial frequency of the note in hertz (Hz)
         * - :attr:`ENDFREQUENCY`
           - :struct:`Scalar`
-          - final frequency of the note in Hertz
+          - final frequency of the note in hertz (Hz)
         * - :attr:`KEYDOWNLENGTH`
           - :struct:`Scalar`
           - time to hold the "synthesizer key" down for
@@ -141,23 +141,23 @@ function, or the built-in SlideNote() function:
     .. attribute:: FREQUENCY
 
         :access: Get Only
-        :type: :struct:`Scalar` (Hertz)
+        :type: :struct:`Scalar` (Hz)
 
-        The initial frequency of the note in Hertz.
+        The initial frequency of the note in hertz (Hz).
 
     .. attribute:: ENDFREQUENCY
 
         :access: Get Only
-        :type: :struct:`Scalar` (Hertz)
+        :type: :struct:`Scalar` (Hz)
 
         If the note was created using :func:`SlideNote()` this is the final
-        frequency of the note, in Hertz.  Otherwise the value is identical to
+        frequency of the note, in hertz (Hz).  Otherwise the value is identical to
         :attr:`FREQUENCY`.
 
     .. attribute:: KEYDOWNLENGTH
 
         :access: Get Only
-        :type: :struct:`Scalar` (seconds)
+        :type: :struct:`Scalar` (s)
 
         The amount of time that the "synthesizer key" is held down for.  In the
         :ref:`ADSR Envelope<skid_envelope>` this represents the total of the
@@ -166,7 +166,7 @@ function, or the built-in SlideNote() function:
     .. attribute:: DURATION
 
         :access: Get Only
-        :type: :struct:`Scalar` (seconds)
+        :type: :struct:`Scalar` (s)
 
         The total time of the note, encompassing the entire
         :ref:`ADSR Envelope<skid_envelope>` including the "release" component.

--- a/doc/source/structures/misc/pidloop.rst
+++ b/doc/source/structures/misc/pidloop.rst
@@ -202,65 +202,65 @@ Structure
     ===================================== ========================= =============
      Suffix                                Type                      Description
     ===================================== ========================= =============
-    :attr:`LASTSAMPLETIME`                :struct:`scalar`          decimal value of the last sample time
-    :attr:`KP`                            :struct:`scalar`          The proportional gain factor
-    :attr:`KI`                            :struct:`scalar`          The integral gain factor
-    :attr:`KD`                            :struct:`scalar`          The derivative gain factor
-    :attr:`INPUT`                         :struct:`scalar`          The most recent input value
-    :attr:`SETPOINT`                      :struct:`scalar`          The current setpoint
-    :attr:`ERROR`                         :struct:`scalar`          The most recent error value
-    :attr:`OUTPUT`                        :struct:`scalar`          The most recent output value
-    :attr:`MAXOUTPUT`                     :struct:`scalar`          The maximum output value
-    :attr:`MINOUTPUT`                     :struct:`scalar`          The maximum output value
-    :attr:`EPSILON`                       :struct:`scalar`          The "don't care" tolerance of error
-    :attr:`IGNOREERROR`                   :struct:`scalar`          Alias for :attr:`EPSILON`.
-    :attr:`ERRORSUM`                      :struct:`scalar`          The time weighted sum of error
-    :attr:`PTERM`                         :struct:`scalar`          The proportional component of output
-    :attr:`ITERM`                         :struct:`scalar`          The integral component of output
-    :attr:`DTERM`                         :struct:`scalar`          The derivative component of output
-    :attr:`CHANGERATE`                    :struct:`scalar` (/s)     The most recent input rate of change
+    :attr:`LASTSAMPLETIME`                :struct:`Scalar`          decimal value of the last sample time
+    :attr:`KP`                            :struct:`Scalar`          The proportional gain factor
+    :attr:`KI`                            :struct:`Scalar`          The integral gain factor
+    :attr:`KD`                            :struct:`Scalar`          The derivative gain factor
+    :attr:`INPUT`                         :struct:`Scalar`          The most recent input value
+    :attr:`SETPOINT`                      :struct:`Scalar`          The current setpoint
+    :attr:`ERROR`                         :struct:`Scalar`          The most recent error value
+    :attr:`OUTPUT`                        :struct:`Scalar`          The most recent output value
+    :attr:`MAXOUTPUT`                     :struct:`Scalar`          The maximum output value
+    :attr:`MINOUTPUT`                     :struct:`Scalar`          The maximum output value
+    :attr:`EPSILON`                       :struct:`Scalar`          The "don't care" tolerance of error
+    :attr:`IGNOREERROR`                   :struct:`Scalar`          Alias for :attr:`EPSILON`.
+    :attr:`ERRORSUM`                      :struct:`Scalar`          The time weighted sum of error
+    :attr:`PTERM`                         :struct:`Scalar`          The proportional component of output
+    :attr:`ITERM`                         :struct:`Scalar`          The integral component of output
+    :attr:`DTERM`                         :struct:`Scalar`          The derivative component of output
+    :attr:`CHANGERATE`                    :struct:`Scalar` (/s)     The most recent input rate of change
     :meth:`RESET`                         none                      Reset the integral and derivative components
-    :meth:`UPDATE(time, input)`           :struct:`scalar`          Returns output based on time and input
+    :meth:`UPDATE(time, input)`           :struct:`Scalar`          Returns output based on time and input
     ===================================== ========================= =============
 
 .. attribute:: PIDLoop:LASTSAMPLETIME
 
-    :type: :struct:`scalar`
+    :type: :struct:`Scalar`
     :access: Get only
 
     The value representing the time of the last sample.  This value is equal to the time parameter of the :meth:`UPDATE` method.
 
 .. attribute:: PIDLoop:KP
 
-    :type: :struct:`scalar`
+    :type: :struct:`Scalar`
     :access: Get/Set
 
     The proportional gain factor.
 
 .. attribute:: PIDLoop:KI
 
-    :type: :struct:`scalar`
+    :type: :struct:`Scalar`
     :access: Get/Set
 
     The integral gain factor.
 
 .. attribute:: PIDLoop:KD
 
-    :type: :struct:`scalar`
+    :type: :struct:`Scalar`
     :access: Get/Set
 
     The derivative gain factor.
 
 .. attribute:: PIDLoop:INPUT
 
-    :type: :struct:`scalar`
+    :type: :struct:`Scalar`
     :access: Get only
 
     The value representing the input of the last sample.  This value is equal to the input parameter of the :meth:`UPDATE` method.
 
 .. attribute:: PIDLoop:SETPOINT
 
-    :type: :struct:`scalar`
+    :type: :struct:`Scalar`
     :access: Get/Set
 
     The current setpoint.  This is the value to which input is compared when :meth:`UPDATE` is called.  It may not be synced with the last sample.
@@ -271,28 +271,28 @@ Structure
 
 .. attribute:: PIDLoop:ERROR
 
-    :type: :struct:`scalar`
+    :type: :struct:`Scalar`
     :access: Get only
 
     The calculated error from the last sample (setpoint - input).
 
 .. attribute:: PIDLoop:OUTPUT
 
-    :type: :struct:`scalar`
+    :type: :struct:`Scalar`
     :access: Get only
 
     The calculated output from the last sample.
 
 .. attribute:: PIDLoop:MAXOUTPUT
 
-    :type: :struct:`scalar`
+    :type: :struct:`Scalar`
     :access: Get/Set
 
     The current maximum output value.  This value also helps with regulating integral wind up mitigation.
 
 .. attribute:: PIDLoop:MINOUTPUT
 
-    :type: :struct:`scalar`
+    :type: :struct:`Scalar`
     :access: Get/Set
 
     The current minimum output value.  This value also helps with regulating integral wind up mitigation.
@@ -300,7 +300,7 @@ Structure
 
 .. attribute:: PIDLoop:EPSILON
 
-    :type: :struct:`scalar`
+    :type: :struct:`Scalar`
     :access: Get/Set
 
     Default = 0.
@@ -326,42 +326,42 @@ Structure
 
 .. attribute:: PIDLoop:IGNOREERROR
 
-    :type: :struct:`scalar`
+    :type: :struct:`Scalar`
     :access: Get/Set
 
     This is just an alias that is the same thing as :attr:`EPSILON`.
 
 .. attribute:: PIDLoop:ERRORSUM
 
-    :type: :struct:`scalar`
+    :type: :struct:`Scalar`
     :access: Get only
 
     The value representing the time weighted sum of all errrors.  It will be equal to :attr:`ITERM` / :attr:`KI`.  This value is adjusted by the integral windup mitigation logic.
 
 .. attribute:: PIDLoop:PTERM
 
-    :type: :struct:`scalar`
+    :type: :struct:`Scalar`
     :access: Get only
 
     The value representing the proportional component of :attr:`OUTPUT`.
 
 .. attribute:: PIDLoop:ITERM
 
-    :type: :struct:`scalar`
+    :type: :struct:`Scalar`
     :access: Get only
 
     The value representing the integral component of :attr:`OUTPUT`.  This value is adjusted by the integral windup mitigation logic.
 
 .. attribute:: PIDLoop:DTERM
 
-    :type: :struct:`scalar`
+    :type: :struct:`Scalar`
     :access: Get only
 
     The value representing the derivative component of :attr:`OUTPUT`.
 
 .. attribute:: PIDLoop:CHANGERATE
 
-    :type: :struct:`scalar`
+    :type: :struct:`Scalar`
     :access: Get only
 
     The rate of change of the :attr:`INPUT` during the last sample.  It will be equal to (input - last input) / (change in time).
@@ -374,9 +374,9 @@ Structure
 
 .. method:: PIDLoop:UPDATE(time, input)
 
-    :parameter time: (:struct:`scalar`) the decimal time in seconds
-    :parameter input: (:struct:`scalar`) the input variable to compare to the setpoint
-    :return: :struct:`scalar` representing the calculated output
+    :parameter time: (:struct:`Scalar`) the decimal time in seconds
+    :parameter input: (:struct:`Scalar`) the input variable to compare to the setpoint
+    :return: :struct:`Scalar` representing the calculated output
 
     Upon calling this method, the PIDLoop will calculate the output based on this this basic framework (see below for detailed derivation): output = error * kp + errorsum * ki + (change in input) / (change in time) * kd.  This method is usually called with the current time in seconds (`TIME:SECONDS`), however it may be called using whatever rate measurement you prefer.  Windup mitigation is included, based on :attr:`MAXOUTPUT` and :attr:`MINOUTPUT`.  Both integral components and derivative components are guarded against a change in time greater than 1s, and will not be calculated on the first iteration.
 

--- a/doc/source/structures/misc/resource_transfer.rst
+++ b/doc/source/structures/misc/resource_transfer.rst
@@ -20,27 +20,27 @@ Structure
           - Description
 
         * - :attr:`STATUS`
-          - :ref:`string <string>`
+          - :struct:`String`
           - Get only
-          - The :ref:`string <string>` status of the transfer (eg "Inactive", "Transferring", "Failed", "Finished")
+          - The :struct:`String` status of the transfer (eg "Inactive", "Transferring", "Failed", "Finished")
         * - :attr:`MESSAGE`
-          - :ref:`string <string>`
+          - :struct:`String`
           - Get only
           - A message about the current status
         * - :attr:`GOAL`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Get only
           - This is how much of the resource will be transferred.
         * - :attr:`TRANSFERRED`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Get only
           - This is how much of the resource has been transferred.
         * - :attr:`RESOURCE`
-          - :ref:`string <string>`
+          - :struct:`String`
           - Get only
           - The name of the resource (eg oxidizer, liquidfuel)   
         * - :attr:`ACTIVE`
-          - :ref:`boolean <boolean>`
+          - :struct:`Boolean`
           - Get / Set
           - Setting this value will either start, pause or restart a transfer. Default is false.
     
@@ -48,7 +48,7 @@ Structure
 .. attribute:: RESOURCETRANSFER:STATUS
 
     :access: Get only
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
 
     This enumerated type shows the status of the transfer. the possible values are:
     
@@ -64,14 +64,14 @@ Structure
 .. attribute:: RESOURCETRANSFER:MESSAGE
 
     :access: Get only
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
 
     This shows the detail related to :attr:`STATUS`
     
 .. attribute:: RESOURCETRANSFER:GOAL
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     
     If you specified an amount to transfer in your transfer request, it will be shown here.
     If you did not, this will return the sentinel value -1.
@@ -79,21 +79,21 @@ Structure
 .. attribute:: RESOURCETRANSFER:TRANSFERRED
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     Returns the amount of the specified resource that has been transferred by this resource transfer.
     
 .. attribute:: RESOURCETRANSFER:RESOURCE
 
     :access: Get only
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
 
     The name of the resource that will be transferred. (eg, oxidizer, liquidfuel)
     
 .. attribute:: RESOURCETRANSFER:ACTIVE
 
     :access: Get / Set
-    :type: :ref:`boolean <boolean>`
+    :type: :struct:`Boolean`
 
     When getting, this suffix is simply a shortcut to tell you if :attr:`STATUS` is Transferring.
     Setting true will change the status of the transfer to Transferring, setting false will change status to inactive.

--- a/doc/source/structures/misc/steeringmanager.rst
+++ b/doc/source/structures/misc/steeringmanager.rst
@@ -24,31 +24,31 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
     :attr:`PITCHPID`                     :struct:`PIDLoop`         The PIDLoop for the pitch :ref:`rotational velocity PID <cooked_omega_pid>`.
     :attr:`YAWPID`                       :struct:`PIDLoop`         The PIDLoop for the yaw :ref:`rotational velocity PID <cooked_omega_pid>`.
     :attr:`ROLLPID`                      :struct:`PIDLoop`         The PIDLoop for the roll :ref:`rotational velocity PID <cooked_omega_pid>`.
-    :attr:`ENABLED`                      :struct:`boolean`         Returns true if the `SteeringManager` is currently controlling the vessel
+    :attr:`ENABLED`                      :struct:`Boolean`         Returns true if the `SteeringManager` is currently controlling the vessel
     :attr:`TARGET`                       :struct:`Direction`       The direction that the vessel is currently steering towards
     :meth:`RESETPIDS()`                  none                      Called to call `RESET` on all steering PID loops.
     :meth:`RESETTODEFAULT()`             none                      Called to reset all steering tuning parameters.
-    :attr:`SHOWFACINGVECTORS`            :struct:`boolean`         Enable/disable display of ship facing, target, and world coordinates vectors.
-    :attr:`SHOWANGULARVECTORS`           :struct:`boolean`         Enable/disable display of angular rotation vectors
-    :attr:`SHOWSTEERINGSTATS`            :struct:`boolean`         Enable/disable printing of the steering information on the terminal
-    :attr:`WRITECSVFILES`                :struct:`boolean`         Enable/disable logging steering to csv files.
-    :attr:`PITCHTS`                      :struct:`scalar` (s)      Settling time for the pitch torque calculation.
-    :attr:`YAWTS`                        :struct:`scalar` (s)      Settling time for the yaw torque calculation.
-    :attr:`ROLLTS`                       :struct:`scalar` (s)      Settling time for the roll torque calculation.
-    :attr:`TORQUEEPSILONMIN`             :struct:`scalar` (s)      Torque deadzone when not rotating at max rate
-    :attr:`TORQUEEPSILONMAX`             :struct:`scalar` (s)      Torquw deadzone when rotating at max roatation rate
-    :attr:`MAXSTOPPINGTIME`              :struct:`scalar` (s)      The maximum amount of stopping time to limit angular turn rate.
-    :attr:`ROLLCONTROLANGLERANGE`        :struct:`scalar` (deg)    The maximum value of :attr:`ANGLEERROR` for which to control roll.
-    :attr:`ANGLEERROR`                   :struct:`scalar` (deg)    The angle between vessel:facing and target directions
-    :attr:`PITCHERROR`                   :struct:`scalar` (deg)    The angular error in the pitch direction
-    :attr:`YAWERROR`                     :struct:`scalar` (deg)    The angular error in the yaw direction
-    :attr:`ROLLERROR`                    :struct:`scalar` (deg)    The angular error in the roll direction
-    :attr:`PITCHTORQUEADJUST`            :struct:`scalar` (kN)     Additive adjustment to pitch torque (calculated)
-    :attr:`YAWTORQUEADJUST`              :struct:`scalar` (kN)     Additive adjustment to yaw torque (calculated)
-    :attr:`ROLLTORQUEADJUST`             :struct:`scalar` (kN)     Additive adjustment to roll torque (calculated)
-    :attr:`PITCHTORQUEFACTOR`            :struct:`scalar`          Multiplicative adjustment to pitch torque (calculated)
-    :attr:`YAWTORQUEFACTOR`              :struct:`scalar`          Multiplicative adjustment to yaw torque (calculated)
-    :attr:`ROLLTORQUEFACTOR`             :struct:`scalar`          Multiplicative adjustment to roll torque (calculated)
+    :attr:`SHOWFACINGVECTORS`            :struct:`Boolean`         Enable/disable display of ship facing, target, and world coordinates vectors.
+    :attr:`SHOWANGULARVECTORS`           :struct:`Boolean`         Enable/disable display of angular rotation vectors
+    :attr:`SHOWSTEERINGSTATS`            :struct:`Boolean`         Enable/disable printing of the steering information on the terminal
+    :attr:`WRITECSVFILES`                :struct:`Boolean`         Enable/disable logging steering to csv files.
+    :attr:`PITCHTS`                      :struct:`Scalar` (s)      Settling time for the pitch torque calculation.
+    :attr:`YAWTS`                        :struct:`Scalar` (s)      Settling time for the yaw torque calculation.
+    :attr:`ROLLTS`                       :struct:`Scalar` (s)      Settling time for the roll torque calculation.
+    :attr:`TORQUEEPSILONMIN`             :struct:`Scalar` (s)      Torque deadzone when not rotating at max rate
+    :attr:`TORQUEEPSILONMAX`             :struct:`Scalar` (s)      Torquw deadzone when rotating at max roatation rate
+    :attr:`MAXSTOPPINGTIME`              :struct:`Scalar` (s)      The maximum amount of stopping time to limit angular turn rate.
+    :attr:`ROLLCONTROLANGLERANGE`        :struct:`Scalar` (deg)    The maximum value of :attr:`ANGLEERROR` for which to control roll.
+    :attr:`ANGLEERROR`                   :struct:`Scalar` (deg)    The angle between vessel:facing and target directions
+    :attr:`PITCHERROR`                   :struct:`Scalar` (deg)    The angular error in the pitch direction
+    :attr:`YAWERROR`                     :struct:`Scalar` (deg)    The angular error in the yaw direction
+    :attr:`ROLLERROR`                    :struct:`Scalar` (deg)    The angular error in the roll direction
+    :attr:`PITCHTORQUEADJUST`            :struct:`Scalar` (kN)     Additive adjustment to pitch torque (calculated)
+    :attr:`YAWTORQUEADJUST`              :struct:`Scalar` (kN)     Additive adjustment to yaw torque (calculated)
+    :attr:`ROLLTORQUEADJUST`             :struct:`Scalar` (kN)     Additive adjustment to roll torque (calculated)
+    :attr:`PITCHTORQUEFACTOR`            :struct:`Scalar`          Multiplicative adjustment to pitch torque (calculated)
+    :attr:`YAWTORQUEFACTOR`              :struct:`Scalar`          Multiplicative adjustment to yaw torque (calculated)
+    :attr:`ROLLTORQUEFACTOR`             :struct:`Scalar`          Multiplicative adjustment to roll torque (calculated)
     ==================================== ========================= =============
 
 .. warning::
@@ -89,7 +89,7 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
 
 .. attribute:: SteeringManager:ENABLED
 
-    :type: :ref:`boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get only
 
     Returns true if the SteeringManager is currently controlling the vessel steering.
@@ -117,56 +117,56 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
 
 .. attribute:: SteeringManager:SHOWFACINGVECTORS
 
-    :type: :ref:`boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get/Set
 
     Setting this suffix to true will cause the steering manager to display graphical vectors (see :struct:`VecDraw`) representing the forward, top, and starboard of the facing direction, as well as the world x, y, and z axis orientation (centered on the vessel).  Setting to false will hide the vectors, as will disabling locked steering.
 
 .. attribute:: SteeringManager:SHOWANGULARVECTORS
 
-    :type: :ref:`boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get/Set
 
     Setting this suffix to true will cause the steering manager to display graphical vectors (see :struct:`VecDraw`) representing the current and target angular velocities in the pitch, yaw, and roll directions.  Setting to false will hide the vectors, as will disabling locked steering.
 
 .. attribute:: SteeringManager:SHOWSTEERINGSTATS
 
-    :type: :ref:`boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get/Set
 
     Setting this suffix to true will cause the steering manager to clear the terminal screen and print steering data each update.
 
 .. attribute:: SteeringManager:WRITECSVFILES
 
-    :type: :ref:`boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get/Set
 
     Setting this suffix to true will cause the steering manager log the data from all 6 PIDLoops calculating target angular velocity and target torque.  The files are stored in the `[KSP Root]\GameData\kOS\Plugins\PluginData\kOS` folder, with one file per loop and a new file created for each new manager instance (i.e. every launch, every revert, and every vessel load).  These files can grow quite large, and add up quickly, so it is recommended to only set this value to true for testing or debugging and not normal operation.
 
 .. attribute:: SteeringManager:PITCHTS
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get/Set
 
     Represents the settling time for the :ref:`PID calculating pitch torque based on target angular velocity <cooked_torque_pid>`.  The proportional and integral gain is calculated based on the settling time and the moment of inertia in the pitch direction.  Ki = (moment of inertia) * (4 / (settling time)) ^ 2.  Kp = 2 * sqrt((moment of inertia) * Ki).
 
 .. attribute:: SteeringManager:YAWTS
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get/Set
 
     Represents the settling time for the :ref:`PID calculating yaw torque based on target angular velocity <cooked_torque_pid>`.  The proportional and integral gain is calculated based on the settling time and the moment of inertia in the yaw direction.  Ki = (moment of inertia) * (4 / (settling time)) ^ 2.  Kp = 2 * sqrt((moment of inertia) * Ki).
 
 .. attribute:: SteeringManager:ROLLTS
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get/Set
 
     Represents the settling time for the :ref:`PID calculating roll torque based on target angular velocity <cooked_torque_pid>`.  The proportional and integral gain is calculated based on the settling time and the moment of inertia in the roll direction.  Ki = (moment of inertia) * (4 / (settling time)) ^ 2.  Kp = 2 * sqrt((moment of inertia) * Ki).
 
 .. attribute:: SteeringManager:TORQUEEPSILONMIN
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get/Set
 
     DEFAULT VALUE: 0.0002
@@ -186,7 +186,7 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
 
 .. attribute:: SteeringManager:TORQUEEPSILONMAX
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get/Set
 
     DEFAULT VALUE: 0.001
@@ -250,7 +250,7 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
 
 .. attribute:: SteeringManager:MAXSTOPPINGTIME
 
-    :type: :ref:`scalar <scalar>` (s)
+    :type: :struct:`Scalar` (s)
     :access: Get/Set
 
     This value is used to limit the turning rate when :ref:`calculating target angular velocity <cooked_omega_pid>`.  The ship will not turn faster than what it can stop in this amount of time.  The maximum angular velocity about each axis is calculated as: (max angular velocity) = MAXSTOPPINGTIME * (available torque) / (moment of inertia).
@@ -261,7 +261,7 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
 
 .. attribute:: SteeringManager:ROLLCONTROLANGLERANGE
 
-    :type: :ref:`scalar <scalar>` (deg)
+    :type: :struct:`Scalar` (deg)
     :access: Get/Set
 
     The maximum value of :attr:`ANGLEERROR<SteeringManager:ANGLEERROR>` for
@@ -275,70 +275,70 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
 
 .. attribute:: SteeringManager:ANGLEERROR
 
-    :type: :ref:`scalar <scalar>` (deg)
+    :type: :struct:`Scalar` (deg)
     :access: Get only
 
     The angle between the ship's facing direction forward vector and the target direction's forward.  This is the combined pitch and yaw error.
 
 .. attribute:: SteeringManager:PITCHERROR
 
-    :type: :ref:`scalar <scalar>` (deg)
+    :type: :struct:`Scalar` (deg)
     :access: Get only
 
     The pitch angle between the ship's facing direction and the target direction.
 
 .. attribute:: SteeringManager:YAWERROR
 
-    :type: :ref:`scalar <scalar>` (deg)
+    :type: :struct:`Scalar` (deg)
     :access: Get only
 
     The yaw angle between the ship's facing direction and the target direction.
 
 .. attribute:: SteeringManager:ROLLERROR
 
-    :type: :ref:`scalar <scalar>` (deg)
+    :type: :struct:`Scalar` (deg)
     :access: Get only
 
     The roll angle between the ship's facing direction and the target direction.
 
 .. attribute:: SteeringManager:PITCHTORQUEADJUST
 
-    :type: :ref:`scalar <scalar>` (kNm)
+    :type: :struct:`Scalar` (kNm)
     :access: Get/Set
 
     You can set this value to provide an additive bias to the calculated available pitch torque used in the pitch :ref:`torque PID <cooked_torque_pid>`. (available torque) = ((calculated torque) + PITCHTORQUEADJUST) * PITCHTORQUEFACTOR.
 
 .. attribute:: SteeringManager:YAWTORQUEADJUST
 
-    :type: :ref:`scalar <scalar>` (kNm)
+    :type: :struct:`Scalar` (kNm)
     :access: Get/Set
 
     You can set this value to provide an additive bias to the calculated available yaw torque used in the yaw :ref:`torque PID <cooked_torque_pid>`. (available torque) = ((calculated torque) + YAWTORQUEADJUST) * YAWTORQUEFACTOR.
 
 .. attribute:: SteeringManager:ROLLTORQUEADJUST
 
-    :type: :ref:`scalar <scalar>` (kNm)
+    :type: :struct:`Scalar` (kNm)
     :access: Get/Set
 
     You can set this value to provide an additive bias to the calculated available roll torque used in the roll :ref:`torque PID <cooked_torque_pid>`. (available torque) = ((calculated torque) + ROLLTORQUEADJUST) * ROLLTORQUEFACTOR.
 
 .. attribute:: SteeringManager:PITCHTORQUEFACTOR
 
-    :type: :ref:`scalar <scalar>` (kNm)
+    :type: :struct:`Scalar` (kNm)
     :access: Get/Set
 
     You can set this value to provide an multiplicative factor bias to the calculated available pitch torque used in the :ref:`torque PID <cooked_torque_pid>`. (available torque) = ((calculated torque) + PITCHTORQUEADJUST) * PITCHTORQUEFACTOR.
 
 .. attribute:: SteeringManager:YAWTORQUEFACTOR
 
-    :type: :ref:`scalar <scalar>` (kNm)
+    :type: :struct:`Scalar` (kNm)
     :access: Get/Set
 
     You can set this value to provide an multiplicative factor bias to the calculated available yaw torque used in the :ref:`torque PID <cooked_torque_pid>`. (available torque) = ((calculated torque) + YAWTORQUEADJUST) * YAWTORQUEFACTOR.
 
 .. attribute:: SteeringManager:ROLLTORQUEFACTOR
 
-    :type: :ref:`scalar <scalar>` (kNm)
+    :type: :struct:`Scalar` (kNm)
     :access: Get/Set
 
     You can set this value to provide an multiplicative factor bias to the calculated available roll torque used in the :ref:`torque PID <cooked_torque_pid>`. (available torque) = ((calculated torque) + ROLLTORQUEADJUST) * ROLLTORQUEFACTOR.

--- a/doc/source/structures/misc/terminal.rst
+++ b/doc/source/structures/misc/terminal.rst
@@ -63,7 +63,7 @@ Structure
 .. attribute:: Terminal:WIDTH
 
     :access: Get/Set
-    :type: :struct:`Scalar`.
+    :type: :struct:`Scalar`
 
     If you read the width it will return a number of character cells wide the terminal
     is.  If you set this value, it will cause the terminal to resize.
@@ -78,7 +78,7 @@ Structure
 .. attribute:: Terminal:HEIGHT
 
     :access: Get/Set
-    :type: :struct:`Scalar`.
+    :type: :struct:`Scalar`
 
     If you read the height it will return a number of character cells tall the terminal
     is.  If you set this value, it will cause the terminal to resize.
@@ -93,7 +93,7 @@ Structure
 .. attribute:: Terminal:REVERSE
 
     :access: Get/Set
-    :type: :struct:`Boolean`.
+    :type: :struct:`Boolean`
 
     If true, then the terminal window is currently set to show
     the whole screen in reversed color - swapping the background
@@ -109,7 +109,7 @@ Structure
 .. attribute:: Terminal:VISUALBEEP
 
     :access: Get/Set
-    :type: :struct:`Boolean`.
+    :type: :struct:`Boolean`
 
     If true, then the terminal window is currently set to show any
     BEEP characters by silently flashing the screen for a moment

--- a/doc/source/structures/misc/vecdraw.rst
+++ b/doc/source/structures/misc/vecdraw.rst
@@ -184,19 +184,19 @@ Suffixes of Vecdraw
           -
           - Same as :attr:`COLOR`
         * - :attr:`LABEL`
-          - :ref:`string <string>`
+          - :struct:`String`
           - Text to show next to vector
         * - :attr:`SCALE`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Scale :attr:`VEC` and :attr:`WIDTH` but not :attr:`START`
         * - :attr:`SHOW`
-          - :ref:`boolean <boolean>`
+          - :struct:`Boolean`
           - True to enable display to screen
         * - :attr:`WIDTH`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - width of vector, default is 0.2
         * - :attr:`POINTY`
-          - :ref:`boolean <boolean>`
+          - :struct:`Boolean`
           - Will the pointy hat be drawn
         * - :attr:`STARTUPDATER`
           - :struct:`KosDelegate`
@@ -254,7 +254,7 @@ Suffixes of Vecdraw
 .. attribute:: VecDraw:LABEL
 
     :access: Get/Set
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
 
     Optional, defaults to "". Text to show on-screen at the midpoint of the vector.
     Note the font size the label is displayed in gets stretched when you
@@ -263,7 +263,7 @@ Suffixes of Vecdraw
 .. attribute:: VecDraw:SCALE
 
     :access: Get/Set
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     Optional, defaults to 1.0. Scalar to multiply the VEC by, and the WIDTH,
     but not the START.
@@ -271,14 +271,14 @@ Suffixes of Vecdraw
 .. attribute:: VecDraw:SHOW
 
     :access: Get/Set
-    :type: :ref:`boolean <boolean>`
+    :type: :struct:`Boolean`
 
     Set to true to make the arrow appear, false to hide it. Defaults to false until you're ready to set it to true.
 
 .. attribute:: VecDraw:WIDTH
 
     :access: Get/Set
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     Define the width of the drawn line, in meters.  The deafult is 0.2 if
     left off.  Note, this also causes the font of the label to be enlarged
@@ -287,7 +287,7 @@ Suffixes of Vecdraw
 .. attribute:: VecDraw:POINTY
 
     :access: Get/Set
-    :type: :ref:`boolean <boolean>`
+    :type: :struct:`Boolean`
 
     (Defaults to True if left off.) Will this line be drawn with
     a pointy arrowhead "hat" on the tip to show which end is the
@@ -297,7 +297,7 @@ Suffixes of Vecdraw
 .. attribute:: VecDraw:WIPING
 
     :access: Get/Set
-    :type: :ref:`boolean <boolean>`
+    :type: :struct:`Boolean`
 
     (Defaults to True if left off.) If true, this line will be drawn
     with a "wipe" effect that varies how transparent it is.  At the

--- a/doc/source/structures/misc/voice.rst
+++ b/doc/source/structures/misc/voice.rst
@@ -60,32 +60,32 @@ Structure
           - Description
 
         * - :attr:`ATTACK`
-          - :struct:`scalar`
+          - :struct:`Scalar`
           - Get/Set
           - The *Attack* setting of the SKID voice's :ref:`ADSR Envelope <skid_envelope>`
 
         * - :attr:`DECAY`
-          - :struct:`scalar`
+          - :struct:`Scalar`
           - Get/Set
           - The *Decay* setting of the SKID voice's :ref:`ADSR Envelope <skid_envelope>`
 
         * - :attr:`SUSTAIN`
-          - :struct:`scalar`
+          - :struct:`Scalar`
           - Get/Set
           - The *Sustain* setting of the SKID voice's :ref:`ADSR Envelope <skid_envelope>`
 
         * - :attr:`RELEASE`
-          - :struct:`scalar`
+          - :struct:`Scalar`
           - Get/Set
           - The *Release* setting of the SKID voice's :ref:`ADSR Envelope <skid_envelope>`
 
         * - :attr:`VOLUME`
-          - :struct:`scalar`
+          - :struct:`Scalar`
           - Get/Set
           - The default volume to play the notes on this voice.
 
         * - :attr:`WAVE`
-          - :struct:`string`
+          - :struct:`String`
           - Get/Set
           - The name for the :ref:`waveform <skid_waveform>` you want this voice to use.
 
@@ -100,17 +100,17 @@ Structure
           - Stop playing note on this voice instance.
 
         * - :attr:`LOOP`
-          - :struct:`boolean`
+          - :struct:`Boolean`
           - Get/Set
           - Whether or not the voice should keep re-playing the song that was queued with PLAY().
 
         * - :attr:`ISPLAYING`
-          - :struct:`boolean`
+          - :struct:`Boolean`
           - Get/Set
           - The playing status of voice.
 
         * - :attr:`TEMPO`
-          - :struct:`scalar`
+          - :struct:`Scalar`
           - Get/Set
           - Stretches or shrinks the duration of the notes to speed up or slow down the song.
 
@@ -175,7 +175,7 @@ Structure
 .. attribute:: Voice:WAVE
 
     :access: Get/Set
-    :type: :struct:`string`
+    :type: :struct:`String`
 
     To select which of the SKID chip's
     :ref:`waveform generators <skid_waveform>` you want this voice
@@ -247,7 +247,7 @@ Structure
 .. attribute:: Voice:LOOP
 
     :access: Get/Set
-    :type: :struct:`boolean`
+    :type: :struct:`Boolean`
 
     If this is set to true, then the PLAY() method of this voice will
     keep on playing the same list of notes continually (starting over
@@ -259,7 +259,7 @@ Structure
 .. attribute:: Voice:ISPLAYING
 
     :access: Get/Set
-    :type: :struct:`boolean`
+    :type: :struct:`Boolean`
 
     **Get**: If this voice is currently playing a note or list of notes
     that was previously passed in to the ``PLAY()`` method, then this
@@ -276,7 +276,7 @@ Structure
 .. attribute:: Voice:TEMPO
 
     :access: Get/Set
-    :type: :struct:`scalar`
+    :type: :struct:`Scalar`
 
     When the voice is playing a :struct:`Note` or (more usefully) a
     :struct:`List` of :struct:`Note`'s, it will stretch or shrink the

--- a/doc/source/structures/orbits/eta.rst
+++ b/doc/source/structures/orbits/eta.rst
@@ -33,21 +33,21 @@ on an Orbit, and can be obtained one of two ways:
        - Description
 
      * - :attr:`APOAPSIS`
-       - :ref:`scalar <scalar>`, seconds
+       - :struct:`Scalar` (s)
        - Seconds from now until apoapsis.
      * - :attr:`PERIAPSIS`
-       - :ref:`scalar <scalar>`, seconds
+       - :struct:`Scalar` (s)
        - Seconds from now until periapsis.
      * - :attr:`NEXTNODE`
-       - :ref:`scalar <scalar>`, seconds
+       - :struct:`Scalar` (s)
        - Seconds from now until the next maneuver node.
      * - :attr:`TRANSITION`
-       - :ref:`scalar <scalar>`, seconds
+       - :struct:`Scalar` (s)
        - Seconds from now until the next orbit patch starts.
 		  
 .. attribute:: ETA:APOAPSIS
 
-    :type: :ref:`scalar <scalar>`, seconds
+    :type: :struct:`Scalar` (s)
     :access: Get-only
 
     Seconds until the object in this orbit patch would hit its apoapsis.
@@ -77,7 +77,7 @@ on an Orbit, and can be obtained one of two ways:
 
 .. attribute:: ETA:PERIAPSIS
 
-    :type: :ref:`scalar <scalar>`, seconds
+    :type: :struct:`Scalar` (s)
     :access: Get only
 
     Seconds until the object in this orbit hits its periapsis.  If the
@@ -95,7 +95,7 @@ on an Orbit, and can be obtained one of two ways:
 
 .. attribute:: ETA:NEXTNODE
 
-    :type: :ref:`scalar <scalar>`, seconds
+    :type: :struct:`Scalar` (s)
     :access: Get only
 
     Seconds until the next manuever node's timestamp.  NOTE this is the
@@ -112,7 +112,7 @@ on an Orbit, and can be obtained one of two ways:
 
 .. attribute:: ETA:TRANSITION
 
-    :type: :ref:`scalar <scalar>`, seconds
+    :type: :struct:`Scalar` (s)
     :access: Get only
 
     Seconds until the transition from this orbit patch to the next one.
@@ -126,4 +126,3 @@ on an Orbit, and can be obtained one of two ways:
     point value (32-bit).  (For various reasons, kOS does not allow
     the value "Infinity" in its Scalars, so "a really big number"
     is used in its place.)
-

--- a/doc/source/structures/orbits/eta.rst
+++ b/doc/source/structures/orbits/eta.rst
@@ -25,7 +25,6 @@ on an Orbit, and can be obtained one of two ways:
   .. structure:: OrbitEta
 
   .. list-table::
-
      :header-rows: 1
      :widths: 2 1 4
 
@@ -36,15 +35,12 @@ on an Orbit, and can be obtained one of two ways:
      * - :attr:`APOAPSIS`
        - :ref:`scalar <scalar>`, seconds
        - Seconds from now until apoapsis.
-
      * - :attr:`PERIAPSIS`
        - :ref:`scalar <scalar>`, seconds
        - Seconds from now until periapsis.
-
      * - :attr:`NEXTNODE`
        - :ref:`scalar <scalar>`, seconds
        - Seconds from now until the next maneuver node.
-
      * - :attr:`TRANSITION`
        - :ref:`scalar <scalar>`, seconds
        - Seconds from now until the next orbit patch starts.

--- a/doc/source/structures/orbits/orbit.rst
+++ b/doc/source/structures/orbits/orbit.rst
@@ -39,13 +39,13 @@ like its apoapsis, periapsis, etc.
 
 .. function:: CREATEORBIT(inc, e, sma, lan, argPe, mEp, t, body)
 
-    :parameter inc: (scalar) inclination, in degrees.
-    :parameter e: (scalar) eccentricity
-    :parameter sma: (scalar) semi-major axis
-    :parameter lan: (scalar) longitude of ascending node, in degrees.
-    :parameter argPe: (scalar) argument of periapsis
-    :parameter mEp: (scalar) mean anomaly at epoch, in degrees.
-    :parameter t: (scalar) epoch
+    :parameter inc: (:struct:`Scalar`) inclination, in degrees.
+    :parameter e: (:struct:`Scalar`) eccentricity
+    :parameter sma: (:struct:`Scalar`) semi-major axis
+    :parameter lan: (:struct:`Scalar`) longitude of ascending node, in degrees.
+    :parameter argPe: (:struct:`Scalar`) argument of periapsis
+    :parameter mEp: (:struct:`Scalar`) mean anomaly at epoch, in degrees.
+    :parameter t: (:struct:`Scalar`) epoch
     :parameter body: (:struct:`Body`) body to orbit around
     :return: :struct:`Orbit`
 
@@ -60,7 +60,7 @@ It is also possible to create an orbit from a position and a velocity using the 
     :parameter pos: (:struct:`Vector`) position (relative to center of body, NOT the usual relative to current ship most positions in kOS use.  Remember to offset a kOS position from the body's position when calculating what to pass in here.)
     :parameter vel: (:struct:`Vector`) velocity
     :parameter body: (:struct:`Body`) body to orbit around
-    :parameter ut: (scalar) time (universal)
+    :parameter ut: (:struct:`Scalar`) time (universal)
     :return: :struct:`Orbit`
 
     This creates a new orbit around Kerbin::

--- a/doc/source/structures/orbits/orbitable.rst
+++ b/doc/source/structures/orbits/orbitable.rst
@@ -33,42 +33,42 @@ All objects that can move in orbit around other objects share some similar struc
     :attr:`SRFRETROGRADE`   :struct:`Direction`
     :attr:`POSITION`        :struct:`Vector`
     :attr:`VELOCITY`        :struct:`OrbitableVelocity`
-    :attr:`DISTANCE`        :ref:`scalar <scalar>` (m)
+    :attr:`DISTANCE`        :struct:`Scalar` (m)
     :attr:`DIRECTION`       :struct:`Direction`
-    :attr:`LATITUDE`        :ref:`scalar <scalar>` (deg)
-    :attr:`LONGITUDE`       :ref:`scalar <scalar>` (deg)
-    :attr:`ALTITUDE`        :ref:`scalar <scalar>` (m)
+    :attr:`LATITUDE`        :struct:`Scalar` (deg)
+    :attr:`LONGITUDE`       :struct:`Scalar` (deg)
+    :attr:`ALTITUDE`        :struct:`Scalar` (m)
     :attr:`GEOPOSITION`     :struct:`GeoCoordinates`
     :attr:`PATCHES`         :struct:`List` of :struct:`Orbits <Orbit>`
-    :attr:`APOAPSIS`        :ref:`scalar <scalar>` (m) (Deprecated, use :OBT:APOAPSIS instead.)
-    :attr:`PERIAPSIS`       :ref:`scalar <scalar>` (m) (Deprecated, use :OBT:PERIAPSIS instead.)
+    :attr:`APOAPSIS`        :struct:`Scalar` (m) (Deprecated, use :OBT:APOAPSIS instead.)
+    :attr:`PERIAPSIS`       :struct:`Scalar` (m) (Deprecated, use :OBT:PERIAPSIS instead.)
     ======================= ==============
 
 
 .. attribute:: Orbitable:NAME
 
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
     :access: Get only
 
     Name of this vessel or body.
 
 .. attribute:: Orbitable:HASBODY
 
-    :type: :ref:`boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get only
 
     True if this object has a body it orbits (false only when this object is the Sun, pretty much).
 
 .. attribute:: Orbitable:HASORBIT
 
-    :type: :ref:`boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get only
 
     Alias for HASBODY.
 
 .. attribute:: Orbitable:HASOBT
 
-    :type: :ref:`boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get only
 
     Alias for HASBODY.
@@ -152,10 +152,10 @@ All objects that can move in orbit around other objects share some similar struc
 
 .. attribute:: Orbitable:DISTANCE
 
-    :type: :ref:`scalar <scalar>` (m)
+    :type: :struct:`Scalar` (m)
     :access: Get only
 
-    The :ref:`scalar <scalar>` distance between this object and the center of :struct:`SHIP`.
+    The :struct:`Scalar` distance between this object and the center of :struct:`SHIP`.
 
 .. attribute:: Orbitable:DIRECTION
 
@@ -166,21 +166,21 @@ All objects that can move in orbit around other objects share some similar struc
 
 .. attribute:: Orbitable:LATITUDE
 
-    :type: :ref:`scalar <scalar>` (deg)
+    :type: :struct:`Scalar` (deg)
     :access: Get only
 
     The latitude in degrees of the spot on the surface of the SOI body directly under this object.
 
 .. attribute:: Orbitable:LONGITUDE
 
-    :type: :ref:`scalar <scalar>` (deg)
+    :type: :struct:`Scalar` (deg)
     :access: Get only
 
     The longitude in degrees of the spot on the surface of the SOI body directly under this object. Longitude returned will always be normalized to be in the range [-180,180].
 
 .. attribute:: Orbitable:ALTITUDE
 
-    :type: :ref:`scalar <scalar>` (m)
+    :type: :struct:`Scalar` (m)
     :access: Get only
 
     The altitude in meters above the *sea level* surface of the SOI body (not the center of the SOI body. To get the true radius of the orbit for proper math calculations remember to add altitude to the SOI body's radius.)
@@ -201,7 +201,7 @@ All objects that can move in orbit around other objects share some similar struc
 
 .. attribute:: Orbitable:APOAPSIS
 
-    :type: :ref:`scalar <scalar>` (deg)
+    :type: :struct:`Scalar` (deg)
     :access: Get only
 
     .. deprecated:: 0.15
@@ -213,7 +213,7 @@ All objects that can move in orbit around other objects share some similar struc
 
 .. attribute:: Orbitable:PERIAPSIS
 
-    :type: :ref:`scalar <scalar>` (deg)
+    :type: :struct:`Scalar` (deg)
     :access: Get only
 
     .. deprecated:: 0.15

--- a/doc/source/structures/reflection/structure.rst
+++ b/doc/source/structures/reflection/structure.rst
@@ -1,7 +1,7 @@
 .. _structure:
 
-Structure:
-==========
+Structure
+=========
 
 The root of all kOS data types.
 
@@ -247,4 +247,3 @@ or ``42`` or ``"abc"``.  For example, you can do::
     Not all types can be saved using the built-in serialization function
     :ref:`WRITEJSON <writejson>`.  For those that can, values of that
     type will return ``True`` for this suffix, otherwise it returns ``False``.
-

--- a/doc/source/structures/vessels/aggregateresource.rst
+++ b/doc/source/structures/vessels/aggregateresource.rst
@@ -42,47 +42,47 @@ This is also the type returned by STAGE:RESOURCES ::
           - Description
 
         * - :attr:`NAME`
-          - :ref:`string <string>`
+          - :struct:`String`
           - Resource name
         * - :attr:`AMOUNT`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Total amount remaining
         * - :attr:`CAPACITY`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Total amount when full
         * - :attr:`DENSITY`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Density of this resource
         * - :attr:`PARTS`
-          - List
+          - :struct:`List`
           - Parts containing this resource
 
 
 .. attribute:: AggregateResource:NAME
 
     :access: Get only
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
 
     The name of the resource, i.e. "LIQUIDFUEL", "ELECTRICCHARGE", "MONOPROP".
 
 .. attribute:: AggregateResource:AMOUNT
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     The value of how much resource is left.
 
 .. attribute:: AggregateResource:CAPACITY
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     What AMOUNT would be if the resource was filled to the top.
 
 .. attribute:: AggregateResource:DENSITY
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     The density value of this resource, expressed in Megagrams f mass
     per Unit of resource.  (i.e. a value of 0.005 would mean that each
@@ -92,6 +92,6 @@ This is also the type returned by STAGE:RESOURCES ::
 .. attribute:: AggregateResource:PARTS
 
     :access: Get only
-    :type: List
+    :type: :struct:`List`
 
     Because this is a summation of the resources from many parts. kOS gives you the list of all parts that do or could contain the resource.

--- a/doc/source/structures/vessels/alt.rst
+++ b/doc/source/structures/vessels/alt.rst
@@ -21,14 +21,14 @@ the better new way to do it:
           - Description
 
         * - :attr:`APOAPSIS`
-          - :ref:`scalar <scalar>`, meters
+          - :struct:`Scalar` (m)
           - altitude in meters of SHIP's apoapsis.  Same as SHIP:APOAPSIS.
 
         * - :attr:`PERIAPSIS`
-          - :ref:`scalar <scalar>`, meters
+          - :struct:`Scalar` (m)
           - altitude in meters of SHIP's periapsis.  Same as SHIP:PERIAPSIS.
 
         * - :attr:`RADAR`
-          - :ref:`scalar <scalar>`, meters
+          - :struct:`Scalar` (m)
           - Altitude of SHIP above the ground terrain, rather than above sea level.
 		  

--- a/doc/source/structures/vessels/bounds.rst
+++ b/doc/source/structures/vessels/bounds.rst
@@ -345,7 +345,7 @@ illustrate what is being talked about:
           - Get/Set
           - origin point of box, in absolute ship-raw coords.
         * - :attr:`FACING`
-          - :struct:`Direction``
+          - :struct:`Direction`
           - Get/Set
           - The orientation of the box's own reference frame.
         * - :attr:`RELMIN`
@@ -385,11 +385,11 @@ illustrate what is being talked about:
           - Get only
           - Position (in absolute ship-raw coords) of the box corner most "that-a-way".
         * - :attr:`BOTTOMALT`
-          - :ref:`Scalar`
+          - :struct:`Scalar`
           - Get Only
           - Sea-level altitude of bottom-most corner of box.
         * - :attr:`BOTTOMALTRADAR`
-          - :ref:`Scalar`
+          - :struct:`Scalar`
           - Get Only
           - Radar altitude of bottom-most corner of box.
         * - RELORIGIN is missing
@@ -692,7 +692,7 @@ illustrate what is being talked about:
     
 .. attribute:: Bounds:BOTTOMALT
 
-    :type: :ref:`Scalar`
+    :type: :struct:`Scalar`
     :access: Get-only
 
     The above-sea-level altitude reading from the bottom-most corner of
@@ -726,7 +726,7 @@ illustrate what is being talked about:
 
 .. attribute:: Bounds:BOTTOMALTRADAR
 
-    :type: :ref:`Scalar`
+    :type: :struct:`Scalar`
     :access: Get-only
 
     The radar-altitude reading from the bottom-most corner of

--- a/doc/source/structures/vessels/consumedresource.rst
+++ b/doc/source/structures/vessels/consumedresource.rst
@@ -3,7 +3,7 @@
 ConsumedResource
 =================
 
-A single resource value an engine consumes (i.e. fuel, oxidizer, etc). This is the type returned by the :struct:`Engine`:CONSUMEDRESOURCES suffix
+A single resource value an engine consumes (i.e. fuel, oxidizer, etc). This is the type returned by the :attr:`Engine:CONSUMEDRESOURCES` suffix
 
 .. structure:: ConsumedResource
 
@@ -16,62 +16,62 @@ A single resource value an engine consumes (i.e. fuel, oxidizer, etc). This is t
           - Description
 
         * - :attr:`NAME`
-          - :ref:`string <string>`
+          - :struct:`String`
           - Resource name
         * - :attr:`AMOUNT`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Total amount remaining (only valid while engine is running)
         * - :attr:`CAPACITY`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Total amount when full (only valid while engine is running)
         * - :attr:`DENSITY`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Density of this resource
         * - :attr:`FUELFLOW`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Current volumetric flow rate of fuel
         * - :attr:`MAXFUELFLOW`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Untweaked maximum volumetric flow rate of fuel
         * - :attr:`REQUIREDFLOW`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Required volumetric flow rate of fuel for current throttle
         * - :attr:`MASSFLOW`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Current mass flow rate of fuel
         * - :attr:`MAXMASSFLOW`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Untweaked maximum mass flow rate of fuel
         * - :attr:`RATIO`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Volumetric flow ratio of this resource
 
 
 .. attribute:: ConsumedResource:NAME
 
     :access: Get only
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
 
     The name of the resource, i.e. "LIQUIDFUEL", "ELECTRICCHARGE", "MONOPROP".
 
 .. attribute:: ConsumedResource:AMOUNT
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     The value of how much resource is left and accessible to this engine. Only valid while the engine is running.
 
 .. attribute:: ConsumedResource:CAPACITY
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     What AMOUNT would be if the resource was filled to the top. Only valid while the engine is running.
 
 .. attribute:: ConsumedResource:DENSITY
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     The density value of this resource, expressed in Megagrams f mass
     per Unit of resource.  (i.e. a value of 0.005 would mean that each
@@ -81,21 +81,21 @@ A single resource value an engine consumes (i.e. fuel, oxidizer, etc). This is t
 .. attribute:: ConsumedResource:FUELFLOW
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     How much volume of this fuel is this engine consuming at this very moment.
 
 .. attribute:: ConsumedResource:MAXFUELFLOW
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     How much volume of this fuel would this engine consume at standard pressure and velocity if the throttle was max at 1.0, and the thrust limiter was max at 100%.
     
 .. attribute:: ConsumedResource:REQUIREDFLOW
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     How much volume of this fuel does this require at this very moment for the current throttle setting.
     This will usually equal FUELFLOW but may be higher for INTAKEAIR for instance.
@@ -103,21 +103,20 @@ A single resource value an engine consumes (i.e. fuel, oxidizer, etc). This is t
 .. attribute:: ConsumedResource:MASSFLOW
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     How much mass of this fuel is this engine consuming at this very moment.
 
 .. attribute:: ConsumedResource:MAXMASSFLOW
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     How much mass of this fuel would this engine consume at standard pressure and velocity if the throttle was max at 1.0, and the thrust limiter was max at 100%.
     
 .. attribute:: ConsumedResource:RATIO
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     What is the volumetric ratio of this fuel as a proportion of the overall fuel mixture, e.g. if this is 0.5 then this fuel is half the required fuel for the engine.
-

--- a/doc/source/structures/vessels/consumedresourcercs.rst
+++ b/doc/source/structures/vessels/consumedresourcercs.rst
@@ -16,47 +16,47 @@ A single resource value an rcs thruster consumes (i.e. monopropellant, etc). Thi
           - Description
 
         * - :attr:`NAME`
-          - :ref:`string <string>`
+          - :struct:`String`
           - Resource name
         * - :attr:`AMOUNT`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Total amount remaining (only valid while engine is running)
         * - :attr:`CAPACITY`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Total amount when full (only valid while engine is running)
         * - :attr:`DENSITY`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Density of this resource
         * - :attr:`RATIO`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Volumetric flow ratio of this resource
 
 
 .. attribute:: ConsumedResourceRCS:NAME
 
     :access: Get only
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
 
     The name of the resource, i.e. "LIQUIDFUEL", "ELECTRICCHARGE", "MONOPROP".
 
 .. attribute:: ConsumedResourceRCS:AMOUNT
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     The value of how much resource is left and accessible to this thruster. Only valid while the thruster is running.
 
 .. attribute:: ConsumedResourceRCS:CAPACITY
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     What AMOUNT would be if the resource was filled to the top. Only valid while the thruster is running.
 
 .. attribute:: ConsumedResourceRCS:DENSITY
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     The density value of this resource, expressed in Megagrams f mass
     per Unit of resource.  (i.e. a value of 0.005 would mean that each
@@ -66,7 +66,6 @@ A single resource value an rcs thruster consumes (i.e. monopropellant, etc). Thi
 .. attribute:: ConsumedResource:RCSRATIO
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     What is the volumetric ratio of this fuel as a proportion of the overall fuel mixture, e.g. if this is 0.5 then this fuel is half the required fuel for the thruster.
-

--- a/doc/source/structures/vessels/core.rst
+++ b/doc/source/structures/vessels/core.rst
@@ -22,13 +22,13 @@ Core represents your ability to identify and interact directly with the running 
           - :struct:`CORE` objects are a type of :struct:`kOSProcessor`
 
         * - :attr:`VESSEL`
-          - `Vessel`
+          - :struct:`Vessel`
         * - :attr:`ELEMENT`
-          - `Element`
+          - :struct:`Element`
         * - :attr:`TAG`
-          - `The kOS nametag on the part this CPU runs on`
+          - :struct:`String`
         * - :attr:`VERSION`
-          - `Version`
+          - :struct:`VersionInfo`
         * - :attr:`CURRENTVOLUME`
           - :struct:`Volume`
         * - :attr:`MESSAGES`
@@ -63,7 +63,7 @@ Core represents your ability to identify and interact directly with the running 
     :access: Get/Set
 
     The kOS name tag currently assigned to the part this core is
-    inside.  This is the same thing as Core:part:tag.
+    inside.  This is the same thing as :attr:`CORE:PART:TAG`.
 
 .. attribute:: CORE:CURRENTVOLUME
 
@@ -78,4 +78,3 @@ Core represents your ability to identify and interact directly with the running 
     :access: Get only
 
     Returns this processsor's message queue.
-

--- a/doc/source/structures/vessels/crewmember.rst
+++ b/doc/source/structures/vessels/crewmember.rst
@@ -16,19 +16,19 @@ Represents a single crew member of a vessel.
           - Description
 
         * - :attr:`NAME`
-          - :ref:`string <string>`
+          - :struct:`String`
           - crew member's name
         * - :attr:`GENDER`
-          - :ref:`string <string>`
+          - :struct:`String`
           - "Male" or "Female"
         * - :attr:`EXPERIENCE`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - experience level (number of stars)
         * - :attr:`TRAIT`
-          - :ref:`string <string>`
+          - :struct:`String`
           - "Pilot", "Engineer" or "Scientist"
         * - :attr:`TOURIST`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - true if this crew member is a tourist
         * - :attr:`PART`
           - :struct:`Part`
@@ -37,35 +37,35 @@ Represents a single crew member of a vessel.
 
 .. attribute:: CrewMember:NAME
 
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
     :access: Get only
 
     crew member's name
 
 .. attribute:: CrewMember:GENDER
 
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
     :access: Get only
 
     "Male" or "Female"
 
 .. attribute:: CrewMember:EXPERIENCE
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     experience level (number of stars)
 
 .. attribute:: CrewMember:TRAIT
 
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
     :access: Get only
 
     crew member's trait (specialization), for example "Pilot"
 
 .. attribute:: CrewMember:TOURIST
 
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get only
 
     true if this crew member is a tourist

--- a/doc/source/structures/vessels/decoupler.rst
+++ b/doc/source/structures/vessels/decoupler.rst
@@ -22,8 +22,6 @@ of the suffixes for them are found.
         * - All suffixes of :struct:`Part`
           -
           - A :struct:`Decoupler` is a kind of :struct:`Part`
-
-.. structure:: Separator
-
+          
     Most :struct:`Decoupler` parts are also :struct:`Separator` parts, and most of
     the useful suffixes for them are in :struct:`Separator`.

--- a/doc/source/structures/vessels/dockingport.rst
+++ b/doc/source/structures/vessels/dockingport.rst
@@ -26,31 +26,31 @@ Such part can also be retrieved from :global:`TARGET`, if docking port is select
           - A :struct:`DockingPort` is a kind of :struct:`Decoupler` (which is :struct:`Part`)
 
         * - :attr:`ACQUIRERANGE`
-          - scalar
+          - :struct:`Scalar`
           - active range of the port
         * - :attr:`ACQUIREFORCE`
-          - scalar
+          - :struct:`Scalar`
           - force experienced when docking
         * - :attr:`ACQUIRETORQUE`
-          - scalar
+          - :struct:`Scalar`
           - torque experienced when docking
         * - :attr:`REENGAGEDDISTANCE`
-          - scalar
+          - :struct:`Scalar`
           - distance at which the port is reset
         * - :attr:`DOCKEDSHIPNAME`
-          - :ref:`string <string>`
+          - :struct:`String`
           - name of vessel the port is docked to
         * - :attr:`NODEPOSITION`
-          - vector
+          - :struct:`Vector`
           - coords of where the docking node attachment point is in SHIP-RAW xyz
         * - :attr:`NODETYPE`
-          - :ref:`string <string>`
+          - :struct:`String`
           - two nodes are only dockable together if their NODETYPE strings match
         * - :attr:`PORTFACING`
           - :struct:`Direction`
           - facing of the port
         * - :attr:`STATE`
-          - :ref:`string <string>`
+          - :struct:`String`
           - current state of the port
         * - :meth:`UNDOCK`
           -
@@ -59,10 +59,10 @@ Such part can also be retrieved from :global:`TARGET`, if docking port is select
           - :struct:`DockingPort`
           - the docking port this docking port is attached to, or "None" if no such port
         * - :attr:`HASPARTNER`
-          - boolean
+          - :struct:`Boolean`
           - whether or not this docking port is attached to another docking port
         * - :attr:`TARGETABLE`
-          - boolean
+          - :struct:`Boolean`
           - check if this port can be targeted
 
 .. note::
@@ -100,7 +100,7 @@ Such part can also be retrieved from :global:`TARGET`, if docking port is select
 
 .. attribute:: DockingPort:DOCKEDSHIPNAME
 
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
     :access: Get only
 
     name of vessel on the other side of the docking port.
@@ -118,7 +118,7 @@ Such part can also be retrieved from :global:`TARGET`, if docking port is select
 
 .. attribute:: DockingPort:NODETYPE
 
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
     :access: Get only
 
     Each docking port has a node type string that specifies its
@@ -148,7 +148,7 @@ Such part can also be retrieved from :global:`TARGET`, if docking port is select
 
 .. attribute:: DockingPort:STATE
 
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
     :access: Get only
 
     One of the following string values:
@@ -185,14 +185,14 @@ Such part can also be retrieved from :global:`TARGET`, if docking port is select
 
 .. attribute:: DockingPort:HASPARTNER
 
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get only
 
     Whether or not this docking port is attached to another docking port.
 
 .. attribute:: DockingPort:TARGETABLE
 
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get only
 
     True if this part can be picked with ``SET TARGET TO``.

--- a/doc/source/structures/vessels/element.rst
+++ b/doc/source/structures/vessels/element.rst
@@ -24,8 +24,8 @@ elements and what they do.
     ===================================== ========================= =============
     Suffix                                Type                      Description
     ===================================== ========================= =============
-    :attr:`NAME`                          :struct:string            The name of the docked craft
-    :attr:`UID`                           :struct:string            Unique Identifier 
+    :attr:`NAME`                          :struct:`String`          The name of the docked craft
+    :attr:`UID`                           :struct:`String`          Unique Identifier 
     :attr:`PARTS`                         :struct:`List`            all :struct:`Parts <Part>`
     :attr:`DOCKINGPORTS`                  :struct:`List`            all :struct:`DockingPorts <DockingPort>`
     :attr:`VESSEL`                        :struct:`Vessel`          the parent :struct:`Vessel`
@@ -34,31 +34,31 @@ elements and what they do.
 
 .. attribute:: Element:UID
 
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
     :access: Get only 
 
     A unique id
 
 .. attribute:: Element:NAME
 
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
     :access: Get/Set
 
-    The name of the Element element, is an artifact from the vessel the element belonged to before docking. Cannot be set to an empty :ref:`string <string>`.
+    The name of the Element element, is an artifact from the vessel the element belonged to before docking. Cannot be set to an empty :struct:`String`.
 
 .. attribute:: Element:PARTS
 
     :type: :struct:`List` of :struct:`Part` objects
     :access: Get only
 
-    A List of all the :ref:`parts <part>` on the Element. ``SET FOO TO SHIP:PARTS.`` has exactly the same effect as ``LIST PARTS IN FOO.``. For more information, see :ref:`ship parts and modules <parts and partmodules>`.
+    A List of all the :struct:`parts <Part>` on the Element. ``SET FOO TO SHIP:PARTS.`` has exactly the same effect as ``LIST PARTS IN FOO.``. For more information, see :ref:`ship parts and modules <parts and partmodules>`.
 
 .. attribute:: Element:DOCKINGPORTS
 
     :type: :struct:`List` of :struct:`DockingPort` objects
     :access: Get only
 
-    A List of all the :ref:`docking ports <DockingPort>` on the Element. 
+    A List of all the :struct:`docking ports <DockingPort>` on the Element. 
 
 .. attribute:: Element:VESSEL
 
@@ -72,5 +72,4 @@ elements and what they do.
     :type: :struct:`List` of :struct:`AggregateResource` objects
     :access: Get only
 
-    A List of all the :ref:`AggregateResources <AggregateResource>` on the element.
-
+    A List of all the :struct:`AggregateResources <AggregateResource>` on the element.

--- a/doc/source/structures/vessels/engine.rst
+++ b/doc/source/structures/vessels/engine.rst
@@ -30,112 +30,112 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
           -
           - Turn engine off
         * - :attr:`THRUSTLIMIT`
-          - :ref:`scalar <scalar>` (%)
+          - :struct:`Scalar` (%)
           - Tweaked thrust limit
         * - :attr:`MAXTHRUST`
-          - :ref:`scalar <scalar>` (kN)
+          - :struct:`Scalar` (kN)
           - Untweaked thrust limit. Zero if engine disabled.
         * - :meth:`MAXTHRUSTAT(pressure)`
-          - :ref:`scalar <scalar>` (kN)
+          - :struct:`Scalar` (kN)
           - Max thrust at the specified pressure (in standard Kerbin atmospheres). Zero if engine disabled.
         * - :attr:`THRUST`
-          - :ref:`scalar <scalar>` (kN)
+          - :struct:`Scalar` (kN)
           - Current thrust. Zero if engine disabled.
         * - :attr:`AVAILABLETHRUST`
-          - :ref:`scalar <scalar>` (kN)
+          - :struct:`Scalar` (kN)
           - Available thrust at full throttle accounting for thrust limiter. Zero if engine disabled.
         * - :meth:`AVAILABLETHRUSTAT(pressure)`
-          - :ref:`scalar <scalar>` (kN)
+          - :struct:`Scalar` (kN)
           - Available thrust at the specified pressure (in standard Kerbin atmospheres). Zero if engine disabled.
         * - :attr:`POSSIBLETHRUST`
-          - :ref:`scalar <scalar>` (kN)
+          - :struct:`Scalar` (kN)
           - Possible thrust at full throttle accounting for thrust limiter, when the engine is enabled.
         * - :meth:`POSSIBLETHRUSTAT(pressure)`
-          - :ref:`scalar <scalar>` (kN)
+          - :struct:`Scalar` (kN)
           - Possible thrust at the specified pressure (in standard Kerbin atmospheres), when the engine is enabled.
         * - :attr:`FUELFLOW`
-          - :ref:`scalar <scalar>` (unit/s)
+          - :struct:`Scalar` (unit/s)
           - Current volumetric flow rate of fuel.
         * - :attr:`MAXFUELFLOW`
-          - :ref:`scalar <scalar>` (unit/s)
+          - :struct:`Scalar` (unit/s)
           - Untweaked maximum volumetric flow rate of fuel at full throttle.
         * - :attr:`MASSFLOW`
-          - :ref:`scalar <scalar>` (Mg/s)
+          - :struct:`Scalar` (Mg/s)
           - Current mass flow rate of fuel.
         * - :attr:`MAXMASSFLOW`
-          - :ref:`scalar <scalar>` (Mg/s)
+          - :struct:`Scalar` (Mg/s)
           - Untweaked maximum mass flow rate of fuel at full throttle.
         * - :attr:`ISP`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_
         * - :meth:`ISPAT(pressure)`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_ at the given pressure (in standard Kerbin atmospheres).
         * - :attr:`VACUUMISP`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Vacuum `specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_
         * - :attr:`VISP`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Synonym for VACUUMISP
         * - :attr:`SEALEVELISP`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_ at Kerbin sealevel
         * - :attr:`SLISP`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Synonym for SEALEVELISP
         * - :attr:`FLAMEOUT`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Check if no more fuel
         * - :attr:`IGNITION`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Check if engine is active
         * - :attr:`ALLOWRESTART`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Check if engine can be reactivated
         * - :attr:`ALLOWSHUTDOWN`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Check if engine can be shutdown
         * - :attr:`THROTTLELOCK`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Check if throttle can not be changed
         * - :attr:`MULTIMODE`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Check if engine has multiple modes
         * - :attr:`MODES`
           - :struct:`List`
           - List (string) of the engine modes
         * - :attr:`MODE`
-          - :ref:`string <string>`
+          - :struct:`String`
           - Name of the current mode (only if multiple)
-        * - :attr:`TOGGLEMODE`
+        * - :meth:`TOGGLEMODE()`
           - 
           - Switch to another mode (only if multiple)
         * - :attr:`PRIMARYMODE`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Is the engine in primary mode? (only if multiple)
         * - :attr:`AUTOSWITCH`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Can the engine switch modes automatically? (only if multiple)
         * - :attr:`HASGIMBAL`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Check if engine has gimbal
         * - :attr:`GIMBAL`
           - :struct:`Gimbal`
           - Gimbal of this engine (only if available)
         * - :attr:`ULLAGE`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Does this engine need ullage (for RealFuels)
         * - :attr:`FUELSTABILITY`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - How stable is the fuel for this engine (for RealFuels)
         * - :attr:`PRESSUREFED`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Is this engine pressure fed? (for RealFuels)
         * - :attr:`IGNITIONS`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Number of ignitions remaining for this engine (for RealFuels)
         * - :attr:`MINTHROTTLE`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - The minimum throttle setting for this engine (for RealFuels)
         * - :attr:`CONFIG`
           - :struct:`String`
@@ -162,7 +162,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
 .. attribute:: Engine:THRUSTLIMIT
 
     :access: Get/Set
-    :type: :ref:`scalar <scalar>` (%)
+    :type: :struct:`Scalar` (%)
 
     If this an engine with a thrust limiter (tweakable) enabled, what
     percentage is it limited to?  Note that this is expressed as a 
@@ -187,7 +187,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
 .. attribute:: Engine:MAXTHRUST
 
     :access: Get only
-    :type: :ref:`scalar <scalar>` (kN)
+    :type: :struct:`Scalar` (kN)
 
     How much thrust would this engine give at its current atmospheric pressure and velocity if the throttle was max at 1.0, and the thrust limiter was max at 100%.  Note this might not be the engine's actual max thrust it could have under other air pressure conditions.  Some engines have a very different value for MAXTHRUST in vacuum as opposed to at sea level pressure.  Also, some jet engines have a very different value for MAXTHRUST depending on how fast they are currently being rammed through the air. Also note that this will read zero if the engine is currently disabled.
 
@@ -196,7 +196,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
 .. method:: Engine:MAXTHRUSTAT(pressure)
 
     :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
-    :type: :ref:`scalar <scalar>` (kN)
+    :type: :struct:`Scalar` (kN)
 
     How much thrust would this engine give if both the throttle and thrust limtier was max at the current velocity, and at the given atmospheric pressure.  Use a pressure of 0.0 for vacuum, and 1.0 for sea level (on Kerbin) (or more than 1 for thicker atmospheres like on Eve). Note that this will read zero if the engine is currently disabled.
     (Pressure must be greater than or equal to zero.  If you pass in a
@@ -207,7 +207,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
 .. attribute:: Engine:THRUST
 
     :access: Get only
-    :type: :ref:`scalar <scalar>` (kN)
+    :type: :struct:`Scalar` (kN)
 
     How much thrust is this engine giving at this very moment.
 
@@ -216,7 +216,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
 .. attribute:: Engine:AVAILABLETHRUST
 
     :access: Get only
-    :type: :ref:`scalar <scalar>` (kN)
+    :type: :struct:`Scalar` (kN)
 
     Taking into account the thrust limiter tweakable setting, how much thrust would this engine give if the throttle was max at its current thrust limit setting and atmospheric pressure and velocity conditions. Note that this will read zero if the engine is currently disabled.
 
@@ -225,7 +225,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
 .. method:: Engine:AVAILABLETHRUSTAT(pressure)
 
     :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
-    :type: :ref:`scalar <scalar>` (kN)
+    :type: :struct:`Scalar` (kN)
 
     Taking into account the thrust limiter tweakable setting, how much thrust would this engine give if the throttle was max at its current thrust limit setting and velocity, but at a different atmospheric pressure you pass into it.  The pressure is measured in ATM's, meaning 0.0 is a vacuum, 1.0 is sea level at Kerbin.  Note that this will read zero if the engine is currently disabled.
     (Pressure must be greater than or equal to zero.  If you pass in a
@@ -236,7 +236,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
 .. attribute:: Engine:POSSIBLETHRUST
 
     :access: Get only
-    :type: :ref:`scalar <scalar>` (kN)
+    :type: :struct:`Scalar` (kN)
 
     Taking into account the thrust limiter tweakable setting, how much thrust would this engine give if the throttle was max at its current thrust limit setting and atmospheric pressure and velocity conditions. This will give the correct value even if the engine is currently disabled.
 
@@ -245,7 +245,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
 .. method:: Engine:POSSIBLETHRUSTAT(pressure)
 
     :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
-    :type: :ref:`scalar <scalar>` (kN)
+    :type: :struct:`Scalar` (kN)
 
     Taking into account the thrust limiter tweakable setting, how much thrust would this engine give if the throttle was max at its current thrust limit setting and velocity, but at a different atmospheric pressure you pass into it.  The pressure is measured in ATM's, meaning 0.0 is a vacuum, 1.0 is sea level at Kerbin.  This will give the correct value even if the engine is currently disabled.
     (Pressure must be greater than or equal to zero.  If you pass in a
@@ -254,42 +254,42 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
 .. attribute:: Engine:FUELFLOW
 
     :access: Get only
-    :type: :ref:`scalar <scalar>` (units/s)
+    :type: :struct:`Scalar` (units/s)
 
     How much fuel volume is this engine consuming at this very moment.
 
 .. attribute:: Engine:MAXFUELFLOW
 
     :access: Get only
-    :type: :ref:`scalar <scalar>` (units/s)
+    :type: :struct:`Scalar` (units/s)
 
     How much fuel volume would this engine consume at standard pressure and velocity if the throttle was max at 1.0, and the thrust limiter was max at 100%.  Note this might not be the engine's actual max fuel flow it could have under other air pressure conditions.  Some jet engines have a very different fuel consumption depending on how fast they are currently being rammed through the air.
     
 .. attribute:: Engine:MASSFLOW
 
     :access: Get only
-    :type: :ref:`scalar <scalar>` (Mg/s)
+    :type: :struct:`Scalar` (Mg/s)
 
     How much fuel mass is this engine consuming at this very moment.
 
 .. attribute:: Engine:MAXMASSFLOW
 
     :access: Get only
-    :type: :ref:`scalar <scalar>` (Mg/s)
+    :type: :struct:`Scalar` (Mg/s)
 
     How much fuel mass would this engine consume at standard pressure and velocity if the throttle was max at 1.0, and the thrust limiter was max at 100%.  Note this might not be the engine's actual max fuel flow it could have under other air pressure conditions.  Some jet engines have a very different fuel consumption depending on how fast they are currently being rammed through the air.
 
 .. attribute:: Engine:ISP
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_
 
 .. method:: Engine:ISPAT(pressure)
 
     :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_ at the given atmospheric pressure.  Use a pressure of 0 for vacuum, and 1 for sea level (on Kerbin).
     (Pressure must be greater than or equal to zero.  If you pass in a
@@ -298,70 +298,70 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
 .. attribute:: Engine:VACUUMISP
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     Vacuum `specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_
 
 .. attribute:: Engine:VISP
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     Synonym for :VACUUMISP
 
 .. attribute:: Engine:SEALEVELISP
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_ at Kerbin sealevel.
 
 .. attribute:: Engine:SLISP
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     Synonym for :SEALEVELISP
 
 .. attribute:: Engine:FLAMEOUT
 
     :access: Get only
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
 
     Is this engine failed because it is starved of a resource (liquidfuel, oxidizer, oxygen)?
 
 .. attribute:: Engine:IGNITION
 
     :access: Get only
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
 
     Has this engine been ignited? If both :attr:`Engine:IGNITION` and :attr:`Engine:FLAMEOUT` are true, that means the engine could start up again immediately if more resources were made available to it.
 
 .. attribute:: Engine:ALLOWRESTART
 
     :access: Get only
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
 
     Is this an engine that can be started again? Usually True, but false for solid boosters.
 
 .. attribute:: Engine:ALLOWSHUTDOWN
 
     :access: Get only
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
 
     Is this an engine that can be shut off once started? Usually True, but false for solid boosters.
 
 .. attribute:: Engine:THROTTLELOCK
 
     :access: Get only
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
 
     Is this an engine that is stuck at a fixed throttle? (i.e. solid boosters)
 
 .. attribute:: Engine:MULTIMODE
 
     :access: Get only
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
 
     Does this engine have multiple modes (i.e. RAPIER)? Check this before calling multi-mode specific suffixes.   
     
@@ -375,7 +375,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
 .. attribute:: Engine:MODE
 
     :access: Get only
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
 
     Name of the current mode. Only assessible for multi-mode engines.
 
@@ -386,21 +386,21 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
 .. attribute:: Engine:PRIMARYMODE
 
     :access: Get/Set
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
 
     True for primary mode, false for secondary. Setting to other value equals toggling the mode. Only assessible for multi-mode engines. 
 
 .. attribute:: Engine:AUTOSWITCH
 
     :access: Get/Set
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
 
     Is automatic switching enabled? Can set to switch between manual and automatic switching. Only assessible for multi-mode engines. 
 
 .. attribute:: Engine:HASGIMBAL
 
     :access: Get only
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
 
     Does this engine have a gimbal enabled?
 
@@ -414,7 +414,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
 .. attribute:: Engine:ULLAGE
 
     :access: Get only
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
     
     If RealFuels is installed, returns true if this engine is a type of engine that requires ullage, otherwise returns false.
     Note: this is a static property of the engine, for current fuel status, check `FUELSTABILITY`.
@@ -422,7 +422,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
 .. attribute:: Engine:FUELSTABILITY
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     
     If RealFuels is installed, returns the fuel stability of this engine as a value between 0 and 1 (where 1 is fullly stable), otherwise returns 1.
     Engines that don't require ullage will always return 1, unless they are pressure fed and the feed pressure is too low.
@@ -430,21 +430,21 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
 .. attribute:: Engine:PRESSUREFED
 
     :access: Get only
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
     
     If RealFuels is installed, returns true if this engine is pressure fed, otherwise returns false.
 
 .. attribute:: Engine:IGNITIONS
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     
     If RealFuels is installed, returns the number of ignitions remaining, or -1 if it is unlimited, otherwise returns -1.
 
 .. attribute:: Engine:MINTHROTTLE
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     
     If RealFuels is installed, returns the minimum throttle setting as a value between 0 and 1, otherwise returns 0.
 

--- a/doc/source/structures/vessels/engine.rst
+++ b/doc/source/structures/vessels/engine.rst
@@ -202,6 +202,8 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
     (Pressure must be greater than or equal to zero.  If you pass in a
     negative value, it will be treated as if you had given a zero instead.)
 
+.. _engine_THRUST:
+
 .. attribute:: Engine:THRUST
 
     :access: Get only

--- a/doc/source/structures/vessels/kosprocessor.rst
+++ b/doc/source/structures/vessels/kosprocessor.rst
@@ -20,7 +20,7 @@ The type of structures returned by kOS when querying a module that contains a kO
           -
           - :struct:`kOSProcessor` objects are a type of :struct:`PartModule`
         * - :attr:`MODE`
-          - `:ref:`string <string>``
+          - :struct:`String`
           - `OFF`, `READY` or `STARVED`
         * - :meth:`ACTIVATE`
           - None
@@ -29,16 +29,16 @@ The type of structures returned by kOS when querying a module that contains a kO
           - None
           - Deactivates this processor
         * - :attr:`TAG`
-          - `:ref:`string <string>``
+          - :struct:`String`
           - This processor's name tag
         * - :attr:`VOLUME`
           - :struct:`Volume`
           - This processor's hard disk
         * - :attr:`BOOTFILENAME`
-          - `:ref:`string <string>``
+          - :struct:`String`
           - The filename for the boot file on this processor
         * - :attr:`CONNECTION`
-          - `:struct:`Connection`
+          - :struct:`Connection`
           - Returns your connection to this processor
 
 .. note::
@@ -48,7 +48,7 @@ The type of structures returned by kOS when querying a module that contains a kO
 .. attribute:: kOSProcessor:MODE
 
     :access: Get only
-    :type: `:ref:`string <string>``
+    :type: :struct:`String`
 
     Indicates the current state of this processor. `OFF` - deactivated, `READY` - active, or `STARVED` - no power.
 
@@ -67,7 +67,7 @@ The type of structures returned by kOS when querying a module that contains a kO
 .. attribute:: kOSProcessor:TAG
 
     :access: Get only
-    :type: `:ref:`string <string>``
+    :type: :struct:`String`
 
     This processor's name tag
 
@@ -81,7 +81,7 @@ The type of structures returned by kOS when querying a module that contains a kO
 .. attribute:: kOSProcessor:BOOTFILENAME
 
     :access: Get or Set
-    :type: `:ref:`string <string>``
+    :type: :struct:`String`
 
     The filename for the boot file on this processor. This may be set to an empty :ref:`string <string>` “” or to “None” to disable the use of a boot file.
 
@@ -90,4 +90,3 @@ The type of structures returned by kOS when querying a module that contains a kO
     :return: :struct:`Connection`
 
     Returns your connection to this processor.
-

--- a/doc/source/structures/vessels/node.rst
+++ b/doc/source/structures/vessels/node.rst
@@ -36,7 +36,7 @@ Creation
 
 .. function:: NODE(time, radial, normal, prograde)
 
-    :parameter time: :ref:`TimeSpan` (ETA), :ref:`TimeStamp` (UT), or :ref:`Scalar` (UT)
+    :parameter time: :struct:`TimeSpan` (ETA), :struct:`TimeStamp` (UT), or :struct:`Scalar` (UT)
     :parameter radial: (m/s) Delta-V in radial-out direction
     :parameter normal: (m/s) Delta-V normal to orbital plane
     :parameter prograde: (m/s) Delta-V in prograde direction
@@ -195,23 +195,23 @@ Structure
           - Get only
           - Alias for :attr:`DELTAV`
         * - :attr:`ETA`
-          - :ref:`scalar <scalar>` (s)
+          - :struct:`Scalar` (s)
           - Get/Set
           - Time until this maneuver
         * - :attr:`TIME`
-          - :ref:`scalar <scalar>` (s)
+          - :struct:`Scalar` (s)
           - Get/Set
           - Universal Time of this maneuver
         * - :attr:`PROGRADE`
-          - :ref:`scalar <scalar>` (m/s)
+          - :struct:`Scalar` (m/s)
           - Get/Set
           - Delta-V along prograde
         * - :attr:`RADIALOUT`
-          - :ref:`scalar <scalar>` (m/s)
+          - :struct:`Scalar` (m/s)
           - Get/Set
           - Delta-V along radial to orbited :struct:`Body`
         * - :attr:`NORMAL`
-          - :ref:`scalar <scalar>` (m/s)
+          - :struct:`Scalar` (m/s)
           - Get/Set
           - Delta-V along normal to the :struct:`Vessel`'s :struct:`Orbit`
         * - :attr:`ORBIT`
@@ -234,14 +234,14 @@ Structure
 .. attribute:: ManeuverNode:ETA
 
     :access: Get/Set
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     The number of seconds until the expected burn time. If you SET this, it will actually move the maneuver node along the path in the map view, identically to grabbing the maneuver node and dragging it.
 
 .. attribute:: ManeuverNode:TIME
 
     :access: Get/Set
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     The time of the node in universal time, rather than ETA relative to the current
     time.  This should be the same as adding :attr:`ManeuverNode:ETA` to ``TIME:SECONDS``.
@@ -249,21 +249,21 @@ Structure
 .. attribute:: ManeuverNode:PROGRADE
 
     :access: Get/Set
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     The delta V in (meters/s) along just the prograde direction (the yellow and green 'knobs' of the maneuver node). A positive value is a prograde burn and a negative value is a retrograde burn.
 
 .. attribute:: ManeuverNode:RADIALOUT
 
     :access: Get/Set
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     The delta V in (meters/s) along just the radial direction (the cyan knobs' of the maneuver node). A positive value is a radial out burn and a negative value is a radial in burn.
 
 .. attribute:: ManeuverNode:NORMAL
 
     :access: Get/Set
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     The delta V in (meters/s) along just the normal direction (the purple knobs' of the maneuver node). A positive value is a normal burn and a negative value is an anti-normal burn.
 

--- a/doc/source/structures/vessels/part.rst
+++ b/doc/source/structures/vessels/part.rst
@@ -510,9 +510,9 @@ These are the generic properties every PART has. You can obtain a list of values
           }
         }
 
-.. method:: Parts:PARTSNAMED(name)
+.. method:: Part:PARTSNAMED(name)
 
-    :parameter name: (:ref:`string <string>`) Name of the parts
+    :parameter name: (:struct:`String`) Name of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
     Same as :meth:`Vessel:PARTSNAMED(name)` except that this version
@@ -522,7 +522,7 @@ These are the generic properties every PART has. You can obtain a list of values
 
 .. method:: Part:PARTSNAMEDPATTERN(namePattern)
 
-    :parameter namePattern: (:ref:`string <string>`) Pattern of the name of the parts
+    :parameter namePattern: (:struct:`String`) Pattern of the name of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
     Same as :meth:`Vessel:PARTSNAMEDPATTERN(namePattern)` except that this version
@@ -532,7 +532,7 @@ These are the generic properties every PART has. You can obtain a list of values
 
 .. method:: Part:PARTSTITLED(title)
 
-    :parameter title: (:ref:`string <string>`) Title of the parts
+    :parameter title: (:struct:`String`) Title of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
     Same as :meth:`Vessel:PARTSTITLED(title)` except that this version
@@ -542,7 +542,7 @@ These are the generic properties every PART has. You can obtain a list of values
 
 .. method:: Part:PARTSTITLEDPATTERN(titlePattern)
 
-    :parameter titlePattern: (:ref:`string <string>`) Patern of the title of the parts
+    :parameter titlePattern: (:struct:`String`) Patern of the title of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
     Same as :meth:`Vessel:PARTSTITLEDPATTERN(titlePattern)` except that this version
@@ -552,7 +552,7 @@ These are the generic properties every PART has. You can obtain a list of values
 
 .. method:: Part:PARTSTAGGED(tag)
 
-    :parameter tag: (:ref:`string <string>`) Tag of the parts
+    :parameter tag: (:struct:`String`) Tag of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
     Same as :meth:`Vessel:PARTSTAGGED(tag)` except that this version
@@ -562,7 +562,7 @@ These are the generic properties every PART has. You can obtain a list of values
 
 .. method:: Part:PARTSTAGGEDPATTERN(tagPattern)
 
-    :parameter tagPattern: (:ref:`string <string>`) Pattern of the tag of the parts
+    :parameter tagPattern: (:struct:`String`) Pattern of the tag of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
     Same as :meth:`Vessel:PARTSTAGGEDPATTERN(tagPattern)` except that this version
@@ -572,7 +572,7 @@ These are the generic properties every PART has. You can obtain a list of values
 
 .. method:: Part:PARTSDUBBED(name)
 
-    :parameter name: (:ref:`string <string>`) name, title or tag of the parts
+    :parameter name: (:struct:`String`) name, title or tag of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
     Same as :meth:`Vessel:PARTSDUBBED(name)` except that this version
@@ -582,7 +582,7 @@ These are the generic properties every PART has. You can obtain a list of values
 
 .. method:: Part:PARTSDUBBEDPATTERN(namePattern)
 
-    :parameter namePattern: (:ref:`string <string>`) Pattern of the name, title or tag of the parts
+    :parameter namePattern: (:struct:`String`) Pattern of the name, title or tag of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
     Same as :meth:`Vessel:PARTSDUBBEDPATERN(namePattern)` except that this version
@@ -592,7 +592,7 @@ These are the generic properties every PART has. You can obtain a list of values
 
 .. method:: Part:MODULESNAMED(name)
 
-    :parameter name: (:ref:`string <string>`) Name of the part modules
+    :parameter name: (:struct:`String`) Name of the part modules
     :return: :struct:`List` of :struct:`PartModule` objects
 
     Same as :meth:`Vessel:MODULESNAMED(name)` except that this version
@@ -608,4 +608,3 @@ These are the generic properties every PART has. You can obtain a list of values
     doesn't search the entire vessel tree and instead it only searches the
     branch of the vessel's part tree from the current part down through
     its children and its children's children and so on.
-

--- a/doc/source/structures/vessels/partmodule.rst
+++ b/doc/source/structures/vessels/partmodule.rst
@@ -57,13 +57,13 @@ Once you have a :struct:`PartModule`, you can use it to invoke the behaviors tha
           -
           - Activate action by name with True or False
         * - :meth:`HASFIELD(name)`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Check if field exists
         * - :meth:`HASEVENT(name)`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Check if event exists
         * - :meth:`HASACTION(name)`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Check if action exists
 
 
@@ -127,14 +127,14 @@ Once you have a :struct:`PartModule`, you can use it to invoke the behaviors tha
      
 .. method:: PartModule:GETFIELD(name)
 
-    :parameter name: (string) Name of the field
+    :parameter name: (:struct:`String`) Name of the field
     :return: varies
 
     Get the value of one of the fields that this PartModule has placed onto the rightclick menu for the part. Note the Security comments below.
 
 .. method:: PartModule:SETFIELD(name,value)
 
-    :parameter name: (string) Name of the field
+    :parameter name: (:struct:`String`) Name of the field
 
     Set the value of one of the fields that this PartModule has placed onto the rightclick menu for the part. Note the Security comments below.
 
@@ -155,7 +155,7 @@ Once you have a :struct:`PartModule`, you can use it to invoke the behaviors tha
 
 .. method:: PartModule:DOEVENT(name)
 
-    :parameter name: (string) Name of the event
+    :parameter name: (:struct:`String`) Name of the event
 
     Trigger an "event button" that is on the rightclick part menu at the moment. Note the Security comments below.
 
@@ -163,31 +163,31 @@ Once you have a :struct:`PartModule`, you can use it to invoke the behaviors tha
 
 .. method:: PartModule:DOACTION(name,bool)
 
-    :parameter name: (string) Name of the action
-    :parameter bool: (:ref:`Boolean <boolean>`) Value to set: True or False
+    :parameter name: (:struct:`String`) Name of the action
+    :parameter bool: (:struct:`Boolean`) Value to set: True or False
 
-    Activate one of this PartModule's action-group-able actions, bypassing the action group system entirely by just activating it for this one part directly. The :ref:`Boolean <boolean>` value decides whether you are toggling the action ON or toggling it OFF. Note the Security comments below.
+    Activate one of this PartModule's action-group-able actions, bypassing the action group system entirely by just activating it for this one part directly. The :struct:`Boolean` value decides whether you are toggling the action ON or toggling it OFF. Note the Security comments below.
 
     WARNING: This suffix is only callable for parts attached to the :ref:`CPU Vessel <cpu vessel>`
 
 .. method:: PartModule:HASFIELD(name)
 
-    :parameter name: (string) Name of the field
-    :return: :ref:`Boolean <boolean>`
+    :parameter name: (:struct:`String`) Name of the field
+    :return: :struct:`Boolean`
 
     Return true if the given field name is currently available for use with :GETFIELD or :SETFIELD on this PartModule, false otherwise.
 
 .. method:: PartModule:HASEVENT(name)
 
-    :parameter name: (string) Name of the event
-    :return: :ref:`Boolean <boolean>`
+    :parameter name: (:struct:`String`) Name of the event
+    :return: :struct:`Boolean`
 
     Return true if the given event name is currently available for use with :DOEVENT on this PartModule, false otherwise.
 
 .. method:: PartModule:HASACTION(name)
 
-    :parameter name: (string) Name of the action
-    :return: :ref:`Boolean <boolean>`
+    :parameter name: (:struct:`String`) Name of the action
+    :return: :struct:`Boolean`
 
     Return true if the given action name is currently available for use with :DOACTION on this PartModule, false otherwise.
 

--- a/doc/source/structures/vessels/rcs.rst
+++ b/doc/source/structures/vessels/rcs.rst
@@ -53,49 +53,49 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type R
           -
           - Does this thruster always apply full thrust.
         * - :attr:`THRUSTLIMIT`
-          - :ref:`scalar <scalar>` (%)
+          - :struct:`Scalar` (%)
           - Tweaked thrust limit.
         * - :attr:`DEADBAND`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - The game's built-in RCS input null zone for this RCS thruster.
         * - :attr:`MAXTHRUST`
-          - :ref:`scalar <scalar>` (kN)
+          - :struct:`Scalar` (kN)
           - Untweaked thrust limit.
         * - :meth:`MAXTHRUSTAT(pressure)`
-          - :ref:`scalar <scalar>` (kN)
+          - :struct:`Scalar` (kN)
           - Max thrust at the specified pressure (in standard Kerbin atmospheres).
         * - :attr:`AVAILABLETHRUST`
-          - :ref:`scalar <scalar>` (kN)
+          - :struct:`Scalar` (kN)
           - Available thrust at full throttle accounting for thrust limiter.
         * - :meth:`AVAILABLETHRUSTAT(pressure)`
-          - :ref:`scalar <scalar>` (kN)
+          - :struct:`Scalar` (kN)
           - Available thrust at the specified pressure (in standard Kerbin atmospheres).
         * - :attr:`MAXFUELFLOW`
-          - :ref:`scalar <scalar>` (unit/s)
+          - :struct:`Scalar` (unit/s)
           - Untweaked maximum volumetric flow rate of fuel at full throttle.
         * - :attr:`MAXMASSFLOW`
-          - :ref:`scalar <scalar>` (Mg/s)
+          - :struct:`Scalar` (Mg/s)
           - Untweaked maximum mass flow rate of fuel at full throttle.
         * - :attr:`ISP`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_
         * - :meth:`ISPAT(pressure)`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_ at the given pressure (in standard Kerbin atmospheres).
         * - :attr:`VACUUMISP`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Vacuum `specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_
         * - :attr:`VISP`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Synonym for VACUUMISP
         * - :attr:`SEALEVELISP`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_ at Kerbin sealevel
         * - :attr:`SLISP`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Synonym for SEALEVELISP
         * - :attr:`FLAMEOUT`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Check if no more fuel.
         * - :attr:`THRUSTVECTORS`
           - :struct:`List`
@@ -112,70 +112,70 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type R
 .. attribute:: RCS:ENABLED
 
     :access: Get/Set
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
     
     Is this rcs thruster enabled.
     
 .. attribute:: RCS:YAWENABLED
 
     :access: Get/Set
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
         
     Is yaw control enabled for this rcs thruster.
     
 .. attribute:: RCS:PITCHENABLED
 
     :access: Get/Set
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
         
     Is pitch control enabled for this rcs thruster.
     
 .. attribute:: RCS:ROLLENABLED
 
     :access: Get/Set
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
         
     Is roll control enabled for this rcs thruster.
     
 .. attribute:: RCS:FOREENABLED
 
     :access: Get/Set
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
         
     Is fore/aft control enabled for this rcs thruster.
     
 .. attribute:: RCS:STARBOARDENABLED
 
     :access: Get/Set
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
         
     Is port/starboard control enabled for this rcs thruster.
     
 .. attribute:: RCS:TOPENABLED
 
     :access: Get/Set
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
         
     Is dorsal/ventral control enabled for this rcs thruster.
     
 .. attribute:: RCS:FOREBYTHROTTLE
 
     :access: Get/Set
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
         
     Does this thruster apply fore thrust when the ship throttled up.
     
 .. attribute:: RCS:FULLTHRUST
 
     :access: Get/Set
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
         
     Does this thruster always apply full thrust.
     
 .. attribute:: RCS:THRUSTLIMIT
 
     :access: Get/Set
-    :type: :ref:`scalar <scalar>` (%)
+    :type: :struct:`Scalar` (%)
 
     If this is a thruster with a thrust limiter (tweakable) enabled, what
     percentage is it limited to?  Note that this is expressed as a
@@ -198,7 +198,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type R
 .. attribute:: RCS:DEADBAND
 
     :access: Get/Set (but Note the Warning on SET below)
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     Default: 0.05.
 
@@ -265,7 +265,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type R
 .. attribute:: RCS:MAXTHRUST
 
     :access: Get only
-    :type: :ref:`scalar <scalar>` (kN)
+    :type: :struct:`Scalar` (kN)
 
     How much thrust would this rcs thruster give at its current atmospheric pressure if one of the control axes that activates it (yaw, pitch, roll, fore, aft, or top) was maxxed, and the thrust limiter was max at 100%.  Note this might not be the thruster's actual max thrust it could have under other air pressure conditions.  Some thrusters have a very different value for MAXTHRUST in vacuum as opposed to at sea level pressure.
 
@@ -274,7 +274,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type R
 .. method:: RCS:MAXTHRUSTAT(pressure)
 
     :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
-    :type: :ref:`scalar <scalar>` (kN)
+    :type: :struct:`Scalar` (kN)
 
     How much thrust would this rcs thruster give if one of the control axes that activated it (yaw, pitch, roll, fore, aft, or top) was maxxed and thrust limiter was max at the given atmospheric pressure.  Use a pressure of 0.0 for vacuum, and 1.0 for sea level (on Kerbin) (or more than 1 for thicker atmospheres like on Eve).
     (Pressure must be greater than or equal to zero.  If you pass in a
@@ -283,7 +283,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type R
 .. attribute:: RCS:THRUST
 
     :access: Get only
-    :type: :ref:`scalar <scalar>` (kN)
+    :type: :struct:`Scalar` (kN)
 
     How much thrust is this rcs thruster is giving at this very moment.
 
@@ -292,7 +292,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type R
 .. attribute:: RCS:AVAILABLETHRUST
 
     :access: Get only
-    :type: :ref:`scalar <scalar>` (kN)
+    :type: :struct:`Scalar` (kN)
 
     Taking into account the thrust limiter tweakable setting, how much thrust would this rcs thruster give at its current thrust limit setting and atmospheric pressure conditions, if one of the control axes that activated it (yaw, pitch, roll, fore, aft, or top) was maxxed .
 
@@ -301,7 +301,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type R
 .. method:: RCS:AVAILABLETHRUSTAT(pressure)
 
     :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
-    :type: :ref:`scalar <scalar>` (kN)
+    :type: :struct:`Scalar` (kN)
 
     Taking into account the thrust limiter tweakable setting, how much thrust at the given atmospheric pressure would this rcs thruster give at its current thrust limit setting if one of the control axes that activated it (yaw, pitch, roll, fore, aft, or top) was maxxed.   The pressure is measured in ATMs, meaning 0.0 is a vacuum, 1.0 is sea level at Kerbin.
     (Pressure must be greater than or equal to zero.  If you pass in a
@@ -310,28 +310,28 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type R
 .. attribute:: RCS:MAXFUELFLOW
 
     :access: Get only
-    :type: :ref:`scalar <scalar>` (units/s)
+    :type: :struct:`Scalar` (units/s)
 
     How much fuel volume would this rcs thruster consume at standard pressure and velocity if one of the control axes that activated it (yaw, pitch, roll, fore, aft, or top) was maxxed, and the thrust limiter was max at 100%.  Note this might not be the engine's actual max fuel flow it could have under other air pressure conditions.
 
 .. attribute:: RCS:MAXMASSFLOW
 
     :access: Get only
-    :type: :ref:`scalar <scalar>` (Mg/s)
+    :type: :struct:`Scalar` (Mg/s)
 
     How much fuel mass would this rcs thruster consume at standard pressure and velocity if one of the control axes that activated it (yaw, pitch, roll, fore, aft, or top) was maxxed, and the thrust limiter was max at 100%.  Note this might not be the engine's actual max fuel flow it could have under other air pressure conditions.
 
 .. attribute:: RCS:ISP
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_
 
 .. method:: RCS:ISPAT(pressure)
 
     :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_ at the given atmospheric pressure.  Use a pressure of 0 for vacuum, and 1 for sea level (on Kerbin).
     (Pressure must be greater than or equal to zero.  If you pass in a
@@ -340,35 +340,35 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type R
 .. attribute:: RCS:VACUUMISP
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     Vacuum `specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_
 
 .. attribute:: RCS:VISP
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     Synonym for :VACUUMISP
 
 .. attribute:: RCS:SEALEVELISP
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_ at Kerbin sealevel.
 
 .. attribute:: RCS:SLISP
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     Synonym for :SEALEVELISP
 
 .. attribute:: RCS:FLAMEOUT
 
     :access: Get only
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
 
     Is this rcs thruster failed because it is starved of a resource (monopropellant)?
 
@@ -385,4 +385,3 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type R
     :type: :struct:`Lexicon` of :struct:`CONSUMEDRESOURCERCS`
 
     This gives a lexicon of all the resources this rcs thruster consumes, keyed by resource name.
-

--- a/doc/source/structures/vessels/resource.rst
+++ b/doc/source/structures/vessels/resource.rst
@@ -16,43 +16,43 @@ A single resource value a thing holds (i.e. fuel, electric charge, etc). This is
           - Description
 
         * - :attr:`NAME`
-          - :ref:`string <string>`
+          - :struct:`String`
           - Resource name
         * - :attr:`AMOUNT`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Amount of this resource left
         * - :attr:`DENSITY`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Density of this resource
         * - :attr:`CAPACITY`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Maximum amount of this resource
         * - :attr:`TOGGLEABLE`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Can this tank be removed from the fuel flow
         * - :attr:`ENABLED`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Is this tank currently in the fuel flow
         
 		
 .. attribute:: Resource:NAME
 
     :access: Get only
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
 
     The name of the resource, i.e. "LIQUIDFUEL", "ELECTRICCHARGE", "MONOPROP".
 
 .. attribute:: Resource:AMOUNT
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     The value of how much resource is left.
 
 .. attribute:: Resource:DENSITY
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     The density value of this resource, expressed in Megagrams f mass
     per Unit of resource.  (i.e. a value of 0.005 would mean that each
@@ -62,7 +62,7 @@ A single resource value a thing holds (i.e. fuel, electric charge, etc). This is
 .. attribute:: Resource:CAPACITY
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     What AMOUNT would be if the resource was filled to the top.
 
@@ -70,13 +70,13 @@ A single resource value a thing holds (i.e. fuel, electric charge, etc). This is
 .. attribute:: Resource:TOGGLEABLE
 
     :access: Get only
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
 
     Many, but not all, resources can be turned on and off, this removes them from the fuel flow. 
 
 .. attribute:: Resource:ENABLED
 
     :access: Get/Set
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
 
     If the resource is TOGGLEABLE, setting this to false will prevent the resource from being taken out normally.

--- a/doc/source/structures/vessels/sciencedatavalue.rst
+++ b/doc/source/structures/vessels/sciencedatavalue.rst
@@ -16,42 +16,42 @@ Represents results of a :struct:`science experiment <ScienceExperimentModule>`.
           - Description
 
         * - :attr:`TITLE`
-          - string
+          - :struct:`String`
           - Experiment title
         * - :attr:`SCIENCEVALUE`
-          - scalar
+          - :struct:`Scalar`
           - Amount of science that would be gained by returning this data to KSC
         * - :attr:`TRANSMITVALUE`
-          - scalar
+          - :struct:`Scalar`
           - Amount of science that would be gained by transmitting this data to KSC
         * - :attr:`DATAAMOUNT`
-          - scalar
+          - :struct:`Scalar`
           - Amount of data
 
 .. attribute:: ScienceData:TITLE
 
     :access: Get only
-    :type: string
+    :type: :struct:`String`
 
     Experiment title
 
 .. attribute:: ScienceData:SCIENCEVALUE
 
     :access: Get only
-    :type: scalar
+    :type: :struct:`Scalar`
 
     Amount of science that would be gained by returning this data to KSC
 
 .. attribute:: ScienceData:TRANSMITVALUE
 
     :access: Get only
-    :type: scalar
+    :type: :struct:`Scalar`
 
     Amount of science that would be gained by transmitting this data to KSC
 
 .. attribute:: ScienceData:DATAAMOUNT
 
     :access: Get only
-    :type: scalar
+    :type: :struct:`Scalar`
 
     Amount of data

--- a/doc/source/structures/vessels/scienceexperiment.rst
+++ b/doc/source/structures/vessels/scienceexperiment.rst
@@ -59,16 +59,16 @@ properly.
           -
           - Discard the data
         * - :attr:`INOPERABLE`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Is this experiment inoperable
         * - :attr:`RERUNNABLE`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Can this experiment be run multiple times
         * - :attr:`DEPLOYED`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Is this experiment deployed
         * - :attr:`HASDATA`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Does the experiment have scientific data
         * - :attr:`DATA`
           - :struct:`List` of :struct:`ScienceData`
@@ -99,28 +99,28 @@ properly.
 .. attribute:: ScienceExperimentModule:INOPERABLE
 
     :access: Get only
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
 
     True if this experiment is no longer operable.
 
 .. attribute:: ScienceExperimentModule:RERUNNABLE
 
     :access: Get only
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
 
     True if this experiment can be run multiple times.
 
 .. attribute:: ScienceExperimentModule:DEPLOYED
 
     :access: Get only
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
 
     True if this experiment is deployed.
 
 .. attribute:: ScienceExperimentModule:HASDATA
 
     :access: Get only
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
 
     True if this experiment has scientific data stored.
 

--- a/doc/source/structures/vessels/sensor.rst
+++ b/doc/source/structures/vessels/sensor.rst
@@ -34,16 +34,16 @@ The type of structures returned by :ref:`LIST SENSORS IN SOMEVARIABLE <list comm
           -
           - :struct:`Sensor` objects are a type of :struct:`Part`
         * - :attr:`ACTIVE`
-          - :ref:`Boolean <boolean>`
+          - :struct:`Boolean`
           - Check if this sensor is active
         * - :attr:`TYPE`
           -
           -
         * - :attr:`DISPLAY`
-          - string
+          - :struct:`String`
           - Value of the readout
         * - :attr:`POWERCONSUMPTION`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Rate of required electric charge
         * - :meth:`TOGGLE()`
           -
@@ -56,7 +56,7 @@ The type of structures returned by :ref:`LIST SENSORS IN SOMEVARIABLE <list comm
 .. attribute:: Sensor:ACTIVE
 
     :access: Get only
-    :type: :ref:`Boolean <boolean>`
+    :type: :struct:`Boolean`
 
     True of the sensor is enabled. Can SET to cause the sensor to activate or de-activate.
 
@@ -67,19 +67,17 @@ The type of structures returned by :ref:`LIST SENSORS IN SOMEVARIABLE <list comm
 .. attribute:: Sensor:DISPLAY
 
     :access: Get only
-    :type: string
+    :type: :struct:`String`
 
     The value of the sensor's readout, usualy including the units.
 
 .. attribute:: Sensor:POWERCONSUMPTION
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     The rate at which this sensor drains ElectricCharge.
 
 .. method:: Sensor:TOGGLE()
 
     Call this method to cause the sensor to switch between active and deactivated or visa versa.
-
-

--- a/doc/source/structures/vessels/separator.rst
+++ b/doc/source/structures/vessels/separator.rst
@@ -1,4 +1,4 @@
-.. _separator
+.. _separator:
 
 Separator
 =========

--- a/doc/source/structures/vessels/vessel.rst
+++ b/doc/source/structures/vessels/vessel.rst
@@ -27,31 +27,31 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
                    Every suffix of :struct:`Orbitable`
     --------------------------------------------------------------------------------------
     :attr:`CONTROL`                          :struct:`Control`               Raw flight controls
-    :attr:`BEARING`                          :struct:`scalar` (deg)          relative heading to this vessel
-    :attr:`HEADING`                          :struct:`scalar` (deg)          Absolute heading to this vessel
-    :attr:`THRUST`                           :struct:`scalar`                Sum of active thrusts
-    :attr:`MAXTHRUST`                        :struct:`scalar`                Sum of active maximum thrusts
-    :meth:`MAXTHRUSTAT(pressure)`            :struct:`scalar`                Sum of active maximum thrusts at the given atmospheric pressure
-    :attr:`AVAILABLETHRUST`                  :struct:`scalar`                Sum of active limited maximum thrusts
-    :meth:`AVAILABLETHRUSTAT(pressure)`      :struct:`scalar`                Sum of active limited maximum thrusts at the given atmospheric pressure
+    :attr:`BEARING`                          :struct:`Scalar` (deg)          relative heading to this vessel
+    :attr:`HEADING`                          :struct:`Scalar` (deg)          Absolute heading to this vessel
+    :attr:`THRUST`                           :struct:`Scalar`                Sum of active thrusts
+    :attr:`MAXTHRUST`                        :struct:`Scalar`                Sum of active maximum thrusts
+    :meth:`MAXTHRUSTAT(pressure)`            :struct:`Scalar`                Sum of active maximum thrusts at the given atmospheric pressure
+    :attr:`AVAILABLETHRUST`                  :struct:`Scalar`                Sum of active limited maximum thrusts
+    :meth:`AVAILABLETHRUSTAT(pressure)`      :struct:`Scalar`                Sum of active limited maximum thrusts at the given atmospheric pressure
     :attr:`FACING`                           :struct:`Direction`             The way the vessel is pointed
     :attr:`BOUNDS`                           :struct:`Bounds`                Construct bounding box information about the vessel
-    :attr:`MASS`                             :struct:`scalar` (metric tons)  Mass of the ship
-    :attr:`WETMASS`                          :struct:`scalar` (metric tons)  Mass of the ship fully fuelled
-    :attr:`DRYMASS`                          :struct:`scalar` (metric tons)  Mass of the ship with no resources
-    :attr:`DYNAMICPRESSURE`                  :struct:`scalar` (ATM's)        Air Pressure surrounding the vessel
-    :attr:`Q`                                :struct:`scalar` (ATM's)        Alias name for DYNAMICPRESSURE
-    :attr:`VERTICALSPEED`                    :struct:`scalar` (m/s)          How fast the ship is moving "up"
-    :attr:`GROUNDSPEED`                      :struct:`scalar` (m/s)          How fast the ship is moving "horizontally"
-    :attr:`AIRSPEED`                         :struct:`scalar` (m/s)          How fast the ship is moving relative to the air
-    :attr:`TERMVELOCITY` (DEPRECATED)        :struct:`scalar` (m/s)          terminal velocity of the vessel
-    :attr:`SHIPNAME`                         :struct:`string`                The name of the vessel
-    :attr:`NAME`                             :struct:`string`                Synonym for SHIPNAME
-    :attr:`STATUS`                           :struct:`string`                Current ship status
+    :attr:`MASS`                             :struct:`Scalar` (metric tons)  Mass of the ship
+    :attr:`WETMASS`                          :struct:`Scalar` (metric tons)  Mass of the ship fully fuelled
+    :attr:`DRYMASS`                          :struct:`Scalar` (metric tons)  Mass of the ship with no resources
+    :attr:`DYNAMICPRESSURE`                  :struct:`Scalar` (ATM's)        Air Pressure surrounding the vessel
+    :attr:`Q`                                :struct:`Scalar` (ATM's)        Alias name for DYNAMICPRESSURE
+    :attr:`VERTICALSPEED`                    :struct:`Scalar` (m/s)          How fast the ship is moving "up"
+    :attr:`GROUNDSPEED`                      :struct:`Scalar` (m/s)          How fast the ship is moving "horizontally"
+    :attr:`AIRSPEED`                         :struct:`Scalar` (m/s)          How fast the ship is moving relative to the air
+    :attr:`TERMVELOCITY` (DEPRECATED)        :struct:`Scalar` (m/s)          terminal velocity of the vessel
+    :attr:`SHIPNAME`                         :struct:`String`                The name of the vessel
+    :attr:`NAME`                             :struct:`String`                Synonym for SHIPNAME
+    :attr:`STATUS`                           :struct:`String`                Current ship status
     :attr:`DELTAV`                           :struct:`DeltaV`                Summed Delta-V info about the ship
     :meth:`STAGEDELTAV(num)`                 :struct:`DeltaV`                One stage's Delta-V info
     :attr:`STAGENUM`                         :struct:`Scalar`                Which stage number is current
-    :attr:`TYPE`                             :struct:`string`                Ship type
+    :attr:`TYPE`                             :struct:`String`                Ship type
     :meth:`STARTTRACKING`                    None                            Start tracking the asteroid "vessel" via the tracking station
     :meth:`STOPTRACKING`                     None                            Stop tracking the asteroid "vessel" via the tracking station
     :attr:`SIZECLASS`                        :struct:`String`                Return the size class for an asteroid-like object
@@ -83,14 +83,14 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
     :meth:`PARTSINGROUP(group)`              :struct:`List`                  :struct:`Parts <Part>` by action group
     :meth:`MODULESINGROUP(group)`            :struct:`List`                  :struct:`PartModules <PartModule>` by action group
     :meth:`ALLTAGGEDPARTS()`                 :struct:`List`                  :struct:`Parts <Part>` that have non-blank nametags
-    :attr:`CREWCAPACITY`                     :struct:`scalar`                Crew capacity of this vessel
+    :attr:`CREWCAPACITY`                     :struct:`Scalar`                Crew capacity of this vessel
     :meth:`CREW()`                           :struct:`List`                  all :struct:`CrewMembers <CrewMember>`
     :attr:`CONNECTION`                       :struct:`Connection`            Returns your connection to this vessel
     :attr:`MESSAGES`                         :struct:`MessageQueue`          This vessel's message queue
-    :attr:`DELTAV`                           :struct:`scalar` (m/s)          The total delta-v of this vessel in its current situation
-    :attr:`DELTAVASL`                        :struct:`scalar` (m/s)          The total delta-v of this vessel if it were at sea level
-    :attr:`DELTAVVACUUM`                     :struct:`scalar` (m/s)          The total delta-v of this vessel if it were in a vacuum
-    :attr:`BURNTIME`                         :struct:`scalar` (s)            The total burn time of this vessel (or 5 if the vessel has 0 delta/v).
+    :attr:`DELTAV`                           :struct:`Scalar` (m/s)          The total delta-v of this vessel in its current situation
+    :attr:`DELTAVASL`                        :struct:`Scalar` (m/s)          The total delta-v of this vessel if it were at sea level
+    :attr:`DELTAVVACUUM`                     :struct:`Scalar` (m/s)          The total delta-v of this vessel if it were in a vacuum
+    :attr:`BURNTIME`                         :struct:`Scalar` (s)            The total burn time of this vessel (or 5 if the vessel has 0 delta/v).
     ======================================== =============================== =============
 
 .. note::
@@ -108,28 +108,28 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
 .. attribute:: Vessel:BEARING
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     *relative* compass heading (degrees) to this vessel from the :ref:`CPU Vessel <cpu vessel>`, taking into account the CPU Vessel's own heading.
 
 .. attribute:: Vessel:HEADING
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     *absolute* compass heading (degrees) to this vessel from the :ref:`CPU Vessel <cpu vessel>`
 
 .. attribute:: Vessel:THRUST
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     Sum of all the :ref:`engines' THRUSTs <engine_THRUST>` of all the currently active engines In Kilonewtons.
 
 .. attribute:: Vessel:MAXTHRUST
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     Sum of all the :ref:`engines' MAXTHRUSTs <engine_MAXTHRUST>` of all the currently active engines In Kilonewtons.
@@ -137,7 +137,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 .. method:: Vessel:MAXTHRUSTAT(pressure)
 
     :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
-    :type: :ref:`scalar <scalar>` (kN)
+    :type: :struct:`Scalar` (kN)
 
     Sum of all the :ref:`engines' MAXTHRUSTATs <engine_MAXTHRUSTAT>` of all the currently active engines In Kilonewtons at the given atmospheric pressure.  Use a pressure of 0 for vacuum, and 1 for sea level (on Kerbin).
     (Pressure must be greater than or equal to zero.  If you pass in a
@@ -145,7 +145,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
 .. attribute:: Vessel:AVAILABLETHRUST
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     Sum of all the :ref:`engines' AVAILABLETHRUSTs <engine_AVAILABLETHRUST>` of all the currently active engines taking into account their throttlelimits. Result is in Kilonewtons.
@@ -153,7 +153,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 .. method:: Vessel:AVAILABLETHRUSTAT(pressure)
 
     :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
-    :type: :ref:`scalar <scalar>` (kN)
+    :type: :struct:`Scalar` (kN)
 
     Sum of all the :ref:`engines' AVAILABLETHRUSTATs <engine_AVAILABLETHRUSTAT>` of all the currently active engines taking into account their throttlelimits at the given atmospheric pressure. Result is in Kilonewtons.  Use a pressure of 0 for vacuum, and 1 for sea level (on Kerbin).
     (Pressure must be greater than or equal to zero.  If you pass in a
@@ -203,28 +203,28 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
 .. attribute:: Vessel:MASS
 
-    :type: :ref:`scalar <scalar>` (metric tons)
+    :type: :struct:`Scalar` (metric tons)
     :access: Get only
 
     The mass of the ship
 
 .. attribute:: Vessel:WETMASS
 
-    :type: :ref:`scalar <scalar>` (metric tons)
+    :type: :struct:`Scalar` (metric tons)
     :access: Get only
 
     The mass of the ship if all resources were full
 
 .. attribute:: Vessel:DRYMASS
 
-    :type: :ref:`scalar <scalar>` (metric tons)
+    :type: :struct:`Scalar` (metric tons)
     :access: Get only
 
     The mass of the ship if all resources were empty
 
 .. attribute:: Vessel:DYNAMICPRESSURE
 
-    :type: :ref:`scalar <scalar>` (ATM's)
+    :type: :struct:`Scalar` (ATM's)
     :access: Get only
 
     Returns what the air pressure is in the atmosphere surrounding the vessel.
@@ -235,21 +235,21 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
 .. attribute:: Vessel:Q
 
-    :type: :ref:`scalar <scalar>` (ATM's)
+    :type: :struct:`Scalar` (ATM's)
     :access: Get only
 
     Alias for DYNAMICPRESSURE
 
 .. attribute:: Vessel:VERTICALSPEED
 
-    :type: :ref:`scalar <scalar>` (m/s)
+    :type: :struct:`Scalar` (m/s)
     :access: Get only
 
     How fast the ship is moving. in the "up" direction relative to the SOI Body's sea level surface.
 
 .. attribute:: Vessel:GROUNDSPEED
 
-    :type: :ref:`scalar <scalar>` (m/s)
+    :type: :struct:`Scalar` (m/s)
     :access: Get only
 
     How fast the ship is moving in the two dimensional plane horizontal
@@ -261,19 +261,19 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
        .. versionadded:: 0.18
            The old name for this value was SURFACESPEED.  The name was changed
            because it was confusing before.  "surface speed" implied it's the
-           :ref:`scalar <scalar>` magnitude of "surface velocity", but it wasn't, because of how
+           :struct:`Scalar` magnitude of "surface velocity", but it wasn't, because of how
            it ignores the vertical component.
 
 .. attribute:: Vessel:AIRSPEED
 
-    :type: :ref:`scalar <scalar>` (m/s)
+    :type: :struct:`Scalar` (m/s)
     :access: Get only
 
     How fast the ship is moving relative to the air. KSP models atmosphere as simply a solid block of air "glued" to the planet surface (the weather on Kerbin is boring and there's no wind). Therefore airspeed is generally the same thing as as the magnitude of the surface velocity.
 
 .. attribute:: Vessel:SHIPNAME
 
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
     :access: Get/Set
 
     The name of the vessel as it appears in the tracking station. When you set this, it cannot be empty.
@@ -284,7 +284,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
 .. attribute:: Vessel:STATUS
 
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
     :access: get only
 
     The current status of the vessel possible results are: `LANDED`, `SPLASHED`, `PRELAUNCH`, `FLYING`, `SUB_ORBITAL`, `ORBITING`, `ESCAPING` and `DOCKED`.
@@ -325,7 +325,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
 .. attribute:: Vessel:TYPE
 
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
     :access: Get/Set
 
     The ship's type as described `on the KSP wiki <http://wiki.kerbalspaceprogram.com/wiki/Craft#Vessel_types>`_.
@@ -537,7 +537,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
 .. method:: Vessel:PARTSNAMED(name)
 
-    :parameter name: (:ref:`string <string>`) Name of the parts
+    :parameter name: (:struct:`String`) Name of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
     Returns a list of all the parts that have this as their
@@ -545,7 +545,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
 .. method:: Vessel:PARTSNAMEDPATTERN(namePattern)
 
-    :parameter namePattern: (:ref:`string <string>`) Pattern of the name of the parts
+    :parameter namePattern: (:struct:`String`) Pattern of the name of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
     Returns a list of all the parts that have this Regex pattern in their
@@ -553,7 +553,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
 .. method:: Vessel:PARTSTITLED(title)
 
-    :parameter title: (:ref:`string <string>`) Title of the parts
+    :parameter title: (:struct:`String`) Title of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
     Returns a list of all the parts that have this as their
@@ -561,7 +561,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
 .. method:: Vessel:PARTSTITLEDPATTERN(titlePattern)
 
-    :parameter titlePattern: (:ref:`string <string>`) Patern of the title of the parts
+    :parameter titlePattern: (:struct:`String`) Patern of the title of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
     Returns a list of all the parts that have this Regex pattern in their
@@ -569,7 +569,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
 .. method:: Vessel:PARTSTAGGED(tag)
 
-    :parameter tag: (:ref:`string <string>`) Tag of the parts
+    :parameter tag: (:struct:`String`) Tag of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
     Returns a list of all the parts that have this name as their
@@ -577,7 +577,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
 .. method:: Vessel:PARTSTAGGEDPATTERN(tagPattern)
 
-    :parameter tagPattern: (:ref:`string <string>`) Pattern of the tag of the parts
+    :parameter tagPattern: (:struct:`String`) Pattern of the tag of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
     Returns a list of all the parts that match this Regex pattern in their
@@ -585,7 +585,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
 .. method:: Vessel:PARTSDUBBED(name)
 
-    :parameter name: (:ref:`string <string>`) name, title or tag of the parts
+    :parameter name: (:struct:`String`) name, title or tag of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
     Return a list of all the parts that match this
@@ -593,7 +593,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
 .. method:: Vessel:PARTSDUBBEDPATTERN(namePattern)
 
-    :parameter namePattern: (:ref:`string <string>`) Pattern of the name, title or tag of the parts
+    :parameter namePattern: (:struct:`String`) Pattern of the name, title or tag of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
     Return a list of parts that match this Regex pattern
@@ -601,7 +601,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
 .. method:: Vessel:MODULESNAMED(name)
 
-    :parameter name: (:ref:`string <string>`) Name of the part modules
+    :parameter name: (:struct:`String`) Name of the part modules
     :return: :struct:`List` of :struct:`PartModule` objects
 
     Return a list of all the :struct:`PartModule` objects that
@@ -630,7 +630,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
 .. attribute:: Vessel:CREWCAPACITY
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     crew capacity of this vessel
@@ -655,7 +655,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
 .. attribute:: Vessel:DELTAV
 
-    :return: :struct:`scalar`
+    :return: :struct:`Scalar`
 
     The total delta-v of this vessel in its current situation, using the stock
     calulations the KSP game shows in the staging list.  Note that this is only
@@ -663,7 +663,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
 .. attribute:: Vessel:DELTAVASL
 
-    :return: :struct:`scalar`
+    :return: :struct:`Scalar`
 
     The total delta-v of this vessel if it were at sea level, using the stock
     calulations the KSP game shows in the staging list.  Note that this is only
@@ -671,7 +671,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
 .. attribute:: Vessel:DELTAVVACUUM
 
-    :return: :struct:`scalar`
+    :return: :struct:`Scalar`
 
     The total delta-v of this vessel if it were at sea vacuum, using the stock
     calulations the KSP game shows in the staging list.  Note that this is only
@@ -679,7 +679,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
 .. attribute:: Vessel:BURNTIME
 
-    :return: :struct:`scalar`
+    :return: :struct:`Scalar`
 
     The total burn time, in seconds, of this vessel (or 5 if the vessel has 0 delta/v). Burn time is not affected by atmosphere.  This is using the stock
     calulations the KSP game shows in the staging list.  Note that this is only
@@ -691,7 +691,7 @@ Deprecated Suffix
 
 .. attribute:: Vessel:TERMVELOCITY
 
-    :type: :ref:`scalar <scalar>` (m/s)
+    :type: :struct:`Scalar` (m/s)
     :access: Get only
 
     (Deprecated with KSP 1.0 atmospheric model)

--- a/doc/source/structures/vessels/vesselsensors.rst
+++ b/doc/source/structures/vessels/vesselsensors.rst
@@ -22,16 +22,16 @@ If you store this in a variable and wait, the numbers are frozen in time and won
           - :struct:`Vector`
           - Acceleration experienced by the :struct:`Vessel`
         * - :attr:`PRES`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Atmospheric Pressure outside this :struct:`Vessel`
         * - :attr:`TEMP`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Temperature outside this :struct:`Vessel`
         * - :attr:`GRAV`
           - :struct:`Vector` (g's)
           - Gravitational acceleration
         * - :attr:`LIGHT`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - Sun exposure on the solar panels of this :struct:`Vessel`
 
 
@@ -45,14 +45,14 @@ If you store this in a variable and wait, the numbers are frozen in time and won
 .. attribute:: VesselSensors:PRES
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     The current pressure of this ship.
 
 .. attribute:: VesselSensors:TEMP
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     The current temperature.
 
@@ -66,7 +66,6 @@ If you store this in a variable and wait, the numbers are frozen in time and won
 .. attribute:: VesselSensors:LIGHT
 
     :access: Get only
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
 
     The total amount of sun exposure that exists here - only readable if there are solar panels on the vessel.
-

--- a/doc/source/structures/volumes_and_files/filecontent.rst
+++ b/doc/source/structures/volumes_and_files/filecontent.rst
@@ -31,10 +31,10 @@ Instances of this class can be iterated over. In each iteration step a single li
 
 
         * - :attr:`LENGTH`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
           - File length (in bytes)
         * - :attr:`EMPTY`
-          - :ref:`boolean <boolean>`
+          - :struct:`Boolean`
           - True if the file is empty
         * - :attr:`TYPE`
           - :struct:`String`
@@ -55,14 +55,14 @@ Instances of this class can be iterated over. In each iteration step a single li
 
 .. attribute:: FileContent:LENGTH
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     Length of the file.
 
 .. attribute:: FileContent:EMPTY
 
-    :type: :ref:`boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get only
 
     True if the file is empty

--- a/doc/source/structures/waypoint.rst
+++ b/doc/source/structures/waypoint.rst
@@ -11,7 +11,7 @@ Waypoints are the location markers you can see on the map view showing you where
 
 .. function:: WAYPOINT(name)
 
-    :parameter name: (:ref:`string <string>`) Name of the waypoint as it appears on the map or in the contract description
+    :parameter name: (:struct:`String`) Name of the waypoint as it appears on the map or in the contract description
     :return: :struct:`Waypoint`
 
     This creates a new Waypoint from a name of a waypoint you read from the contract paramters.  Note that this only works on contracts you've accpted.  Waypoints for proposed contracts haven't accepted yet  do not actually work in kOS.
@@ -36,7 +36,7 @@ Waypoints are the location markers you can see on the map view showing you where
           - Type
 
         * - :attr:`NAME`
-          - :ref:`string <string>`
+          - :struct:`String`
         * - :attr:`BODY`
           - `BodyTarget`
         * - :attr:`GEOPOSITION`
@@ -44,24 +44,24 @@ Waypoints are the location markers you can see on the map view showing you where
         * - :attr:`POSITION`
           - `Vector`
         * - :attr:`ALTITUDE`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
         * - :attr:`AGL`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
         * - :attr:`NEARSURFACE`
-          - :ref:`boolean <boolean>`
+          - :struct:`Boolean`
         * - :attr:`GROUNDED`
-          - :ref:`boolean <boolean>`
+          - :struct:`Boolean`
         * - :attr:`INDEX`
-          - :ref:`scalar <scalar>`
+          - :struct:`Scalar`
         * - :attr:`CLUSTERED`
-          - :ref:`boolean <boolean>`
+          - :struct:`Boolean`
         * - :attr:`ISSELECTED`
-          - :ref:`boolean <boolean>`
+          - :struct:`Boolean`
 
 
 .. attribute:: Waypoint:NAME
 
-    :type: :ref:`string <string>`
+    :type: :struct:`String`
     :access: Get only
 
     Name of waypoint as it appears on the map and contract
@@ -90,7 +90,7 @@ Waypoints are the location markers you can see on the map view showing you where
 
 .. attribute:: Waypoint:ALTITUDE
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     Altitude of waypoint **above "sea" level**.  Warning, this a point somewhere in the midst of the contract altitude range, not the edge of the altitude range.  It corresponds towhere the marker tip hovers on the map, which is not actually at the very edge of the contract condition's range.  It represents a typical midling location inside the contract's altitude range.
@@ -98,7 +98,7 @@ Waypoints are the location markers you can see on the map view showing you where
 
 .. attribute:: Waypoint:AGL
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     Altitude of waypoint **above ground**.  Warning, this a point somewhere in the midst of the contract altitude range, not the edge of the altitude range.  It corresponds to where the marker tip hovers on the map, which is not actually at the very edge of the contract condition's range.  It represents a typical midling location inside the contract's altitude range.
@@ -106,7 +106,7 @@ Waypoints are the location markers you can see on the map view showing you where
 
 .. attribute:: Waypoint:NEARSURFACE
 
-    :type: :ref:`boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get only
 
     True if waypoint is a point near or on the body rather than high in orbit.
@@ -114,29 +114,28 @@ Waypoints are the location markers you can see on the map view showing you where
 
 .. attribute:: Waypoint:GROUNDED
 
-    :type: :ref:`boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get only
 
     True if waypoint is actually glued to the ground.
 
 .. attribute:: Waypoint:INDEX
 
-    :type: :ref:`scalar <scalar>`
+    :type: :struct:`Scalar`
     :access: Get only
 
     The integer index of this waypoint amongst its cluster of sibling waypoints.  In other words, when you have a cluster of waypoints called "Somewhere Alpha", "Somewhere Beta", and "Somewhere Gamma", then the alpha site has index 0, the beta site has index 1 and the gamma site has index 2. When Waypoint:CLUSTERED is false, this value is zero but meaningless.
 
 .. attribute:: Waypoint:CLUSTERED
 
-    :type: :ref:`boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get only
 
     True if this waypoint is part of a set of clustered waypoints with greek letter names appended (Alpha, Beta, Gamma, etc).  If true, there should be a one-to-one correspondence with the greek letter name and the :INDEX suffix. (0 = Alpha, 1 = Beta, 2 = Gamma, etc).
 
 .. attribute:: Waypoint:ISSELECTED
 
-    :type: :ref:`boolean <boolean>`
+    :type: :struct:`Boolean`
     :access: Get only
 
     True if navigation has been activated on this waypoint.
-


### PR DESCRIPTION
Builds on top of #3069.

Removes some unused imports.

Fixes
1. using references rather than struct links
2. attributes linking to methods or vice versa
3. incorrect representation of units
4. some indentation issues

An issue I haven't been able to figure out is from https://github.com/scimas/KOS/blob/0485c8cdd7fbdf3b7d667737a544e8f7cb8056b4/doc/source/math/scalar.rst#L46-47, where the underscores are causing red boxes to appear over the numbers in the generated HTML.
![image](https://user-images.githubusercontent.com/16473290/194721170-7aa72be6-ca12-401c-ae69-e402b73c49e0.png)
