### PR TITLE
Fixes #3079 - Renames all `gui` vars to `my_gui` instead.

### DIFF
--- a/doc/source/structures/gui.rst
+++ b/doc/source/structures/gui.rst
@@ -66,14 +66,14 @@ The "Hello World" program, version 1 with "callbacks"::
         // "Hello World" program for kOS GUI.
         //
         // Create a GUI window
-        LOCAL gui IS GUI(200).
+        LOCAL my_gui IS GUI(200).
         // Add widgets to the GUI
-        LOCAL label IS gui:ADDLABEL("Hello world!").
+        LOCAL label IS my_gui:ADDLABEL("Hello world!").
         SET label:STYLE:ALIGN TO "CENTER".
         SET label:STYLE:HSTRETCH TO True. // Fill horizontally
-        LOCAL ok TO gui:ADDBUTTON("OK").
+        LOCAL ok TO my_gui:ADDBUTTON("OK").
         // Show the GUI.
-        gui:SHOW().
+        my_gui:SHOW().
         // Handle GUI widget interactions.
         //
         // This is the technique known as "callbacks" - instead
@@ -91,21 +91,21 @@ The "Hello World" program, version 1 with "callbacks"::
 
         print "OK pressed.  Now closing demo.".
         // Hide when done (will also hide if power lost).
-        gui:HIDE().
+        my_gui:HIDE().
 
 The same "Hello World" program, version 2 with "polling"::
 
         // "Hello World" program for kOS GUI.
         //
         // Create a GUI window
-        LOCAL gui IS GUI(200).
+        LOCAL my_gui IS GUI(200).
         // Add widgets to the GUI
-        LOCAL label IS gui:ADDLABEL("Hello world!").
+        LOCAL label IS my_gui:ADDLABEL("Hello world!").
         SET label:STYLE:ALIGN TO "CENTER".
         SET label:STYLE:HSTRETCH TO True. // Fill horizontally
-        LOCAL ok TO gui:ADDBUTTON("OK").
+        LOCAL ok TO my_gui:ADDBUTTON("OK").
         // Show the GUI.
-        gui:SHOW().
+        my_gui:SHOW().
         // Handle GUI widget interactions.
         //
         // This is the technique known as "polling" - In a loop you
@@ -119,7 +119,7 @@ The same "Hello World" program, version 2 with "polling"::
         }
         print "OK pressed.  Now closing demo.".
         // Hide when done (will also hide if power lost).
-        gui:HIDE().
+        my_gui:HIDE().
 
 
 
@@ -135,11 +135,11 @@ manipulate to build up a GUI. If no height is specified, it will resize
 automatically to fit the contents you put inside it.  The width can be set
 to 0 to force automatic width resizing too::
 
-        SET gui TO GUI(200).
-        SET button TO gui:ADDBUTTON("OK").
-        gui:SHOW().
+        SET my_gui TO GUI(200).
+        SET button TO my_gui:ADDBUTTON("OK").
+        my_gui:SHOW().
         UNTIL button:TAKEPRESS WAIT(0.1).
-        gui:HIDE().
+        my_gui:HIDE().
 
 See the "ADD" functions in the :struct:`BOX` structure for
 the other widgets you can add.

--- a/doc/source/tutorials/gui.rst
+++ b/doc/source/tutorials/gui.rst
@@ -38,8 +38,8 @@ share the implementation with multiple KSP installs, and with others online::
 Our TabWidget should be usable in any context, but in this example, we just create it at the top-level.
 The AddTabWidget function should however accept any VBOX as the parameter::
 
-    LOCAL gui IS GUI(500).
-    LOCAL tabwidget IS AddTabWidget(gui).
+    LOCAL my_gui IS GUI(500).
+    LOCAL tabwidget IS AddTabWidget(my_gui).
 
 3. Add tabs
 ^^^^^^^^^^^
@@ -74,13 +74,13 @@ tab for setting up Maneuver Nodes might be a better default::
 The rest here is just boilerplate - we add a Close button to the top level, then show and run the GUI until
 the user presses the Close button::
 
-    LOCAL close IS gui:ADDBUTTON("Close").
-    gui:SHOW().
+    LOCAL close IS my_gui:ADDBUTTON("Close").
+    my_gui:SHOW().
     UNTIL close:PRESSED {
         // Handle processing of all the widgets on all the tabs.
         WAIT(0).
     }
-    gui:HIDE().
+    my_gui:HIDE().
 
 The Implementation
 ------------------
@@ -259,7 +259,7 @@ which would mean the communication delay icon is constantly shown. We can test o
 artificially adding extra delay, and testing on the launch pad::
 
     ...
-    SET gui:EXTRADELAY TO 2.
+    SET my_gui:EXTRADELAY TO 2.
     ...
 
 The widget continues to work perfectly. Even if the user rapidly changes tab, the pages change as expected, though


### PR DESCRIPTION
I am fixing this one right away because it's a case where a thing used to work before the release and now doesn't.  (When a release *causes* a new problem, that has a higher priority to fix it in my head than simply failing to fix an existing problem.)

