### PR TITLE
Fixes #3081 by making more KSPFields persist between scenes.

### DIFF
--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -108,10 +108,10 @@ namespace kOS.Module
         [KSPField(isPersistant = false, guiName = "CPU/Disk Upgrade Mass", guiActive = false, guiActiveEditor = true, guiUnits = "Kg", guiFormat = "0.00", groupName = PAWGroup, groupDisplayName = PAWGroup)]
         public float additionalMassGui = 0F;
 
-        [KSPField(isPersistant = false, guiActive = false, guiActiveEditor = false)]
+        [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = false)]
         public float diskSpaceCostFactor = 0.0244140625F; //implies approx 100funds for 4096bytes of diskSpace
 
-        [KSPField(isPersistant = false, guiActive = false, guiActiveEditor = false)]
+        [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = false)]
         public float diskSpaceMassFactor = 0.0000000048829F;  //implies approx 0.020kg for 4096bytes of diskSpace
 
         [KSPField(isPersistant = true, guiActive = false)]
@@ -123,7 +123,7 @@ namespace kOS.Module
         // for the kOS processor.  The only reason it's being given a value
         // here is as a fallback for those cases where an old legacy part
         // might be loaded from before the part files had this value.
-        [KSPField(isPersistant = false, guiActive = false)]
+        [KSPField(isPersistant = true, guiActive = false)]
         public float ECPerInstruction = 0.000004F;
 
         // This represents how much EC to consume per Byte of the current volume, per second.
@@ -131,7 +131,7 @@ namespace kOS.Module
         // when you change to another volume).
         // IMPORTANT: The value defaults to zero and must be overriden in the module
         // definition for any given part (within the part.cfg file).
-        [KSPField(isPersistant = false, guiActive = false)]
+        [KSPField(isPersistant = true, guiActive = false)]
         public float ECPerBytePerSecond = 0F;
 
         public kOSProcessor()


### PR DESCRIPTION
Fixes #3081 

It turns out the actual fix was far simpler than anticipated.

Yes, there was a race condition between KOSProcessor's ``OnStart()`` and RP-0's ModuleProceduralAvionics' ``OnStart()``, but that race condition is rendered moot when you just have the changes that the VAB applies due to tech level get stored in the craft file so they're already correct when you launch the vessel, before OnStart() even happens.

The root problem was caused by the fact that some of the fields that store the mass and funds cost per byte of extra space weren't persisting and thus kept getting set back to default on every scene change.  The fact that OnStart() tries to put them back again, and all the mess about doing so in the right order, don't really matter if those values persist in the savegame and craft files anyway so they don't need to get overriden in OnStart().

The reason this problem appeared in RP-1 and not in stock is that in stock the values come right from the Part.cfg settings and the way you upgrade tech for the computer is by picking a different kOS part. Therefore the defaults are correct since they never get changed from what the Part.cfg file says.  But in RP-1 where all avionics cores are the "same" part except for how you alter them in the VAB, it mattered that changes had been done that differed from the part's defaults and thos changes had to be saved.