### PR TITLE
Fixes #3089 - Invoke UI callback when setting part module field value

### DIFF
--- a/src/kOS/Suffixed/PartModuleField/PartModuleFields.cs
+++ b/src/kOS/Suffixed/PartModuleField/PartModuleFields.cs
@@ -468,6 +468,13 @@ namespace kOS.Suffixed.PartModuleField
             {
                 object convertedValue = Convert.ChangeType(newValue, field.FieldInfo.FieldType);
                 field.SetValue(convertedValue, partModule);
+
+                // Some mods rely on UI callback to be called when field value is changed
+                UI_Control control;
+                if (partModule.Fields.TryGetFieldUIControl(field.name, out control))
+                {
+                    control.onFieldChanged?.Invoke(field, convertedValue);
+                }
             }
             else
             {


### PR DESCRIPTION
Fixes #3089

Invoke UI `onFieldChanged` callback when setting part module field value to fix compatibility with some mods because some mods listen to this callback to apply field value changes.

