### PR TITLE
Fix managedwindow memory leak

### DIFF
--- a/src/kOS/Screen/GUIWindow.cs
+++ b/src/kOS/Screen/GUIWindow.cs
@@ -73,11 +73,13 @@ namespace kOS.Screen
             OptOutOfControlLocking = true;
         }
 
-        public void OnDestroy()
+        new public void OnDestroy()
         {
             if (shared != null) shared.RemoveWindow(this);
             GameEvents.onHideUI.Remove(OnHideUI);
             GameEvents.onShowUI.Remove(OnShowUI);
+
+            base.OnDestroy();
         }
 
         void OnHideUI()

--- a/src/kOS/Screen/KOSManagedWindow.cs
+++ b/src/kOS/Screen/KOSManagedWindow.cs
@@ -147,6 +147,10 @@ namespace kOS.Screen
             set { mouseButtonDownPosRelative = value; }
         }
 
+        protected void OnDestroy()
+        {
+            depthSort.Remove(this);
+        }
 
         /// <summary>
         /// Implement this for how to make your widget get the keyboard focus.

--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -204,11 +204,13 @@ namespace kOS.Screen
             return style;
         }
 
-        public void OnDestroy()
+        new public void OnDestroy()
         {
             LoseFocus();
             GameEvents.onHideUI.Remove(OnHideUI);
             GameEvents.onShowUI.Remove(OnShowUI);
+
+            base.OnDestroy();
         }
         
         public kOS.Safe.Sound.ISoundMaker GetSoundMaker()


### PR DESCRIPTION
-classes derived from ManagedWindow need to call base.OnDestroy to remove the references from the statis depthSort list