### PR TITLE
Fix #3119. Don't expose ListValue<T> lists to users

### DIFF
--- a/src/kOS.Safe/Encapsulation/Lexicon.cs
+++ b/src/kOS.Safe/Encapsulation/Lexicon.cs
@@ -380,9 +380,9 @@ namespace kOS.Safe.Encapsulation
         /// to the list.
         /// </summary>
         /// <returns></returns>
-        public override List<StringValue> GetSuffixNames()
+        public override ListValue GetSuffixNames()
         {
-            List<StringValue> theList = base.GetSuffixNames();
+            ListValue theList = base.GetSuffixNames();
 
             foreach (Structure key in internalDictionary.Keys)
             {
@@ -392,7 +392,7 @@ namespace kOS.Safe.Encapsulation
                     theList.Add(keyStr);
                 }
             }
-            return new List<StringValue>(theList.OrderBy(item => item.ToString()));
+            return new ListValue(theList.OrderBy(item => item.ToString()));
         }
         public override Dump Dump()
         {

--- a/src/kOS.Safe/Encapsulation/Lexicon.cs
+++ b/src/kOS.Safe/Encapsulation/Lexicon.cs
@@ -115,10 +115,10 @@ namespace kOS.Safe.Encapsulation
         private void InitalizeSuffixes()
         {
             AddSuffix("CLEAR", new NoArgsVoidSuffix(Clear, "Removes all items from Lexicon"));
-            AddSuffix("KEYS", new Suffix<ListValue<Structure>>(GetKeys, "Returns the lexicon keys"));
+            AddSuffix("KEYS", new Suffix<ListValue>(GetKeys, "Returns the lexicon keys"));
             AddSuffix("HASKEY", new OneArgsSuffix<BooleanValue, Structure>(HasKey, "Returns true if a key is in the Lexicon"));
             AddSuffix("HASVALUE", new OneArgsSuffix<BooleanValue, Structure>(HasValue, "Returns true if value is in the Lexicon"));
-            AddSuffix("VALUES", new Suffix<ListValue<Structure>>(GetValues, "Returns the lexicon values"));
+            AddSuffix("VALUES", new Suffix<ListValue>(GetValues, "Returns the lexicon values"));
             AddSuffix("COPY", new NoArgsSuffix<Lexicon>(() => new Lexicon(this), "Returns a copy of Lexicon"));
             AddSuffix("LENGTH", new NoArgsSuffix<ScalarValue>(() => internalDictionary.Count, "Returns the number of elements in the collection"));
             AddSuffix("REMOVE", new OneArgsSuffix<BooleanValue, Structure>(one => Remove(one), "Removes the value at the given key"));
@@ -158,12 +158,12 @@ namespace kOS.Safe.Encapsulation
             return internalDictionary.ContainsKey(key);
         }
 
-        public ListValue<Structure> GetValues()
+        public ListValue GetValues()
         {
             return ListValue.CreateList(Values);
         }
 
-        public ListValue<Structure> GetKeys()
+        public ListValue GetKeys()
         {
             return ListValue.CreateList(Keys);
         }
@@ -380,9 +380,9 @@ namespace kOS.Safe.Encapsulation
         /// to the list.
         /// </summary>
         /// <returns></returns>
-        public override ListValue<StringValue> GetSuffixNames()
+        public override List<StringValue> GetSuffixNames()
         {
-            ListValue<StringValue> theList = base.GetSuffixNames();
+            List<StringValue> theList = base.GetSuffixNames();
 
             foreach (Structure key in internalDictionary.Keys)
             {
@@ -392,7 +392,7 @@ namespace kOS.Safe.Encapsulation
                     theList.Add(keyStr);
                 }
             }
-            return new ListValue<StringValue>(theList.OrderBy(item => item.ToString()));
+            return new List<StringValue>(theList.OrderBy(item => item.ToString()));
         }
         public override Dump Dump()
         {

--- a/src/kOS.Safe/Encapsulation/StringValue.cs
+++ b/src/kOS.Safe/Encapsulation/StringValue.cs
@@ -238,11 +238,11 @@ namespace kOS.Safe.Encapsulation
             return GetEnumerator();
         }
 
-        // As the regular Split, except returning a ListValue rather than an array.
-        public ListValue<StringValue> SplitToList(string separator)
+        // As the regular Split, except returning a List rather than an array.
+        public List<StringValue> SplitToList(string separator)
         {
             string[] split = Regex.Split(internalString, Regex.Escape(separator), RegexOptions.IgnoreCase);
-            ListValue<StringValue> returnList = new ListValue<StringValue>();
+            List<StringValue> returnList = new List<StringValue>();
             foreach (string s in split)
                 returnList.Add(new StringValue(s));
             return returnList;
@@ -273,7 +273,7 @@ namespace kOS.Safe.Encapsulation
             AddSuffix("PADRIGHT",   new OneArgsSuffix<StringValue, ScalarValue>( one => PadRight(one)));
             AddSuffix("REMOVE",     new TwoArgsSuffix<StringValue, ScalarValue, ScalarValue>( (one, two) => Remove(one, two)));
             AddSuffix("REPLACE",    new TwoArgsSuffix<StringValue, StringValue, StringValue>( (one, two) => Replace(one, two)));
-            AddSuffix("SPLIT",      new OneArgsSuffix<ListValue<StringValue>, StringValue>( one => SplitToList(one)));
+            AddSuffix("SPLIT",      new OneArgsSuffix<ListValue, StringValue>( one => new ListValue(SplitToList(one))));
             AddSuffix("STARTSWITH", new OneArgsSuffix<BooleanValue, StringValue>( one => StartsWith(one)));
             AddSuffix("TOLOWER",    new NoArgsSuffix<StringValue>(() => ToLower()));
             AddSuffix("TOUPPER",    new NoArgsSuffix<StringValue>(() => ToUpper()));

--- a/src/kOS.Safe/Encapsulation/StringValue.cs
+++ b/src/kOS.Safe/Encapsulation/StringValue.cs
@@ -238,11 +238,11 @@ namespace kOS.Safe.Encapsulation
             return GetEnumerator();
         }
 
-        // As the regular Split, except returning a List rather than an array.
-        public List<StringValue> SplitToList(string separator)
+        // As the regular Split, except returning a ListValue rather than an array.
+        public ListValue SplitToList(string separator)
         {
             string[] split = Regex.Split(internalString, Regex.Escape(separator), RegexOptions.IgnoreCase);
-            List<StringValue> returnList = new List<StringValue>();
+            ListValue returnList = new ListValue();
             foreach (string s in split)
                 returnList.Add(new StringValue(s));
             return returnList;
@@ -273,7 +273,7 @@ namespace kOS.Safe.Encapsulation
             AddSuffix("PADRIGHT",   new OneArgsSuffix<StringValue, ScalarValue>( one => PadRight(one)));
             AddSuffix("REMOVE",     new TwoArgsSuffix<StringValue, ScalarValue, ScalarValue>( (one, two) => Remove(one, two)));
             AddSuffix("REPLACE",    new TwoArgsSuffix<StringValue, StringValue, StringValue>( (one, two) => Replace(one, two)));
-            AddSuffix("SPLIT",      new OneArgsSuffix<ListValue, StringValue>( one => new ListValue(SplitToList(one))));
+            AddSuffix("SPLIT",      new OneArgsSuffix<ListValue, StringValue>( one => SplitToList(one)));
             AddSuffix("STARTSWITH", new OneArgsSuffix<BooleanValue, StringValue>( one => StartsWith(one)));
             AddSuffix("TOLOWER",    new NoArgsSuffix<StringValue>(() => ToLower()));
             AddSuffix("TOUPPER",    new NoArgsSuffix<StringValue>(() => ToUpper()));

--- a/src/kOS.Safe/Encapsulation/Structure.cs
+++ b/src/kOS.Safe/Encapsulation/Structure.cs
@@ -63,7 +63,7 @@ namespace kOS.Safe.Encapsulation
 
               AddSuffix("TOSTRING",       new NoArgsSuffix<StringValue>(() => ToString()));
               AddSuffix("HASSUFFIX",      new OneArgsSuffix<BooleanValue, StringValue>(HasSuffix));
-              AddSuffix("SUFFIXNAMES",    new NoArgsSuffix<ListValue<StringValue>>(GetSuffixNames));
+              AddSuffix("SUFFIXNAMES",    new NoArgsSuffix<ListValue>(() => new ListValue(GetSuffixNames())));
               AddSuffix("ISSERIALIZABLE", new NoArgsSuffix<BooleanValue>(() => this is SerializableStructure));
               AddSuffix("TYPENAME",       new NoArgsSuffix<StringValue>(() => new StringValue(KOSName)));
               AddSuffix("ISTYPE",         new OneArgsSuffix<BooleanValue,StringValue>(GetKOSIsType));
@@ -208,7 +208,7 @@ namespace kOS.Safe.Encapsulation
             return false;
         }
         
-        public virtual ListValue<StringValue> GetSuffixNames()
+        public virtual List<StringValue> GetSuffixNames()
         {
             callInitializeSuffixes();
             List<StringValue> names = new List<StringValue>();            
@@ -218,7 +218,7 @@ namespace kOS.Safe.Encapsulation
             
             // Return the list alphabetized by suffix name.  The key lookups above, since they're coming
             // from a hashed dictionary, won't be in any predictable ordering:
-            return new ListValue<StringValue>(names.OrderBy(item => item.ToString()));
+            return names.OrderBy(item => item.ToString()).ToList();
         }
         
         public virtual BooleanValue GetKOSIsType(StringValue queryTypeName)

--- a/src/kOS.Safe/Encapsulation/Structure.cs
+++ b/src/kOS.Safe/Encapsulation/Structure.cs
@@ -63,7 +63,7 @@ namespace kOS.Safe.Encapsulation
 
               AddSuffix("TOSTRING",       new NoArgsSuffix<StringValue>(() => ToString()));
               AddSuffix("HASSUFFIX",      new OneArgsSuffix<BooleanValue, StringValue>(HasSuffix));
-              AddSuffix("SUFFIXNAMES",    new NoArgsSuffix<ListValue>(() => new ListValue(GetSuffixNames())));
+              AddSuffix("SUFFIXNAMES",    new NoArgsSuffix<ListValue>(GetSuffixNames));
               AddSuffix("ISSERIALIZABLE", new NoArgsSuffix<BooleanValue>(() => this is SerializableStructure));
               AddSuffix("TYPENAME",       new NoArgsSuffix<StringValue>(() => new StringValue(KOSName)));
               AddSuffix("ISTYPE",         new OneArgsSuffix<BooleanValue,StringValue>(GetKOSIsType));
@@ -208,17 +208,17 @@ namespace kOS.Safe.Encapsulation
             return false;
         }
         
-        public virtual List<StringValue> GetSuffixNames()
+        public virtual ListValue GetSuffixNames()
         {
             callInitializeSuffixes();
-            List<StringValue> names = new List<StringValue>();            
-            
-            names.AddRange(instanceSuffixes.Keys.Select(item => (StringValue)item));
-            names.AddRange(GetStaticSuffixesForType(GetType()).Keys.Select(item => (StringValue)item));
+            List<StringValue> names = new List<StringValue>();
+
+            foreach (var suffix in instanceSuffixes.Keys) names.Add(suffix);
+            foreach (var staticSuffix in GetStaticSuffixesForType(GetType()).Keys) names.Add(staticSuffix);
             
             // Return the list alphabetized by suffix name.  The key lookups above, since they're coming
             // from a hashed dictionary, won't be in any predictable ordering:
-            return names.OrderBy(item => item.ToString()).ToList();
+            return new ListValue(names.OrderBy(item => item.ToString()));
         }
         
         public virtual BooleanValue GetKOSIsType(StringValue queryTypeName)

--- a/src/kOS.Safe/Persistence/FileContent.cs
+++ b/src/kOS.Safe/Persistence/FileContent.cs
@@ -61,13 +61,8 @@ namespace kOS.Safe.Persistence
             AddSuffix("EMPTY", new Suffix<BooleanValue>(() => Size == 0));
             AddSuffix("TYPE", new Suffix<StringValue>(() => Category.ToString()));
             AddSuffix("STRING", new Suffix<StringValue>(() => String));
-            AddSuffix("BINARY", new Suffix<ListValue<ScalarIntValue>>(() => ContentAsIntList()));
+            AddSuffix("BINARY", new Suffix<ListValue>(() => new ListValue(Bytes.Select(x => new ScalarIntValue(x)))));
             AddSuffix("ITERATOR", new Suffix<Enumerator>(() => new Enumerator(GetEnumerator())));
-        }
-
-        private ListValue<ScalarIntValue> ContentAsIntList()
-        {
-            return new ListValue<ScalarIntValue>(Bytes.Select(x => new ScalarIntValue(x)));
         }
 
         public override Dump Dump()

--- a/src/kOS/Binding/FlightStats.cs
+++ b/src/kOS/Binding/FlightStats.cs
@@ -57,15 +57,15 @@ namespace kOS.Binding
                     return false; // Since there is no solver, there can be no node.
                 return vessel.patchedConicSolver.maneuverNodes.Count > 0;
             });
-            shared.BindingMgr.AddGetter("ALLNODES", () => new ListValue(GetAllNodes(shared)));
+            shared.BindingMgr.AddGetter("ALLNODES", () => GetAllNodes(shared));
         }
 
-        public List<Node> GetAllNodes(SharedObjects shared)
+        public ListValue GetAllNodes(SharedObjects shared)
         {
             var vessel = shared.Vessel;
             if (vessel.patchedConicSolver == null || vessel.patchedConicSolver.maneuverNodes.Count == 0)
-                return new List<Node>();
-            var ret = new List<Node>(vessel.patchedConicSolver.maneuverNodes.Select(e => Node.FromExisting(vessel, e, shared)));
+                return new ListValue();
+            var ret = new ListValue(vessel.patchedConicSolver.maneuverNodes.Select(e => Node.FromExisting(vessel, e, shared)));
             return ret;
         }
     }

--- a/src/kOS/Binding/FlightStats.cs
+++ b/src/kOS/Binding/FlightStats.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using kOS.Module;
 using kOS.Control;
 using kOS.Safe.Binding;
@@ -56,15 +57,15 @@ namespace kOS.Binding
                     return false; // Since there is no solver, there can be no node.
                 return vessel.patchedConicSolver.maneuverNodes.Count > 0;
             });
-            shared.BindingMgr.AddGetter("ALLNODES", () => GetAllNodes(shared));
+            shared.BindingMgr.AddGetter("ALLNODES", () => new ListValue(GetAllNodes(shared)));
         }
 
-        public ListValue<Node> GetAllNodes(SharedObjects shared)
+        public List<Node> GetAllNodes(SharedObjects shared)
         {
             var vessel = shared.Vessel;
             if (vessel.patchedConicSolver == null || vessel.patchedConicSolver.maneuverNodes.Count == 0)
-                return new ListValue<Node>();
-            var ret = new ListValue<Node>(vessel.patchedConicSolver.maneuverNodes.Select(e => Node.FromExisting(vessel, e, shared)));
+                return new List<Node>();
+            var ret = new List<Node>(vessel.patchedConicSolver.maneuverNodes.Select(e => Node.FromExisting(vessel, e, shared)));
             return ret;
         }
     }

--- a/src/kOS/Function/Suffixed.cs
+++ b/src/kOS/Function/Suffixed.cs
@@ -732,7 +732,7 @@ namespace kOS.Function
             AssertArgBottomAndConsume(shared); // no args
             
             // ReSharper disable SuggestUseVarKeywordEvident
-            ListValue<WaypointValue> returnList = new ListValue<WaypointValue>();
+            ListValue returnList = new ListValue();
             // ReSharper enable SuggestUseVarKeywordEvident
 
             WaypointManager wpm = WaypointManager.Instance();

--- a/src/kOS/Suffixed/AggregateResourceValue.cs
+++ b/src/kOS/Suffixed/AggregateResourceValue.cs
@@ -99,10 +99,10 @@ namespace kOS.Suffixed
             return list;
         }
 
-        public static List<AggregateResourceValue> FromVessel(Vessel vessel, SharedObjects shared)
+        public static ListValue FromVessel(Vessel vessel, SharedObjects shared)
         {
             var resources = ProspectResources(vessel.parts, shared);
-            return resources.Values.ToList();
+            return new ListValue(resources.Values);
         }
     }
 }

--- a/src/kOS/Suffixed/AggregateResourceValue.cs
+++ b/src/kOS/Suffixed/AggregateResourceValue.cs
@@ -99,10 +99,10 @@ namespace kOS.Suffixed
             return list;
         }
 
-        public static ListValue<AggregateResourceValue> FromVessel(Vessel vessel, SharedObjects shared)
+        public static List<AggregateResourceValue> FromVessel(Vessel vessel, SharedObjects shared)
         {
             var resources = ProspectResources(vessel.parts, shared);
-            return ListValue<AggregateResourceValue>.CreateList(resources.Values);
+            return resources.Values.ToList();
         }
     }
 }

--- a/src/kOS/Suffixed/Part/DockingPortValue.cs
+++ b/src/kOS/Suffixed/Part/DockingPortValue.cs
@@ -62,7 +62,7 @@ namespace kOS.Suffixed.Part
             }
 
             var otherVessel = VesselTarget.CreateOrGetExisting(otherNode.vessel, Shared);
-            foreach (var part in otherVessel.Parts)
+            foreach (PartValue part in otherVessel.Parts)
             {
                 if (part.Part == otherNode.part)
                 {

--- a/src/kOS/Suffixed/Part/PartValue.cs
+++ b/src/kOS/Suffixed/Part/PartValue.cs
@@ -22,7 +22,7 @@ namespace kOS.Suffixed.Part
         public global::Part Part { get; private set; }
         public PartValue Parent { get; private set; }
         public DecouplerValue Decoupler { get; private set; }
-        public ListValue<PartValue> Children { get; private set; }
+        public List<PartValue> Children { get; private set; }
         public Structure ParentValue { get { return (Structure)Parent ?? StringValue.None; } }
         public Structure DecouplerValue { get { return (Structure)Decoupler ?? StringValue.None; } }
         public int DecoupledIn { get { return (Decoupler != null) ? Decoupler.Part.inverseStage : -1; } }
@@ -37,7 +37,7 @@ namespace kOS.Suffixed.Part
             Parent = parent;
             Decoupler = decoupler;
             RegisterInitializer(PartInitializeSuffixes);
-            Children  = new ListValue<PartValue>();
+            Children  = new List<PartValue>();
         }
 
         private void PartInitializeSuffixes()
@@ -66,7 +66,7 @@ namespace kOS.Suffixed.Part
             AddSuffix(new[] { "DECOUPLER", "SEPARATOR" }, new Suffix<Structure>(() => DecouplerValue, "The part that will decouple/separate this part when activated"));
             AddSuffix(new[] { "DECOUPLEDIN", "SEPARATEDIN" }, new Suffix<ScalarValue>(() => DecoupledIn));
             AddSuffix("HASPARENT", new Suffix<BooleanValue>(() => Part.parent != null, "Tells you if this part has a parent, is used to avoid null exception from PARENT"));
-            AddSuffix("CHILDREN", new Suffix<ListValue<PartValue>>(() => PartValueFactory.ConstructGeneric(Part.children, Shared), "A LIST() of the children parts of this part"));
+            AddSuffix("CHILDREN", new Suffix<ListValue>(() => new ListValue(PartValueFactory.ConstructGeneric(Part.children, Shared)), "A LIST() of the children parts of this part"));
             AddSuffix("DRYMASS", new Suffix<ScalarValue>(() => Part.GetDryMass(), "The Part's mass when empty"));
             AddSuffix("MASS", new Suffix<ScalarValue>(() => Part.CalculateCurrentMass(), "The Part's current mass"));
             AddSuffix("WETMASS", new Suffix<ScalarValue>(() => Part.GetWetMass(), "The Part's mass when full"));

--- a/src/kOS/Suffixed/Part/PartValue.cs
+++ b/src/kOS/Suffixed/Part/PartValue.cs
@@ -22,7 +22,7 @@ namespace kOS.Suffixed.Part
         public global::Part Part { get; private set; }
         public PartValue Parent { get; private set; }
         public DecouplerValue Decoupler { get; private set; }
-        public List<PartValue> Children { get; private set; }
+        public ListValue Children { get; private set; }
         public Structure ParentValue { get { return (Structure)Parent ?? StringValue.None; } }
         public Structure DecouplerValue { get { return (Structure)Decoupler ?? StringValue.None; } }
         public int DecoupledIn { get { return (Decoupler != null) ? Decoupler.Part.inverseStage : -1; } }
@@ -37,7 +37,7 @@ namespace kOS.Suffixed.Part
             Parent = parent;
             Decoupler = decoupler;
             RegisterInitializer(PartInitializeSuffixes);
-            Children  = new List<PartValue>();
+            Children  = new ListValue();
         }
 
         private void PartInitializeSuffixes()
@@ -66,7 +66,7 @@ namespace kOS.Suffixed.Part
             AddSuffix(new[] { "DECOUPLER", "SEPARATOR" }, new Suffix<Structure>(() => DecouplerValue, "The part that will decouple/separate this part when activated"));
             AddSuffix(new[] { "DECOUPLEDIN", "SEPARATEDIN" }, new Suffix<ScalarValue>(() => DecoupledIn));
             AddSuffix("HASPARENT", new Suffix<BooleanValue>(() => Part.parent != null, "Tells you if this part has a parent, is used to avoid null exception from PARENT"));
-            AddSuffix("CHILDREN", new Suffix<ListValue>(() => new ListValue(PartValueFactory.ConstructGeneric(Part.children, Shared)), "A LIST() of the children parts of this part"));
+            AddSuffix("CHILDREN", new Suffix<ListValue>(() => PartValueFactory.ConstructGeneric(Part.children, Shared), "A LIST() of the children parts of this part"));
             AddSuffix("DRYMASS", new Suffix<ScalarValue>(() => Part.GetDryMass(), "The Part's mass when empty"));
             AddSuffix("MASS", new Suffix<ScalarValue>(() => Part.CalculateCurrentMass(), "The Part's current mass"));
             AddSuffix("WETMASS", new Suffix<ScalarValue>(() => Part.GetWetMass(), "The Part's mass when full"));

--- a/src/kOS/Suffixed/Part/PartValueFactory.cs
+++ b/src/kOS/Suffixed/Part/PartValueFactory.cs
@@ -12,8 +12,8 @@ namespace kOS.Suffixed.Part
             return ListValue.CreateList(parts.Select(part => Construct(part, shared)).Where(p => p != null));
         }
 
-        public static ListValue<PartValue> ConstructGeneric(IEnumerable<global::Part> parts, SharedObjects shared) {
-            return ListValue<PartValue>.CreateList(parts.Select(part => Construct(part, shared)).Where(p => p != null));
+        public static List<PartValue> ConstructGeneric(IEnumerable<global::Part> parts, SharedObjects shared) {
+            return parts.Select(part => Construct(part, shared)).Where(p => p != null).ToList();
         }
 
         public static PartValue Construct(global::Part part, SharedObjects shared) {

--- a/src/kOS/Suffixed/Part/PartValueFactory.cs
+++ b/src/kOS/Suffixed/Part/PartValueFactory.cs
@@ -12,8 +12,8 @@ namespace kOS.Suffixed.Part
             return ListValue.CreateList(parts.Select(part => Construct(part, shared)).Where(p => p != null));
         }
 
-        public static List<PartValue> ConstructGeneric(IEnumerable<global::Part> parts, SharedObjects shared) {
-            return parts.Select(part => Construct(part, shared)).Where(p => p != null).ToList();
+        public static ListValue ConstructGeneric(IEnumerable<global::Part> parts, SharedObjects shared) {
+            return new ListValue(parts.Select(part => Construct(part, shared)).Where(p => p != null));
         }
 
         public static PartValue Construct(global::Part part, SharedObjects shared) {

--- a/src/kOS/Suffixed/ResourceTransferValue.cs
+++ b/src/kOS/Suffixed/ResourceTransferValue.cs
@@ -116,11 +116,7 @@ namespace kOS.Suffixed
             {
                 return TransferPartType.Part;
             }
-            if (toTest is ListValue)
-            {
-                return TransferPartType.Parts;
-            }
-            if (toTest is ListValue<PartValue>)
+            if (toTest is ListValue || toTest is ListValue<PartValue> || toTest is List<PartValue>)
             {
                 return TransferPartType.Parts;
             }
@@ -348,6 +344,12 @@ namespace kOS.Suffixed
                     if (partListValue != null)
                     {
                         parts.AddRange(partListValue.Select(pv => pv.Part));
+                        break;
+                    }
+                    var partList= obj as List<PartValue>;
+                    if (partList!= null)
+                    {
+                        parts.AddRange(partList.Select(pv => pv.Part));
                         break;
                     }
                     break;

--- a/src/kOS/Suffixed/StageValues.cs
+++ b/src/kOS/Suffixed/StageValues.cs
@@ -18,7 +18,7 @@ namespace kOS.Suffixed
         private readonly SharedObjects shared;
         private HashSet<global::Part> partHash = new HashSet<global::Part>();
         private PartSet partSet;
-        private List<ActiveResourceValue> resList;
+        private ListValue resList;
         private Lexicon resLex;
 
         // Set by VesselTarget (from InvalidateParts)
@@ -53,10 +53,10 @@ namespace kOS.Suffixed
             AddSuffix("DELTAV", new Suffix<DeltaVCalc>(() => new DeltaVCalc(shared, shared.Vessel.VesselDeltaV.GetStage(shared.Vessel.currentStage))));
         }
 
-        private List<ActiveResourceValue> GetResourceManifest()
+        private ListValue GetResourceManifest()
         {
             if (resList != null) return resList;
-            resList = new List<ActiveResourceValue>();
+            resList = new ListValue();
             CreatePartSet();
             var defs = PartResourceLibrary.Instance.resourceDefinitions;
             foreach (var def in defs)

--- a/src/kOS/Suffixed/StageValues.cs
+++ b/src/kOS/Suffixed/StageValues.cs
@@ -18,7 +18,7 @@ namespace kOS.Suffixed
         private readonly SharedObjects shared;
         private HashSet<global::Part> partHash = new HashSet<global::Part>();
         private PartSet partSet;
-        private ListValue<ActiveResourceValue> resList;
+        private List<ActiveResourceValue> resList;
         private Lexicon resLex;
 
         // Set by VesselTarget (from InvalidateParts)
@@ -47,16 +47,16 @@ namespace kOS.Suffixed
 
             AddSuffix("NUMBER", new Suffix<ScalarValue>(() => StageManager.CurrentStage));
             AddSuffix("READY", new Suffix<BooleanValue>(() => shared.Vessel.isActiveVessel && StageManager.CanSeparate));
-            AddSuffix("RESOURCES", new Suffix<ListValue<ActiveResourceValue>>(GetResourceManifest));
-            AddSuffix("RESOURCESLEX", new Suffix<Lexicon>(GetResourceDictionary));
+            AddSuffix("RESOURCES", new Suffix<ListValue>(() => new ListValue(GetResourceManifest())));
+            AddSuffix("RESOURCESLEX", new Suffix<Lexicon>(() => new Lexicon(GetResourceDictionary())));
             AddSuffix(new string[] { "NEXTDECOUPLER", "NEXTSEPARATOR" }, new Suffix<Structure>(() => shared.VesselTarget.NextDecoupler ?? (Structure)StringValue.None));
             AddSuffix("DELTAV", new Suffix<DeltaVCalc>(() => new DeltaVCalc(shared, shared.Vessel.VesselDeltaV.GetStage(shared.Vessel.currentStage))));
         }
 
-        private ListValue<ActiveResourceValue> GetResourceManifest()
+        private List<ActiveResourceValue> GetResourceManifest()
         {
             if (resList != null) return resList;
-            resList = new ListValue<ActiveResourceValue>();
+            resList = new List<ActiveResourceValue>();
             CreatePartSet();
             var defs = PartResourceLibrary.Instance.resourceDefinitions;
             foreach (var def in defs)

--- a/src/kOS/Suffixed/TimeWarpValue.cs
+++ b/src/kOS/Suffixed/TimeWarpValue.cs
@@ -33,9 +33,9 @@ namespace kOS.Suffixed
         private void InitializeSuffixes()
         {
             AddSuffix("RATE", new SetSuffix<ScalarValue>(GetRate, SetRate));
-            AddSuffix("RATELIST", new Suffix<ListValue<ScalarValue>>(GetRatesList));
-            AddSuffix("RAILSRATELIST", new Suffix<ListValue<ScalarValue>>(() => GetRatesList(TimeWarp.Modes.HIGH)));
-            AddSuffix("PHYSICSRATELIST", new Suffix<ListValue<ScalarValue>>(() => GetRatesList(TimeWarp.Modes.LOW)));
+            AddSuffix("RATELIST", new Suffix<ListValue>(() => ListValue.CreateList(GetRateArrayForMode(TimeWarp.WarpMode))));
+            AddSuffix("RAILSRATELIST", new Suffix<ListValue>(() => ListValue.CreateList(GetRateArrayForMode(TimeWarp.Modes.HIGH))));
+            AddSuffix("PHYSICSRATELIST", new Suffix<ListValue>(() => ListValue.CreateList(GetRateArrayForMode(TimeWarp.Modes.LOW))));
             AddSuffix("MODE", new SetSuffix<StringValue>(GetModeAsString, SetModeAsString));
             AddSuffix("WARP", new SetSuffix<ScalarIntValue>(GetWarp, SetWarp));
             AddSuffix("WARPTO", new OneArgsSuffix<ScalarValue>(WarpTo));
@@ -132,24 +132,6 @@ namespace kOS.Suffixed
         public ScalarValue GetDeltaT()
         {
             return TimeWarp.fixedDeltaTime;
-        }
-
-        public ListValue<ScalarValue> GetRatesList()
-        {
-            return GetRatesList(TimeWarp.WarpMode);
-        }
-
-        public ListValue<ScalarValue> GetRatesList(TimeWarp.Modes warpMode)
-        {
-            float[] ratesArray = GetRateArrayForMode(warpMode);
-
-            ListValue<ScalarValue> ratesKOSList = new ListValue<ScalarValue>();
-
-            // Have to convert the elements one at a time from (float) to (ScalarDoubleValue):
-            foreach (float val in ratesArray)
-                ratesKOSList.Add(val);
-
-            return ratesKOSList;
         }
 
         public BooleanValue IsWarpSettled()

--- a/src/kOS/Suffixed/VesselTarget.Parts.cs
+++ b/src/kOS/Suffixed/VesselTarget.Parts.cs
@@ -19,9 +19,9 @@ namespace kOS.Suffixed
         //..... [root, child1, child2, ..., part1-1, part1-2, ..., part2-1, ... heap ;)
         private PartValue rootPart;
         private DecouplerValue nextDecoupler;
-        private List<PartValue> allParts;
-        private List<DockingPortValue> dockingPorts;
-        private List<DecouplerValue> decouplers;
+        private ListValue allParts;
+        private ListValue dockingPorts;
+        private ListValue decouplers;
         private Dictionary<global::Part, PartValue> partCache;
 
         private void InvalidateParts()
@@ -53,7 +53,7 @@ namespace kOS.Suffixed
                 return nextDecoupler;
             }
         }
-        public List<PartValue> Parts
+        public ListValue Parts
         {
             get
             {
@@ -62,7 +62,7 @@ namespace kOS.Suffixed
                 return allParts;
             }
         }
-        public List<DockingPortValue> DockingPorts
+        public ListValue DockingPorts
         {
             get
             {
@@ -71,7 +71,7 @@ namespace kOS.Suffixed
                 return dockingPorts;
             }
         }
-        public List<DecouplerValue> Decouplers
+        public ListValue Decouplers
         {
             get
             {
@@ -98,12 +98,16 @@ namespace kOS.Suffixed
         {
             rootPart = null;
             nextDecoupler = null;
-            allParts = new List<PartValue>();
-            dockingPorts = new List<DockingPortValue>();
-            decouplers = new List<DecouplerValue>();
+            allParts = new ListValue();
+            dockingPorts = new ListValue();
+            decouplers = new ListValue();
             partCache = new Dictionary<global::Part, PartValue>();
 
             ConstructPart(Vessel.rootPart, null, null);
+
+            allParts.IsReadOnly = true;
+            dockingPorts.IsReadOnly = true;
+            decouplers.IsReadOnly = true;
         }
         private void ConstructPart(global::Part part, PartValue parent, DecouplerValue decoupler)
         {
@@ -189,6 +193,7 @@ namespace kOS.Suffixed
             allParts.Add(self);
             foreach (var child in part.children)
                 ConstructPart(child, self, decoupler);
+            self.Children.IsReadOnly = true;
         }
 
         private ListValue GetPartsDubbed(StringValue searchTerm)

--- a/src/kOS/Suffixed/VesselTarget.Parts.cs
+++ b/src/kOS/Suffixed/VesselTarget.Parts.cs
@@ -19,9 +19,9 @@ namespace kOS.Suffixed
         //..... [root, child1, child2, ..., part1-1, part1-2, ..., part2-1, ... heap ;)
         private PartValue rootPart;
         private DecouplerValue nextDecoupler;
-        private ListValue<PartValue> allParts;
-        private ListValue<DockingPortValue> dockingPorts;
-        private ListValue<DecouplerValue> decouplers;
+        private List<PartValue> allParts;
+        private List<DockingPortValue> dockingPorts;
+        private List<DecouplerValue> decouplers;
         private Dictionary<global::Part, PartValue> partCache;
 
         private void InvalidateParts()
@@ -53,7 +53,7 @@ namespace kOS.Suffixed
                 return nextDecoupler;
             }
         }
-        public ListValue<PartValue> Parts
+        public List<PartValue> Parts
         {
             get
             {
@@ -62,7 +62,7 @@ namespace kOS.Suffixed
                 return allParts;
             }
         }
-        public ListValue<DockingPortValue> DockingPorts
+        public List<DockingPortValue> DockingPorts
         {
             get
             {
@@ -71,7 +71,7 @@ namespace kOS.Suffixed
                 return dockingPorts;
             }
         }
-        public ListValue<DecouplerValue> Decouplers
+        public List<DecouplerValue> Decouplers
         {
             get
             {
@@ -98,16 +98,12 @@ namespace kOS.Suffixed
         {
             rootPart = null;
             nextDecoupler = null;
-            allParts = new ListValue<PartValue>();
-            dockingPorts = new ListValue<DockingPortValue>();
-            decouplers = new ListValue<DecouplerValue>();
+            allParts = new List<PartValue>();
+            dockingPorts = new List<DockingPortValue>();
+            decouplers = new List<DecouplerValue>();
             partCache = new Dictionary<global::Part, PartValue>();
 
             ConstructPart(Vessel.rootPart, null, null);
-
-            allParts.IsReadOnly = true;
-            dockingPorts.IsReadOnly = true;
-            decouplers.IsReadOnly = true;
         }
         private void ConstructPart(global::Part part, PartValue parent, DecouplerValue decoupler)
         {
@@ -193,7 +189,6 @@ namespace kOS.Suffixed
             allParts.Add(self);
             foreach (var child in part.children)
                 ConstructPart(child, self, decoupler);
-            self.Children.IsReadOnly = true;
         }
 
         private ListValue GetPartsDubbed(StringValue searchTerm)

--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -255,9 +255,9 @@ namespace kOS.Suffixed
             AddSuffix("PARTSTAGGED", new OneArgsSuffix<ListValue, StringValue>(GetPartsTagged));
             AddSuffix("PARTSTAGGEDPATTERN", new OneArgsSuffix<ListValue, StringValue>(GetPartsTaggedPattern));
             AddSuffix("ALLTAGGEDPARTS", new NoArgsSuffix<ListValue>(GetAllTaggedParts));
-            AddSuffix("PARTS", new NoArgsSuffix<ListValue>(() => new ListValue(Parts)));
-            AddSuffix("DOCKINGPORTS", new NoArgsSuffix<ListValue>(() => new ListValue(DockingPorts)));
-            AddSuffix(new string[] { "DECOUPLERS", "SEPARATORS" }, new NoArgsSuffix<ListValue>(() => new ListValue(Decouplers)));
+            AddSuffix("PARTS", new NoArgsSuffix<ListValue>(() => Parts));
+            AddSuffix("DOCKINGPORTS", new NoArgsSuffix<ListValue>(() => DockingPorts));
+            AddSuffix(new string[] { "DECOUPLERS", "SEPARATORS" }, new NoArgsSuffix<ListValue>(() => Decouplers));
             AddSuffix("ELEMENTS", new NoArgsSuffix<ListValue>(() => Vessel.PartList("elements", Shared)));
             
             AddSuffix("ENGINES", new NoArgsSuffix<ListValue>(() => Vessel.PartList("engines", Shared)));
@@ -291,7 +291,7 @@ namespace kOS.Suffixed
             AddSuffix("CONTROLPART", new Suffix<PartValue>(() => PartValueFactory.Construct(GetControlPart(), Shared)));
             AddSuffix("DRYMASS", new Suffix<ScalarValue>(() => Vessel.GetDryMass(), "The Ship's mass when empty"));
             AddSuffix("WETMASS", new Suffix<ScalarValue>(() => Vessel.GetWetMass(), "The Ship's mass when full"));
-            AddSuffix("RESOURCES", new Suffix<ListValue>(() => new ListValue(AggregateResourceValue.FromVessel(Vessel, Shared)), "The Aggregate resources from every part on the craft"));
+            AddSuffix("RESOURCES", new Suffix<ListValue>(() => AggregateResourceValue.FromVessel(Vessel, Shared), "The Aggregate resources from every part on the craft"));
             AddSuffix("LOADDISTANCE", new Suffix<LoadDistanceValue>(() => new LoadDistanceValue(Vessel)));
             AddSuffix("ISDEAD", new NoArgsSuffix<BooleanValue>(() => (Vessel == null || Vessel.state == Vessel.State.DEAD)));
             AddSuffix("STATUS", new Suffix<StringValue>(() => Vessel.situation.ToString()));
@@ -353,11 +353,11 @@ namespace kOS.Suffixed
         {
             Direction myFacing = VesselUtils.GetFacing(Vessel);
             Quaternion inverseMyFacing = Quaternion.Inverse(myFacing.Rotation);
-            Vector rootOrigin = Parts[0].GetPosition();
+            Vector rootOrigin = ((PartValue)Parts[0]).GetPosition();
             Bounds unionBounds = new Bounds();
             for (int pNum = 0; pNum < Parts.Count; ++pNum)
             {
-                PartValue p = Parts[pNum];
+                PartValue p = (PartValue)Parts[pNum];
                 Vector partOriginOffsetInVesselBounds = p.GetPosition() - rootOrigin;
                 Bounds b = p.GetBoundsValue().GetUnityBounds();
                 Vector partCenter = new Vector(b.center);
@@ -382,7 +382,7 @@ namespace kOS.Suffixed
             // The above operation is expensive and should force the CPU to do a WAIT 0:
             Shared.Cpu.YieldProgram(new YieldFinishedNextTick());
 
-            return new BoundsValue(min, max, delegate { return Parts[0].GetPosition(); }, delegate { return VesselUtils.GetFacing(Vessel); }, Shared);
+            return new BoundsValue(min, max, delegate { return ((PartValue)Parts[0]).GetPosition(); }, delegate { return VesselUtils.GetFacing(Vessel); }, Shared);
         }
 
         public void ThrowIfNotCPUVessel()

--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -255,9 +255,9 @@ namespace kOS.Suffixed
             AddSuffix("PARTSTAGGED", new OneArgsSuffix<ListValue, StringValue>(GetPartsTagged));
             AddSuffix("PARTSTAGGEDPATTERN", new OneArgsSuffix<ListValue, StringValue>(GetPartsTaggedPattern));
             AddSuffix("ALLTAGGEDPARTS", new NoArgsSuffix<ListValue>(GetAllTaggedParts));
-            AddSuffix("PARTS", new NoArgsSuffix<ListValue<PartValue>>(() => Parts));
-            AddSuffix("DOCKINGPORTS", new NoArgsSuffix<ListValue<DockingPortValue>>(() => DockingPorts));
-            AddSuffix(new string[] { "DECOUPLERS", "SEPARATORS" }, new NoArgsSuffix<ListValue<DecouplerValue>>(() => Decouplers));
+            AddSuffix("PARTS", new NoArgsSuffix<ListValue>(() => new ListValue(Parts)));
+            AddSuffix("DOCKINGPORTS", new NoArgsSuffix<ListValue>(() => new ListValue(DockingPorts)));
+            AddSuffix(new string[] { "DECOUPLERS", "SEPARATORS" }, new NoArgsSuffix<ListValue>(() => new ListValue(Decouplers)));
             AddSuffix("ELEMENTS", new NoArgsSuffix<ListValue>(() => Vessel.PartList("elements", Shared)));
             
             AddSuffix("ENGINES", new NoArgsSuffix<ListValue>(() => Vessel.PartList("engines", Shared)));
@@ -291,7 +291,7 @@ namespace kOS.Suffixed
             AddSuffix("CONTROLPART", new Suffix<PartValue>(() => PartValueFactory.Construct(GetControlPart(), Shared)));
             AddSuffix("DRYMASS", new Suffix<ScalarValue>(() => Vessel.GetDryMass(), "The Ship's mass when empty"));
             AddSuffix("WETMASS", new Suffix<ScalarValue>(() => Vessel.GetWetMass(), "The Ship's mass when full"));
-            AddSuffix("RESOURCES", new Suffix<ListValue<AggregateResourceValue>>(() => AggregateResourceValue.FromVessel(Vessel, Shared), "The Aggregate resources from every part on the craft"));
+            AddSuffix("RESOURCES", new Suffix<ListValue>(() => new ListValue(AggregateResourceValue.FromVessel(Vessel, Shared)), "The Aggregate resources from every part on the craft"));
             AddSuffix("LOADDISTANCE", new Suffix<LoadDistanceValue>(() => new LoadDistanceValue(Vessel)));
             AddSuffix("ISDEAD", new NoArgsSuffix<BooleanValue>(() => (Vessel == null || Vessel.state == Vessel.State.DEAD)));
             AddSuffix("STATUS", new Suffix<StringValue>(() => Vessel.situation.ToString()));


### PR DESCRIPTION
Use `Collections.Generic.List<T>` instead of `ListValue<T>`. Return a `ListValue` copy of these lists to user code.

Changes:
FileContent:binary
Lexicon:keys
Lexicon:values
Part:children
Stage:resources
Stage:resourceslex
String:split
Structure:suffixnames
Timewarp:ratelist
Timewarp:railsratelist
Timewarp:physicsratelist
Vessel:parts
Vessel:dockingports
Vessel:decouplers (separators)
Vessel:resources
allnodes bound variable
allwaypoints function

Stage:resources, Stage:resourceslex, Vessel:parts, Vessel:dockingports, Vessel:decouplers now return copies instead of references to internal lists. All lists returned by these suffixes don't get modified over time so the only way to tell that they are copies now is to use the equality operator. Stage:resources and Stage:resourceslex returning a reference was a bug.