### PR TITLE
Fix numeric formatting patterns by unwrapping scalar values

### DIFF
--- a/src/kOS.Safe.Test/Structures/StringValueTest.cs
+++ b/src/kOS.Safe.Test/Structures/StringValueTest.cs
@@ -219,5 +219,16 @@ namespace kOS.Safe.Test.Structures
             stringTest = new StringValue(" 1.23e+3a ");
             Assert.Throws(typeof(Exceptions.KOSNumberParseException), () => stringTest.ToScalar());
         }
+
+        [Test]
+        public void CanFormat()
+        {
+            var formatString = new StringValue("test1={0:0.0} test2='{0,10:0.0}'");
+
+            var expected = new StringValue("test1=13.4 test2='      13.4'");
+            var actual = formatString.Format(new ScalarDoubleValue(13.37));
+
+            Assert.That(expected.ToString(), Is.EqualTo(actual.ToString()));
+        }
     }
 }

--- a/src/kOS.Safe/Encapsulation/StringValue.cs
+++ b/src/kOS.Safe/Encapsulation/StringValue.cs
@@ -7,6 +7,7 @@ using kOS.Safe.Utilities;
 using kOS.Safe.Serialization;
 using System.Collections.Generic;
 using System.Collections;
+using System.Linq;
 
 namespace kOS.Safe.Encapsulation
 {
@@ -257,7 +258,21 @@ namespace kOS.Safe.Encapsulation
         {
             if (args.Length == 0)
                 return this;
-            return new StringValue(string.Format(CultureInfo.InvariantCulture, this, args));
+
+            // Unwrap the primitive scalar value and send them
+            // into String.Format as-is. This is required to allow
+            // for numeric formatting patterns, like rounding.
+            var primitiveArgs = args
+                .Select(arg => {
+                    if (arg is ScalarValue scalar) {
+                        return scalar.ToPrimitive();
+                    }
+
+                    return arg;
+                })
+                .ToArray();
+
+            return new StringValue(string.Format(CultureInfo.InvariantCulture, this, primitiveArgs));
         }
 
         private void StringInitializeSuffixes()


### PR DESCRIPTION
This fixes #3134 where numeric formatting pattern does not work.

The old behavior sends ScalarValue objects to String.Format, which .NET knows nothing about. By unwrapping ScalarValue's into their primitive values we get support for formatting patterns related to Int32 and Double, the only two subclasses of ScalarValue.

Related:
- https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings
- https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-numeric-format-strings

Before:
```
    print "{0:0.0}":format(13.37).
    > prints "13.37"
```

After:
```
    print "{0:0.0}":format(13.37).
    > prints "13.4"
```