### PR TITLE
Fixed spelling issues in documentation

### DIFF
--- a/doc/source/addons/IR.rst
+++ b/doc/source/addons/IR.rst
@@ -220,7 +220,7 @@ Access structure IRAddon via ``ADDONS:IR``.
     ===================================== ==================================== =============
      :attr:`NAME`                          :ref:`string <string>`               Name of the Servo
      :attr:`UID`                           :ref:`scalar <scalar>` (int)         Unique ID of the servo part (part.flightID).
-     :attr:`HIGHLIGHT`                     :ref:`Boolean <boolean>` (set-only)  Set Hightlight status of the part.
+     :attr:`HIGHLIGHT`                     :ref:`Boolean <boolean>` (set-only)  Set Highlight status of the part.
      :attr:`POSITION`                      :ref:`scalar <scalar>` (readonly)    Current position of the servo.
      :attr:`MINCFGPOSITION`                :ref:`scalar <scalar>` (readonly)    Minimum position for servo as defined by part creator in part.cfg
      :attr:`MAXCFGPOSITION`                :ref:`scalar <scalar>` (readonly)    Maximum position for servo as defined by part creator in part.cfg
@@ -264,7 +264,7 @@ Access structure IRAddon via ``ADDONS:IR``.
     :type: :ref:`Boolean <boolean>`
     :access: Set
 
-    Set Hightlight status of the part.
+    Set Highlight status of the part.
 
 .. attribute:: IRServo:POSITION
 
@@ -412,7 +412,7 @@ Access structure IRAddon via ``ADDONS:IR``.
 
 Example code::
 
-    print "IR Iavailable: " + ADDONS:IR:AVAILABLE.
+    print "IR available: " + ADDONS:IR:AVAILABLE.
 
     Print "Groups:".
 

--- a/doc/source/addons/KAC.rst
+++ b/doc/source/addons/KAC.rst
@@ -8,7 +8,7 @@ Kerbal Alarm Clock
 - Forum thread, including full instructions: http://forum.kerbalspaceprogram.com/threads/24786
 
 You can find out if Kerbal Alarm Clock addon is available in the
-current game installation by usng the boolean expression
+current game installation by using the boolean expression
 ``addons:available("KAC")``.
 
 Note that due to changes in Kerbal Alarm Clock, kOS can no longer support
@@ -206,7 +206,7 @@ Available Functions
 .. function:: LISTALARMS(alarmType)
 
     If `alarmType` equals "All", returns :struct:`List` of *all* :struct:`KACAlarm` objects attached to current vessel or have no vessel attached.
-    Otherwise returns :struct:`List` of all :struct:`KACAlarm` objects with `KACAlarm:TYPE` equeal to `alarmType` and attached to current vessel or have no vessel attached.::
+    Otherwise returns :struct:`List` of all :struct:`KACAlarm` objects with `KACAlarm:TYPE` equal to `alarmType` and attached to current vessel or have no vessel attached.::
 
         set al to listAlarms("All").
         for i in al

--- a/doc/source/addons/RemoteTech.rst
+++ b/doc/source/addons/RemoteTech.rst
@@ -10,7 +10,7 @@ RemoteTech is a modification for Squad's "Kerbal Space Program" (KSP) which over
 - Documentation: http://remotetechnologiesgroup.github.io/RemoteTech/
 
 You can find out if the RemoteTech addon is available in the
-current game installation by usng the boolean expression::
+current game installation by using the boolean expression::
 
     addons:available("RT")
 
@@ -44,7 +44,7 @@ Interaction with kOS
 .. note::
 
     .. versionadded:: v1.0.2
-        kOS now supports access to connection informaion from a unified location.
+        kOS now supports access to connection information from a unified location.
         See :ref:`Connectivity Managers <connectivityManagers>` for more
         information. All of the previous implementation as detailed on this page
         remains supported.

--- a/doc/source/addons/Trajectories.rst
+++ b/doc/source/addons/Trajectories.rst
@@ -98,7 +98,7 @@ Access structure TRAddon via ``ADDONS:TR``.
     :type: :struct:`String`
     :access: Get
 
-    **Only gives the correct answer for Trajectries version >= 2.2.0**
+    **Only gives the correct answer for Trajectories version >= 2.2.0**
 
     *For earlier versions, it gives a hardcoded fixed answer, as follows:*
 
@@ -120,7 +120,7 @@ Access structure TRAddon via ``ADDONS:TR``.
     :type: :struct:`Scalar`
     :access: Get
 
-    **Only gives the correct answer for Trajectries version >= 2.0.0**
+    **Only gives the correct answer for Trajectories version >= 2.0.0**
 
     *For earlier versions, it gives a hardcoded fixed answer, as follows:*
 
@@ -139,7 +139,7 @@ Access structure TRAddon via ``ADDONS:TR``.
     :type: :struct:`Scalar`
     :access: Get
 
-    **Only gives the correct answer for Trajectries version >= 2.2.0**
+    **Only gives the correct answer for Trajectories version >= 2.2.0**
 
     *For earlier versions, it gives a hardcoded fixed answer, as follows:*
 
@@ -158,7 +158,7 @@ Access structure TRAddon via ``ADDONS:TR``.
     :type: :struct:`Scalar`
     :access: Get
 
-    **Only gives the correct answer for Trajectries version >= 2.2.0**
+    **Only gives the correct answer for Trajectories version >= 2.2.0**
 
     *For earlier versions, it gives a hardcoded fixed answer, as follows:*
 

--- a/doc/source/bindings.rst
+++ b/doc/source/bindings.rst
@@ -475,7 +475,7 @@ calculating a complex formula, or more milliseconds activating
 actions on a PartModule, and so on, then this feature may
 help.  The ProfileResult() was meant mainly for kOS developers
 trying to internally determine which parts of the system could
-use the most optomizing.  However, as long as it was implemented
+use the most optimizing.  However, as long as it was implemented
 for that purpose, it may as well be made available to all
 the users of kOS as well.
 

--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -103,7 +103,7 @@ Can Set the RCS Deadband
 
 Addition on :attr:`RCS:DEADBAND`
 
-SteeringManager Epislon
+SteeringManager Epsilon
 :::::::::::::::::::::::
 
 Addition of :attr:`SteeringManager:TORQUEEPSILONMIN` and
@@ -169,13 +169,13 @@ CreateOrbit from position and velocity
 
 A new variant of CreateOrbit - :func:`CREATEORBIT(pos, vel, body, ut)`,
 that lets you make an orbit out of state vectors instead of
-Kepplerian values.
+Keplerian values.
 
 Ranges take fractional numbers
 ::::::::::::::::::::::::::::::
 
 :ref:`Ranges <range>` now accept fractional values for start, stop
-and step.  (Previously everthing had to be an integer.)
+and step.  (Previously everything had to be an integer.)
 
 Numerous mistake fixes
 ::::::::::::::::::::::
@@ -226,7 +226,7 @@ New Function, :func:`BODYEXISTS(name)`
 Wordwrap on Labels
 ::::::::::::::::::
 
-You can set wordrap off for labels by the new suffx, :attr:`Style:WORDWRAP`.
+You can set wordwrap off for labels by the new suffix, :attr:`Style:WORDWRAP`.
 
 CreateOrbit
 :::::::::::
@@ -404,7 +404,7 @@ and were removed.
 Document Simulate in BG
 :::::::::::::::::::::::
 
-Documented the need to have Simulate in BG enabled when playing in windwed mode,
+Documented the need to have Simulate in BG enabled when playing in windowed mode,
 on the :ref:`Telnet <telnet>` page.
 
 Stage/decouple docs
@@ -432,7 +432,7 @@ New suffixes on Body page
 :ref:`Body <body>` page now has more fleshed-out examples and documentation
 to go with the new :HASOCEAN, :HASSURFACE, and :CHILDREN suffixes
 
-New Basic tutoial
+New Basic tutorial
 :::::::::::::::::
 
 New Basic Tutorial page.
@@ -556,7 +556,7 @@ error tones, or for playing simple music.  A basic example would be::
 
 For an example of a song, check out the :ref:`Example song section of voice documentation<voicesong>`
 
-Also check out the :ref:`SKID chip documentation<skid>` for an indepth explaination.
+Also check out the :ref:`SKID chip documentation<skid>` for an indepth explanation.
 
 CommNet Support
 :::::::::::::::
@@ -662,7 +662,7 @@ Subdirectories
 See :ref:`Understanding directories <directories>`.
 
 You are now able to store subdirectories ("folders") in your volumes,
-both in the archive and in local volumes.  To accomodate the new feature
+both in the archive and in local volumes.  To accommodate the new feature
 new versions of the file manipulation commands had to be made (please
 go over the documentation in the link given above).
 
@@ -769,7 +769,7 @@ KSP 1.1 release binaries (build 1230)
 Changes in 0.19.3
 -----------------
 
-Interuptable Triggers
+Interruptible Triggers
 :::::::::::::::::::::
 
 Triggers are no longer required to complete within a single update frame,
@@ -807,7 +807,7 @@ this: ::
     }
 
 ``ON`` will now evaluate the expression instead of treating it like a variable
-identifer.
+identifier.
 
 Changes in 0.19.2
 -----------------
@@ -904,7 +904,7 @@ Multimode Engine and Gimbal Support
 :::::::::::::::::::::::::::::::::::
 
 :ref:`Engines <engine>` can now support multiple-mode information, and can
-acces thei gimbal information in the ``:GIMBAL`` suffix.
+access their gimbal information in the ``:GIMBAL`` suffix.
 
 DMagic Orbital Science
 ::::::::::::::::::::::
@@ -938,7 +938,7 @@ JOIN
 ::::
 
 Join suffix on :ref:`lists <list>` now lets you make a string with a
-delimeter of the list's elements.
+delimiter of the list's elements.
 
 Hours per day
 :::::::::::::
@@ -965,7 +965,7 @@ you can use along with lists.
 Run Once
 ::::::::
 
-:ref:`New ONCE argment to the run command <run_once>`
+:ref:`New ONCE argument to the run command <run_once>`
 
 Volumes and Processors integration
 ::::::::::::::::::::::::::::::::::
@@ -999,7 +999,7 @@ A major change to Cooked Steering!
 Should help people using torque-less craft like with Realism Overhaul.
 Removed the old steering logic and replaced it with a nice auto-tuning system.
 
-:ref:`SteeringManager <steeringmanager>` structure now lests you acccess and alter parts of the cooked steering system.
+:ref:`SteeringManager <steeringmanager>` structure now lets you access and alter parts of the cooked steering system.
 
 :ref:`PIDLoop <pidloop>` structure now lets you borrow the PID mechanism used by the new cooked steering, for your own purposes.
 
@@ -1159,13 +1159,13 @@ Docking port, element, and vessel references
 
 You can now get a list of docking ports on any element or vessel using
 the DOCKINGPORTS suffix.  Vessels also expose a list of their elements
-(the ELEMENTS suffix) and an element will refernce it's parent vessel
+(the ELEMENTS suffix) and an element will reference it's parent vessel
 (the VESSEL suffix).
 
 New sounds and terminal features
 ::::::::::::::::::::::::::::::::
 
-For purely cosmetic purpopses, there are new sound features and
+For purely cosmetic purposes, there are new sound features and
  a few terminal tweaks.
 
 - A terminal keyclick option for the in-game GUI terminal.
@@ -1274,7 +1274,7 @@ that a manual user can do by using the right-click menus.
 Kerbal Alarm Clock support
 ::::::::::::::::::::::::::
 
-If you have the Kerbal Alarm Clock Mod isntalled, you can now
+If you have the Kerbal Alarm Clock Mod installed, you can now
 :ref:`query and manipulate its alarms <KAC>` from within your
 kOS scripts.
 

--- a/doc/source/commands/communication.rst
+++ b/doc/source/commands/communication.rst
@@ -157,8 +157,8 @@ Connectivity Managers
         support both CommNet and RemoteTech. Other mods may be supported or
         provide their own support in the future.
 
-kOS can implement communications over a variaty of connectivity configurations.
-We refer to these options as "Connectivity Managers." You can slect the active
+kOS can implement communications over a variety of connectivity configurations.
+We refer to these options as "Connectivity Managers." You can select the active
 manager from the :ref:`kOS section of KSP's Difficulty Settings<settingsWindow>`.
 If the currently selected manager no longer is available, or if a new manager
 becomes available, you will be prompted with a dialog box to select the manager

--- a/doc/source/commands/flight/cooked.rst
+++ b/doc/source/commands/flight/cooked.rst
@@ -56,7 +56,7 @@ The special LOCK variables for cooked steering
 
     IF you have the *Breaking Ground DLC* for Kerbal Space Program, please
     be aware that even though you can set up control groups to make parts
-    such as propellors and engines react to the throttle, they will not
+    such as propellers and engines react to the throttle, they will not
     react to ``lock throttle``.  This is because the DLC ignores the
     autopilot API in using this feature.  It only pays attention to the
     actual pilot controls, not the autopilot controls overriding them.
@@ -116,7 +116,7 @@ Like all ``LOCK`` expressions, the steering and throttle continually update on t
     **About** ``lock steering`` **and** ``SAS`` **:**  While kOS had previously supported
     enabling SAS at the same time as locking steering, this functionality broke
     when the underlying KSP method was changed in a version upgrade.  It is our
-    hope to evenentually restore this functionality.  Please check github issue
+    hope to eventually restore this functionality.  Please check github issue
     `#2117 <https://github.com/KSP-KOS/KOS/issues/2117>`_ for updates.
 
 .. _LOCK WHEELTHROTTLE:
@@ -366,8 +366,8 @@ settings that might help solve some problems, in the list below:
 
   - **explanation**: Once it's
     at the desired orientation and it has mostly zeroed the rotational
-    velocity, it's trying to hold it there with microadjustments to the
-    controls, and those microadjustments are "too tight".
+    velocity, it's trying to hold it there with micro-adjustments to the
+    controls, and those micro-adjustments are "too tight".
 
 - **problem**: The vessel is having a hard time holding on to its
   ``lock steering`` direction during a burn when you have physics

--- a/doc/source/commands/flight/pilot.rst
+++ b/doc/source/commands/flight/pilot.rst
@@ -10,7 +10,7 @@ that these suffixes refer to the player's actual input controls, rather
 than kOS's own controls that are layered on top of them, overriding them.
 
 Please note that the *Breaking Ground DLC* parts that can be configured
-to respond to the throttle, such as electric motors and propellor pitches
+to respond to the throttle, such as electric motors and propeller pitches
 will only respond to the settings described here on this page, and NOT
 the settings described in the :ref:`raw control <raw>` page, or the
 settings in ``lock throttle`` or ``lock steering``.  SQUAD designed
@@ -35,7 +35,7 @@ settings that "stay put" and don't reset to center when the pilot lets
 go of the stick.  For example, while ``PILOTPITCH`` matches whatever
 temporary position the pilot's stick is in, ``PILOTPITCHTRIM`` stays
 where it was last set.  Thus ``PILOTPITCHTRIM`` is settable here,
-while ``PILOTPITCH`` is not.  The docmentation below marks which
+while ``PILOTPITCH`` is not.  The documentation below marks which
 suffixes are indeed set-able.  Through the use of these trim-able
 settings, it is possible to control the ship in a way that still
 lets the pilot temporarily grab the controls for a second to override
@@ -139,7 +139,7 @@ what kOS is doing.
     lets go of the controls.
 
     RP-1 Special Case:  If using the RP-1 mod, and flying a "sounding rocket"
-    where the avionics controls are insuficcient to steer but are good
+    where the avionics controls are insufficient to steer but are good
     enough to ignite engines, then ``lock throttle`` does not work to
     activate those engines, but this suffix can do it.  RP-1 actively
     suppresses the normal ability for an autopilot to control the throttle
@@ -164,7 +164,7 @@ what kOS is doing.
 
     Get-only.
 
-    Returns the pilot's rotation input  about the logintudinal axis of the ship left-wing-down :math:`(-1)` or left-wing-up :math:`(+1)`.
+    Returns the pilot's rotation input  about the longitudinal axis of the ship left-wing-down :math:`(-1)` or left-wing-up :math:`(+1)`.
 
 .. _SHIP CONTROL PILOTROTATION:
 .. object:: SHIP:CONTROL:PILOTROTATION

--- a/doc/source/commands/flight/raw.rst
+++ b/doc/source/commands/flight/raw.rst
@@ -50,7 +50,7 @@ Breaking Ground DLC
 -------------------
 
 Please note that the *Breaking Ground DLC* parts that can be configured
-to respond to the control axes, such as electric motors and propellor
+to respond to the control axes, such as electric motors and propeller
 pitches, will only respond to the settings described on the 
 :ref:`pilot controls page <pilot>` and NOT the settings described
 here on this :ref:`raw control <raw>` page, nor will it respond to
@@ -198,7 +198,7 @@ These "Raw" controls allow you the direct control of flight parameters while the
 
     The reason why this trim does nothing and you have to use the pilot
     trim instead is because KSP only looks at the trim when its part of
-    the *pilot's* own control structure, not an autpilot's control structure.
+    the *pilot's* own control structure, not an autopilot's control structure.
 
     *Warning*:
     Setting this value can cause :ref:`:NEUTRAL <SHIP CONTROL NEUTRAL>` to
@@ -215,7 +215,7 @@ These "Raw" controls allow you the direct control of flight parameters while the
 
     The reason why this trim does nothing and you have to use the pilot
     trim instead is because KSP only looks at the trim when its part of
-    the *pilot's* own control structure, not an autpilot's control structure.
+    the *pilot's* own control structure, not an autopilot's control structure.
 
     *Warning*:
     Setting this value can cause :ref:`NEUTRAL <SHIP CONTROL NEUTRAL>` to
@@ -232,7 +232,7 @@ These "Raw" controls allow you the direct control of flight parameters while the
 
     The reason why this trim does nothing here is because KSP only looks at the
     trim when its part of the *pilot's* own control structure, not an
-    autpilot's control structure.
+    autopilot's control structure.
 
     *Warning*:
     Setting this value can cause :ref:`NEUTRAL <SHIP CONTROL NEUTRAL>` to
@@ -288,7 +288,7 @@ These "Raw" controls allow you the direct control of flight parameters while the
 
     The reason why this trim does nothing here is because KSP only looks at the
     trim when its part of the *pilot's* own control structure, not an
-    autpilot's control structure.
+    autopilot's control structure.
 
     *Warning*:
     Setting this value can cause :ref:`NEUTRAL <SHIP CONTROL NEUTRAL>` to
@@ -305,7 +305,7 @@ These "Raw" controls allow you the direct control of flight parameters while the
 
     The reason why this trim does nothing here is because KSP only looks at the
     trim when its part of the *pilot's* own control structure, not an
-    autpilot's control structure.
+    autopilot's control structure.
 
     *Warning*:
     Setting this value can cause :ref:`NEUTRAL <SHIP CONTROL NEUTRAL>` to
@@ -340,7 +340,7 @@ These "Raw" controls allow you the direct control of flight parameters while the
     The two terms ``NEUTRAL`` and ``NEUTRALIZE`` are synonyms.  (They used to
     be two separate suffixes, one for getting and one for setting, but
     that made no sense so they were combined but both spellings were
-    retained for backward compantiblity with old scripts.)
+    retained for backward compatibility with old scripts.)
 
 
 Unlocking controls

--- a/doc/source/commands/flight/systems.rst
+++ b/doc/source/commands/flight/systems.rst
@@ -34,7 +34,7 @@ RCS and SAS
     :access: Toggle ON/OFF; get/set
     :type: Action Group, :struct:`Boolean`
 
-    Turns the SAS **on** or **off**, like using ``T`` at the keybaord::
+    Turns the SAS **on** or **off**, like using ``T`` at the keyboard::
 
         SAS ON. // same as SET SAS TO TRUE.
         SAS OFF. // same as SET SAS TO FALSE.
@@ -96,7 +96,7 @@ RCS and SAS
 STOCK ACTION GROUPS
 -------------------
 
-    These action groups (including abovementioned :global:`SAS` and
+    These action groups (including above mentioned :global:`SAS` and
     :global:`RCS`) are stored as :struct:`Boolean` values which can be read to
     determine their current state.  Reading their value can be used by kOS as
     a form of user input::
@@ -334,7 +334,7 @@ kOS PSEUDO ACTION GROUPS
     :access: Toggle ON/OFF; get/set
     :type: Action Group, :struct:`Boolean`
 
-    Activates (has effect only on drills that are deployed and in contact with minable surface) or stops all the mining drills::
+    Activates (has effect only on drills that are deployed and in contact with mineable surface) or stops all the mining drills::
 
         DRILLS ON.
 
@@ -345,7 +345,7 @@ kOS PSEUDO ACTION GROUPS
     :access: Toggle ON/OFF; get/set
     :type: Action Group, :struct:`Boolean`
 
-    Activates or deactivates all the fuel cells (distingushed from other conveters by converter/action names)::
+    Activates or deactivates all the fuel cells (distinguished from other converters by converter/action names)::
 
         FUELCELLS ON.
 
@@ -356,7 +356,7 @@ kOS PSEUDO ACTION GROUPS
     :access: Toggle ON/OFF; get/set
     :type: Action Group, :struct:`Boolean`
 
-    Activates or deactivates all the ISRU converters (distingushed from other conveters by converter/action names)::
+    Activates or deactivates all the ISRU converters (distinguished from other converters by converter/action names)::
 
         ISRU ON.
 

--- a/doc/source/commands/list.rst
+++ b/doc/source/commands/list.rst
@@ -18,7 +18,7 @@ Lists need to be iterated over sometimes, to help with this we have the :ref:`FO
         LIST FILES.
 
 2. ``LIST ListKeyword.``
-    This variant prints items to the termianl sceen. Depending on the *ListKeyword* used (see below), different values are printed.
+    This variant prints items to the terminal screen. Depending on the *ListKeyword* used (see below), different values are printed.
 
 3. ``LIST ListKeyword IN YourVariable.``
     This variant takes the items that would otherwise have been printed to the terminal screen, and instead makes a :struct:`List` of them in ``YourVariable``, that you can then iterate over with a :ref:`FOR loop <for>` if you like.

--- a/doc/source/commands/prediction.rst
+++ b/doc/source/commands/prediction.rst
@@ -44,7 +44,7 @@ These return predicted information about the future position and velocity of an 
 
     Returns a prediction of where the :struct:`Orbitable` will be at some :ref:`universal Time <universal_time>`. If the :struct:`Orbitable` is a :struct:`Vessel`, and the :struct:`Vessel` has planned :ref:`maneuver nodes <maneuver node>`, the prediction assumes they will be executed exactly as planned.
 
-    *Refrence Frame:* The reference frame that the future position
+    *Reference Frame:* The reference frame that the future position
     gets returned in is the same reference frame as the current position
     vectors use.  In other words it's in ship:raw coords where the origin
     is the current ``SHIP``'s center of mass.
@@ -60,16 +60,16 @@ These return predicted information about the future position and velocity of an 
     :type orbitable:  :struct:`Orbitable`
     :param time:    Time of prediction
     :type time:     :struct:`TimeStamp` or :struct:`Scalar` universal seconds
-    :return: An :ref:`ObitalVelocity <orbitablevelocity>` structure.
+    :return: An :ref:`OrbitalVelocity <orbitablevelocity>` structure.
 
     Returns a prediction of what the :ref:`Orbitable's <orbitable>` velocity will be at some :ref:`universal Time <universal_time>`. If the :struct:`Orbitable` is a :struct:`Vessel`, and the :struct:`Vessel` has planned :struct:`maneuver nodes <Node>`, the prediction assumes they will be executed exactly as planned.
 
     *Prerequisite:*  If you are in a career mode game rather than a
     sandbox mode game, This function requires that you have your space
-    center's buildings advanced to the point where you can make manuever
+    center's buildings advanced to the point where you can make maneuver
     nodes on the map view, as described in :struct:`Career:CANMAKENODES`.
 
-    *Refrence Frame:* The reference frame that the future velocity gets
+    *Reference Frame:* The reference frame that the future velocity gets
     returned in is the same reference frame as the current velocity
     vectors use.  In other words it's relative to the ship's CURRENT
     body it's orbiting just like ``ship:velocity`` is.  For example,

--- a/doc/source/commands/runprogram.rst
+++ b/doc/source/commands/runprogram.rst
@@ -9,7 +9,7 @@ Running Programs
 
 KerboScript supports running executing code saved in files on the local or
 archive disks. The terms "program" and "script" are generally used
-interchangably when describing this behavior. Programs can either be run using
+interchangeably when describing this behavior. Programs can either be run using
 one of the :ref:`runfunctions` or the :ref:`run`.  Supported file types are:
 
     Raw Text KerboScript files
@@ -25,7 +25,7 @@ one of the :ref:`runfunctions` or the :ref:`run`.  Supported file types are:
 
 .. seealso::
     :ref:`Compiling`
-        An explaination of how scripts are compiled, as well as an explaination
+        An explanation of how scripts are compiled, as well as an explaination
         of how :key:`COMPILE` stores opcodes.
     :ref:`Filename Warning<filename_case_warning>`
         Warning detailing issues with case sensitive host file systems.

--- a/doc/source/downloads_links.rst
+++ b/doc/source/downloads_links.rst
@@ -15,7 +15,7 @@ Obtaining kOS itself
       and check for updates whenever you run it.  kOS sends update information to CKAN
       so kOS updates should appear in your CKAN manager tool as soon as they're released.
     - `Download from github directly <https://github.com/KSP-KOS/KOS/releases>`__
-      Github is where development of the mod occurs, and new releases will apear there
+      Github is where development of the mod occurs, and new releases will appear there
       first, without delays, and its where old obsolete releases can be found, if you
       need one for use with an older version of KSP.
     - `Use SpaceDock <https://spacedock.info/mod/60/kOS:%20Scriptable%20Autopilot%20System>`__

--- a/doc/source/general/boot.rst
+++ b/doc/source/general/boot.rst
@@ -15,7 +15,7 @@ Here's the tl;dr version of how to use a boot file:
   1. Place a kerboscript program file in the archive ``"0:/boot/"``
      directory.  For example, ``"0:/boot/myboot.ks"``.  Make sure
      the file ends in ``.ks``.
-  2. Bring up the vessel into the VAB or SPH.  Rightclick the
+  2. Bring up the vessel into the VAB or SPH.  Right-click the
      kOS computer part, and use the slider widget to select your
      file from step 1 above.
   3. When you save and launch this vessel, it should copy that
@@ -183,7 +183,7 @@ topic.
 Booting when spawning to launchpad
 ----------------------------------
 
-When you first spawn a new vessel on the launchapd from the VAB (or when
+When you first spawn a new vessel on the launchpad from the VAB (or when
 you spawn it to the runway from the SPH), kOS performs the following
 initial steps to get the boot file copied from archive to the ship:
 

--- a/doc/source/general/career_limits.rst
+++ b/doc/source/general/career_limits.rst
@@ -20,14 +20,14 @@ These are rules inherited from the stock KSP game that kOS is simply adhering to
    future orbit patches.
 
 -  If your mission control center AND tracking center are not upgraded enough,
-   then you cannot add manuever nodes.
+   then you cannot add maneuver nodes.
 
 The following are rules invented by kOS that are thematically very similar to stock KSP, intended to be as close to the meaning of the stock game's rules as possible:
 
 -  In order to be allowed to execute the :struct:`PartModule` :DOACTION method, either
    your VAB or your SPH must be upgraded to the point where it will allow access to
    custom action groups.  This is because otherwise the :DOACTION method would be a
-   backdoor "cheat" past the restricted access to the action group feaures of various
+   backdoor "cheat" past the restricted access to the action group features of various
    PartModules that the game is meant to have.
 
 -  In order to be allowed to add a ``nametag`` to parts inside the editor so they get
@@ -94,7 +94,7 @@ Structure
     :access: Get
 
     If your tracking center and mission control buildings are both upgraded enough, then the game allows
-    you to make manuever nodes (which the game calls "flight planning").  This will return true if you
+    you to make maneuver nodes (which the game calls "flight planning").  This will return true if you
     can make maneuver nodes.
 
 .. attribute:: Career:CANDOACTIONS

--- a/doc/source/general/compiling.rst
+++ b/doc/source/general/compiling.rst
@@ -82,7 +82,7 @@ Let's say that you have 3 programs your probe needs, called:
 -  myprog2.ks
 -  myprog3.ks
 
-And that myprog1 calls myprog2 and myprog3, and you normally would call the progam this way::
+And that myprog1 calls myprog2 and myprog3, and you normally would call the program this way::
 
     SWITCH TO 1.
     COPYPATH( "0:/myprog1", "" ).
@@ -141,4 +141,4 @@ Downsides to Using KSM Files
 More Reading and Fiddling with Your Bits
 ----------------------------------------
 
-So, if you are intrigued by all this and want to see how it all *REALLY* works under the hood, Computronix has deciced to make `internal document MLfile-zx1/a <https://github.com/KSP-KOS/KOS/blob/develop/src/kOS.Safe/Compilation/CompiledObject-doc.md>`__ on the basic plan of the ML file system open for public viewing, if you are one of those rare Kerbals that enjoys fiddling with your bits. No, not THOSE kind of bits, the computery kind!
+So, if you are intrigued by all this and want to see how it all *REALLY* works under the hood, Computronix has decided to make `internal document MLfile-zx1/a <https://github.com/KSP-KOS/KOS/blob/develop/src/kOS.Safe/Compilation/CompiledObject-doc.md>`__ on the basic plan of the ML file system open for public viewing, if you are one of those rare Kerbals that enjoys fiddling with your bits. No, not THOSE kind of bits, the computery kind!

--- a/doc/source/general/cpu_hardware.rst
+++ b/doc/source/general/cpu_hardware.rst
@@ -88,7 +88,7 @@ It is important to note that versions of kOS prior to v0.17 executed
 program code during these *update ticks* so they were tied to your 
 animation FPS.  But versions more recent than that started executing
 code on *physics ticks*, as is more proper for the simulation, and
-to make script behvaior more consistent across different computers with
+to make script behavior more consistent across different computers with
 different frame rates.
 
 .. _electricdrain:
@@ -101,7 +101,7 @@ vital to long distance probes.  In these modes the computer deliberately
 runs slowly in order to use less power, and then the program can tell it to
 speed up to normal speed again when it needs to wake up and do something.
 
-Older versions of kOS implemented this concept with a constant electric drain regardless of CPU load.  As of version 0.19.0, this concept is simplified by just draining electric charge by "micropayments" of charge per instruction executed.
+Older versions of kOS implemented this concept with a constant electric drain regardless of CPU load.  As of version 0.19.0, this concept is simplified by just draining electric charge by "micro-payments" of charge per instruction executed.
 
 To change this setting if you want to re-balance the system, see the
 page about :ref:`kOSProcessor part config values <EcPerInstruction>`.
@@ -278,7 +278,7 @@ it rudely interrupted things. Doing that can allow other triggers of
 equal priority to itself to interrupt it again.  To see how this works,
 look at :func:`DROPPRIORITY()`, explained below on this page.  In general,
 however, it's a better idea not to use this unless you fully understand
-how the prioriy system here works.
+how the priority system here works.
 
 Do Not Loop a Long Time in a Trigger Body!
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -307,7 +307,7 @@ it rudely interrupted things. Doing that can allow other triggers of
 equal priority to itself to interrupt it again.  To see how this works,
 look at :func:`DROPPRIORITY()`, explained below on this page.  In general,
 however, it's a better idea not to use this unless you fully understand
-how the prioriy system here works.
+how the priority system here works.
 
 But I Want a Loop!!
 ~~~~~~~~~~~~~~~~~~~
@@ -417,8 +417,8 @@ If you wish, you can cause your trigger, or callback, to deliberately
 relinquish its hold on other interrupts, allowing them to interrupt it
 despite the fact that it is itself in the middle of an interrupt.
 You do this by  deliberately reducing your current priority level
-back down a step to whatever it was prior to being incresed by the
-interrrupt, which is what this special built-in function does:
+back down a step to whatever it was prior to being increased by the
+interrupt, which is what this special built-in function does:
 
 .. function:: DROPPRIORITY()
 
@@ -567,7 +567,7 @@ that runs once per **physics tick**.  (A "FixedUpdate" in Unity3d terms).
 * 1. instructionsExecuted = 0
 * 2. how_many_instructions_this_time = config:IPU plus or minus one. (It
   wavers slightly because doing so can help prevent edge cases where
-  the interrupt triggers syhnc up perfectly with the end of an update
+  the interrupt triggers sync up perfectly with the end of an update
   and thus starve main code.)
   TODO: THIS +/- 1 thing ISN'T TRUE IN THE CODE YET.  I'm WRITING THIS
   DOCUMENT BEFORE I'M IMPLEMENTING THIS.  COME BACK AND REMOVe THIS

--- a/doc/source/general/gui.rst
+++ b/doc/source/general/gui.rst
@@ -6,7 +6,7 @@ Making GUIs in kOS
 .. versionadded:: 1.1.0
 
 Sometimes it is useful to create an in-game set of screen widgets to let
-you interact with the kOS program with mouseclicks.  You can create
+you interact with the kOS program with mouse clicks.  You can create
 GUI widgets in kOS for this purpose, making them as complex or as
 simple as you like.  The widgets will live inside windows that pop
 up on screen as you invoke them.

--- a/doc/source/general/kospartmodule.rst
+++ b/doc/source/general/kospartmodule.rst
@@ -104,7 +104,7 @@ ECPerBytePerSecond:
    - **Type:** float
    - **Default if omitted:** 0.0
    - **Effect:** How much ElectricCharge resource is consumed per
-     byte of disk space avaialable (not just used).
+     byte of disk space available (not just used).
 
 It is possible to make the disk cost more electricity to run the
 bigger it is.  By default this ships as zero, but it can be changed

--- a/doc/source/general/parts_and_partmodules.rst
+++ b/doc/source/general/parts_and_partmodules.rst
@@ -16,7 +16,7 @@ TODO: PUT LINKS POINTING TO A TUTORIAL WALKING THROUGH WHAT THIS IS TEACHING.
 
 THERE NEEDS TO BE TWO TUTORIALS MINIMUM:
 
-1. A Tuturial made on an ONLY STOCK (other than kOS of course) install, using only STOCK parts to do something interesting.
+1. A Tutorial made on an ONLY STOCK (other than kOS of course) install, using only STOCK parts to do something interesting.
 
 2. A Tutorial more complex showing that this can be used with mods too, probably the Leg Leveller example from the teaser video, but with the code updated to use the newer part query methods.
 
@@ -84,7 +84,7 @@ has a length of zero::
 
 Examples::
 
-    // Change the altitude at which all the drouge chutes will deploy:
+    // Change the altitude at which all the drogue chutes will deploy:
     FOR somechute IN somevessel:PARTSNAMED("parachuteDrogue") {
       somechute:GETMODULE("ModuleParachute"):SETFIELD("DEPLOYALTITUDE", 1500).
     }.
@@ -107,7 +107,7 @@ The diagram here shows an example of a small vessel and how it might get represe
 Accessing the parts list as a list
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can get a list of all the parts on a vessel using the suffix :PARTS, or by using the LIST PARTS IN command. When you do this, the resulting list is a "flattening" of the tree of parts, created by use of a depth-first search starting from the root part. In the diagram shown here, the red numbers indicate one possible way the parts might be represented in LIST indeces if you used SHIP:PARTS on such a vessel. Note there is no guarantee it would look exactly like this, as it depends on exactly what order the parts were attached in the VAB.
+You can get a list of all the parts on a vessel using the suffix :PARTS, or by using the LIST PARTS IN command. When you do this, the resulting list is a "flattening" of the tree of parts, created by use of a depth-first search starting from the root part. In the diagram shown here, the red numbers indicate one possible way the parts might be represented in LIST indexes if you used SHIP:PARTS on such a vessel. Note there is no guarantee it would look exactly like this, as it depends on exactly what order the parts were attached in the VAB.
 
 Shortcuts to smaller lists of parts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -127,7 +127,7 @@ Return a List of just the parts that have had some sort of activity attached to 
 PartModules and the right-click menu:
 -------------------------------------
 
-Each Part, in turn has a list of what are called `PartModules <../structures/vessels/partmodule.html>`__ on it. A PartModule is a collection of variables and executable program hooks that gives the part some of its behaviors and properties. Without a PartModule, a part is really nothing more than a passive bit of structure that has nothing more than a shape, a look, and a strength to it. Some of the parts in the "structure" tab of the parts bin, like pure I-beams and girders, are like this - they have no PartModules on them. But all of the *interesting* parts you might want to do something with will have a PartModule on them. Through PartModules, \*\*kOS will now allow you to manipulate or query anything that any KSP programmer, stock or mod, has added to the rightclick menu\*\*, or action group actions, for a part.
+Each Part, in turn has a list of what are called `PartModules <../structures/vessels/partmodule.html>`__ on it. A PartModule is a collection of variables and executable program hooks that gives the part some of its behaviors and properties. Without a PartModule, a part is really nothing more than a passive bit of structure that has nothing more than a shape, a look, and a strength to it. Some of the parts in the "structure" tab of the parts bin, like pure I-beams and girders, are like this - they have no PartModules on them. But all of the *interesting* parts you might want to do something with will have a PartModule on them. Through PartModules, \*\*kOS will now allow you to manipulate or query anything that any KSP programmer, stock or mod, has added to the right-click menu\*\*, or action group actions, for a part.
 
 PartModules, Stock vs Mods:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -179,13 +179,13 @@ This causes the event to execute once.
 KSPActions:
 ~~~~~~~~~~~
 
-A KSPAction is a bit different from a KSPField or KSPEvent. A KSPAction is like a KSPEvent in that it causes some software inside the PartModule to be run. But it doesn't work via the RMB context menu for the part. Instead KSPAction's are those things you see being made avaiable to you as options you can assign into an Action Group in the VAB or SPH. When you have the action group editor tab enabled in the VAB or SPH, and then click on a part, that part asks all of its PartModules if they have any KSPActions they'd like to provide access to, and gathers all those answers and lists them in the user interface for you to select from and assign to the action group.
+A KSPAction is a bit different from a KSPField or KSPEvent. A KSPAction is like a KSPEvent in that it causes some software inside the PartModule to be run. But it doesn't work via the RMB context menu for the part. Instead KSPAction's are those things you see being made available to you as options you can assign into an Action Group in the VAB or SPH. When you have the action group editor tab enabled in the VAB or SPH, and then click on a part, that part asks all of its PartModules if they have any KSPActions they'd like to provide access to, and gathers all those answers and lists them in the user interface for you to select from and assign to the action group.
 
 kOS now allows you to access any of those actions without necessarily having had to assign them to any action groups if you didn't want to.
 
 KSPActions are manipulated by the following suffix of PartModule, called :meth:`PartModule:DoAction`.
 
--  :DOACTION("name of action", new\_boolan\_value).
+-  :DOACTION("name of action", new\_boolean\_value).
 
 The name of the action is the name you see in the action group editor interface, and the new boolean value is either True or False. Unlike KSPEvents, a KSPAction has two states, true and false. When you toggle the brakes, for example, they go from on to off, or from off to on. When you call :DOACTION, you are specifying if the KSPAction should behave as if you have just toggled the group on, or just toggled the group off. But instead of actually toggling an action group - you are just telling the single PartModule on a single Part to perform the same behavior it would have performed had that action been assigned to an action group. You don't *actually* have to assign the action to an action group for this to work.
 
@@ -245,4 +245,4 @@ That this doesn't work anymore after that, and the "Activate" event now causes a
 
 And the reason is that the PartModule chose to change the label on the event. It changed to the word "Deactivate" now. kOS can no longer trigger an event called "Activate" because that's no longer its name.
 
-Be on the lookout for cases like this. Experiment with how the context menu is being manipulated and keep in mind that the list of strings you got the last time you exectued :ALLFIELDS a few minutes ago might not be the same list you'd get if you ran it now, because the PartModule has changed what is being shown on the menu.
+Be on the lookout for cases like this. Experiment with how the context menu is being manipulated and keep in mind that the list of strings you got the last time you executed :ALLFIELDS a few minutes ago might not be the same list you'd get if you ran it now, because the PartModule has changed what is being shown on the menu.

--- a/doc/source/general/skid.rst
+++ b/doc/source/general/skid.rst
@@ -4,7 +4,7 @@
 Using the Sound/Kerbal Interface Device (SKID)
 ==============================================
 
-A hidden feature shippped with all kOS CPU's was uncovered recently.
+A hidden feature shipped with all kOS CPU's was uncovered recently.
 It turns out all kOS CPU's come with a so-called SKID chip
 (Sound/Kerbal Interface Device).  This little integrated chip can
 send audio data through the terminal lines and play the sounds on
@@ -212,7 +212,7 @@ such as a drum, that is incapable of holding a sustained note and
 instead just fades right away whenever you hit a note:
 
 * Attack = 0.0s
-* Decay = 0.2s   (Note decays immediatly on being struck)
+* Decay = 0.2s   (Note decays immediately on being struck)
 * Sustain = 0.0  (and it decays to zero, so you can't "hold" the note).
 * Release = 0.0s (Because Sustain is zero, this setting doesn't matter).
 
@@ -504,7 +504,7 @@ object using the :func:`Note()` built-in function, or the
     // if you have the voice's RELEASE value set to zero.):
     SET N2 to SLIDENOTE("A4", "A5", 0.25, 0.3).
 
-Once a note has been constructed, it's components are not changable.  The
+Once a note has been constructed, it's components are not changeable.  The
 only way to change the note is to make a new note and use it to overwrite
 the previous note.
 

--- a/doc/source/general/telnet.rst
+++ b/doc/source/general/telnet.rst
@@ -174,7 +174,7 @@ Using it
    of them type "st", then the other types "age", followed by the first person
    typing "." and the return key.)  All the keyboards and all the screens are
    slaved together to be equal.  You can view the in-game gui terminal while 
-   somebody is typing on a telnet temrinal.
+   somebody is typing on a telnet terminal.
 
 9. In order to make the terminals act as clones of each other, the game will attempt
    to keep them all the same size.  If you resize your telnet client window, it should
@@ -191,7 +191,7 @@ Using it
   effectively "argue" back and forth with each other, constantly changing each
   other's size.   If you experience this problem (your terminal window will be
   flipping back and forth between two different sizes, resizing itself over and over
-  again in a neverending loop), you can try to get out of it by issuing a hardcoded
+  again in a never-ending loop), you can try to get out of it by issuing a hardcoded
   command to set the terminal size, such as::
 
     SET TERMINAL:WIDTH TO 50.

--- a/doc/source/general/volumes.rst
+++ b/doc/source/general/volumes.rst
@@ -133,13 +133,13 @@ volume but with the following exceptions:
 
 -  It is globally the same even across save games.
 -  The archive represents the large bank of disk storage back at mission
-   control's mainframe, rather than the storage on an indivdual craft.
+   control's mainframe, rather than the storage on an individual craft.
    While "Volume 1" on one vessel might be a different disk than "Volume
    1" on another vessel, there is only one volume called "archive" in the
    entire solar system. Also, there's only one "archive" across all
    saved universes. If you play a new campaign from scratch, your
    archive in that new game will still have all the files in it from
-   your previous saved game. This is because behid the scenes it's
+   your previous saved game. This is because behind the scenes it's
    stored in the ``Ships/Script`` directory, not the save game directory.
 -  It is infinitely large.
 -  Unlike the other volumes, the archive volume does not have a byte

--- a/doc/source/language/delegates.rst
+++ b/doc/source/language/delegates.rst
@@ -263,7 +263,7 @@ Can't call dead delegates
 -------------------------
 
 You might store a KOSDelegate in a global variable.
-Global varibles continue existing even after all the programs
+Global variables continue existing even after all the programs
 are done and you are back at the terminal interpreter.
 
 This makes it possible to have a (global) variable 

--- a/doc/source/language/features.rst
+++ b/doc/source/language/features.rst
@@ -125,7 +125,7 @@ that the whole expression will be true anyway.
 A similar short circuiting happens with AND.  Once the left side of the
 AND operator is false, then the entire AND expression is guaranteed
 to be false regardless of what's on the right side, so kerboscript
-doesn't bother calculating the righthand side once the lefthand side is false.
+doesn't bother calculating the right-hand side once the left-hand side is false.
 
 Read the link above for implications of why this matters in programming.
 
@@ -211,7 +211,7 @@ The full list of available suffixes for each type :ref:`can be found here <struc
 Triggers
 --------
 
-One useful feature of kerboscript (but a potentialy confusing one for 
+One useful feature of kerboscript (but a potentially confusing one for
 people new to the language, so we don't recommend you use it at
 first) is the "trigger". Triggers are small sections of your program
 that can interrupt your normal program flow when certain things

--- a/doc/source/language/flow.rst
+++ b/doc/source/language/flow.rst
@@ -67,7 +67,7 @@ Checks if the expression supplied returns true. If it does, ``IF`` executes the 
 CHOOSE (Ternary operator)
 -------------------------
 
-An expression that evalualtes to one of two choices depending on a
+An expression that evaluates to one of two choices depending on a
 conditional check:
 
    CHOOSE expression1 IF condition ELSE expression2
@@ -152,7 +152,7 @@ Note that if you are creating a loop in which you are watching a physical value 
     SET PREV_TIME to TIME:SECONDS.
     SET PREV_VEL to SHIP:VELOCITY.
     SET ACCEL to V(9999,9999,9999).
-    PRINT "Waiting for accellerations to stop.".
+    PRINT "Waiting for accelerations to stop.".
     UNTIL ACCEL:MAG < 0.5 {
         SET ACCEL TO (SHIP:VELOCITY - PREV_VEL) / (TIME:SECONDS - PREV_TIME).
         SET PREV_TIME to TIME:SECONDS.
@@ -261,7 +261,7 @@ What the parts mean
     only one statement present.  To create a null FROM clause, give
     it an empty set of braces.
 
-- ``DO`` one statement or a block of statements inside braxes ``{``..``}``:
+- ``DO`` one statement or a block of statements inside braces ``{``..``}``:
 
   - This is where the loop body gets put.  Much like with the UNTIL and FOR
     loops, these braces are not mandatory when there is only exactly one
@@ -555,7 +555,7 @@ Here is the difference between them:
   notices the condition is true, the trigger fires and it performs
   the statements. The condition to check for must be a boolean
   expression.
-- ``ON`` statement: When kOS checks it in the backround, if it
+- ``ON`` statement: When kOS checks it in the background, if it
   notices the expression *is now different from what it was the last
   time it checked*, the trigger fires and it performs the statements.
   The condition to check for can be any expression for which it
@@ -672,7 +672,7 @@ backward compatibility, of using the ``preserve`` keyword.
 Preserving with ``return``
 ::::::::::::::::::::::::::
 
-Triggers are essentialy functions that don't quite look like functions.
+Triggers are essentially functions that don't quite look like functions.
 They are frequently called, but they're not called *by you*.  They're
 called by the Kerbal Operating System itself.  So you can tell the
 Kerbal Operating System what your intentions were by simply deciding

--- a/doc/source/language/syntax.rst
+++ b/doc/source/language/syntax.rst
@@ -41,21 +41,21 @@ operator symbols:
     * ``not`` -> ``not A`` Logical inversion of A.  Due to the high precedence,
       if A is some complex expression you may need to write this with brackets
       as ``not(A)`` in kerboscript to make it parse right.
-    * ``=``, <>``, ``>=``, ``<=``, ``>``, ``<`` -> Comparitors.  Note
+    * ``=``, <>``, ``>=``, ``<=``, ``>``, ``<`` -> Comparators.  Note
       that equals and not-equals are different than in some common languages:
 
-        * The equals comparitor is a single character ``=`` not a double-equal ``==``.
-        * The not-equal comparitor is ``<>`` not ``!=``.
+        * The equals comparator is a single character ``=`` not a double-equal ``==``.
+        * The not-equal comparator is ``<>`` not ``!=``.
 
-    * ``and`` -> Logical AND of two Boolean expresssions.
-    * ``or`` -> Logical OR of two Boolean expresssions.
+    * ``and`` -> Logical AND of two Boolean expressions.
+    * ``or`` -> Logical OR of two Boolean expressions.
       
 ** Logic constants**: all logic operators return one of these, and you may assign them to variables:
 
-    * ``false`` -> (case insensitive, so can be writtedn as False, FALSE, etc)
+    * ``false`` -> (case insensitive, so can be written as False, FALSE, etc)
     * ``true`` -> (case insensitive, so can be written as True, TRUE, etc)
     * Although not a recommended programming style to use, numbers used in a
-      logic context get interpreted as Boolean values followng the typical
+      logic context get interpreted as Boolean values following the typical
       rule that zero is ``false`` and anything other than zero is ``true``.
 
 **Instructions and Keywords**::
@@ -114,7 +114,7 @@ The rest may be letters, digits or underscores.
     Kerboscript accepts Unicode source code, encoded using the UTF-8
     encoding method.  Because of this, the definition of a "letter"
     character for an identifier includes letters from many languages'
-    alphabets, including accented Latin alphabet characters, Cyrllic
+    alphabets, including accented Latin alphabet characters, Cyrillic
     characters, etc.  Not all languages have been tested but in
     principle they should work as long as they have a Unicode standard
     accepted definition of what counts as a "letter".  We defer to
@@ -161,7 +161,7 @@ Numbers (scalars)
 -----------------
 
 Numbers in kerboscript are referred to as "scalars", to distinguish
-them from the many cases where a values will be represnted
+them from the many cases where a values will be represented
 as a vectors.  You are allowed to use integers, decimal fractional numbers
 (numbers with a decimal point and a fractional part), and scientific
 notation numbers.
@@ -176,7 +176,7 @@ The following are valid scalar syntax::
    1.123e12
    1.234e-12
 
-Kerobscript does not support imaginary numbers or irrational numbers
+Kerboscript does not support imaginary numbers or irrational numbers
 or rational numbers that cannot be represented as a finite decimal
 (i.e.  sqrt(-1) returns a Not-a-Number error.  Pi will have to be
 an approximation.  "One third", ends up being something like 0.333333333).)
@@ -283,7 +283,7 @@ an alternate way to get the value for a key, as in the example below::
     print MyLex:key1.    // key used in an alternate way as a "suffix".
 
 There are some limits to using this syntax, as described in more detail
-:ref:`in the documentation for the Lexion type <lexicon_suffix>`.
+:ref:`in the documentation for the Lexicon type <lexicon_suffix>`.
 
 .. _syntax functions:
 

--- a/doc/source/language/user_functions.rst
+++ b/doc/source/language/user_functions.rst
@@ -295,7 +295,7 @@ in the ``PARAMETER`` statement, like in the examples below::
     MYFUNC(1,2,3,"hi").  // prints "1, 2, 3, hi".
 
 Whenever arguments are missing, the system always makes up the difference by
-using defaults for the lastmost parameters until the correct number have been
+using defaults for the rightmost parameters until the correct number have been
 padded.  (So for example, if you call MYFUNC() above with 3 arguments, it's
 the last argument, P4, that gets defaulted, but P3 does not.  But if you call
 it with 2 arguments, both P4 and P3 get defaulted.)
@@ -333,7 +333,7 @@ live in and the memory the interpreter's pseudo-machine
 language instructions live in are two different things.
 
 The effect you may see if you attempt this is merely
-an "Unknown Identifer" error, or worse yet, it may end
+an "Unknown Identifier" error, or worse yet, it may end
 up jumping into random parts of your code that have nothing
 to do with the actual function call you're trying to
 make.

--- a/doc/source/language/variables.rst
+++ b/doc/source/language/variables.rst
@@ -234,7 +234,7 @@ function optional by defaulting them to a starting value with the ``IS`` keyword
     runpath(MYPROG,1,2,3,"hi").  // also prints "1, 2, 3, hi".
 
 Whenever arguments are missing, the system always makes up the difference by
-using defaults for the lastmost parameters until the correct number have been
+using defaults for the rightmost parameters until the correct number have been
 padded.  (So for example, if you call MYFUNC() above with 3 arguments, it's
 the last argument, P4, that gets defaulted, but P3 does not.  But if you call
 it with 2 arguments, both P4 and P3 get defaulted.)
@@ -580,7 +580,7 @@ program files::
     @CLOBBERBUILTINS on.
 
 This is a compiler directive that *MUST* occur at the top of the file,
-and the only other things that are allowed to preceed it are
+and the only other things that are allowed to precede it are
 comments, blanks, and other compiler directives such as
 :ref:`@LAZYGLOBAL <lazyglobal>`.
 
@@ -686,7 +686,7 @@ Explicit scoping keywords
 The ``DECLARE``, ``FUNCTION``, and ``LOCK`` commands can be given
 explicit ``GLOBAL`` or ``LOCAL`` keywords to define their intended
 scoping level (however in the case of functions, ``GLOBAL`` will be
-igorned, see above under 'Presumed defaults'.)::
+ignored, see above under 'Presumed defaults'.)::
 
     //
     // These are all synonymous with each other:
@@ -796,7 +796,7 @@ and
 
   - ON <any expression> { <statements> }.
 
-Can use local variables in their trigger expressions in thier
+Can use local variables in their trigger expressions in their
 headers or in the statements of their bodies.  The local scope
 they were declared inside of stays present as part of their
 "closure".
@@ -826,7 +826,7 @@ Example::
 .. note::
     .. versionadded:: 1.1.0
         In the past, triggers such as WHEN and ON were not
-        able to use local variables in their check condintions.
+        able to use local variables in their check conditions.
         They had to use only global variables in order to
         be trigger-able after the local scope goes away.  Now
         these triggers preserve their "closure scope" so they

--- a/doc/source/math/basic.rst
+++ b/doc/source/math/basic.rst
@@ -344,7 +344,7 @@ Mathematical Functions
         }
 
     The parameter ``key`` is a string, and it's used when you want
-    to track separate psuedo-random number sequences by name and 
+    to track separate pseudo-random number sequences by name and
     have them be deterministically repeatable. *Like other
     string keys in kOS, this key is case-insensitive.*
 
@@ -399,7 +399,7 @@ Mathematical Functions
     Initializes a new random number sequence from a seed, giving it a
     key name you can use to refer to it in future calls to :func:`RANDOM(key)`
 
-    Using this you can make psuedo-random number sequences that can be
+    Using this you can make pseudo-random number sequences that can be
     re-run using the same seed to get the same result a second time.
 
     Parameter ``key`` is a string - a name you can use to refer to this
@@ -414,7 +414,7 @@ Mathematical Functions
 
     Whenever you call ``RANDOMSEED(key, seed)``, it starts a new
     random number sequence using the integer seed you give it, and names
-    that sequence with a string key you can use later to retrive
+    that sequence with a string key you can use later to retrieve
     values from that random number sequence.
 
     Example::

--- a/doc/source/math/direction.rst
+++ b/doc/source/math/direction.rst
@@ -67,7 +67,7 @@ Creation
 
 .. function:: LOOKDIRUP(lookAt,lookUp)
 
-    A :struct:`Direction` can be created with the LOOKDIRUP function by using two vectors.   This is like converting a vector to a direction directly, except that it also provides roll information, which a single vector lacks.   *lookAt* is a vector describing the Direction's FORE orientation (its local Z axis), and *lookUp* is a vector describing the direction's TOP orientation (its local Y axis).  Note that *lookAt* and *lookUp* need not actually be perpendicualr to each other - they just need to be non-parallel in some way.  When they are not perpendicular, then a vector resulting from projecting *lookUp* into the plane that is normal to *lookAt* will be used as the effective *lookUp* instead::
+    A :struct:`Direction` can be created with the LOOKDIRUP function by using two vectors.   This is like converting a vector to a direction directly, except that it also provides roll information, which a single vector lacks.   *lookAt* is a vector describing the Direction's FORE orientation (its local Z axis), and *lookUp* is a vector describing the direction's TOP orientation (its local Y axis).  Note that *lookAt* and *lookUp* need not actually be perpendicular to each other - they just need to be non-parallel in some way.  When they are not perpendicular, then a vector resulting from projecting *lookUp* into the plane that is normal to *lookAt* will be used as the effective *lookUp* instead::
 
         // Aim up the SOI's north axis (V(0,1,0)), rolling the roof to point to the sun.
         LOCK STEERING TO LOOKDIRUP( V(0,1,0), SUN:POSITION ).

--- a/doc/source/math/geocoordinates.rst
+++ b/doc/source/math/geocoordinates.rst
@@ -154,7 +154,7 @@ Structure
     the actual surface at this latitude and longitude.  It will calculate as if you had some
     point fixed to the ground, like an imaginary tower bolted to the surface, but not at the
     ground's altitude.  (The body's rotation will impart a larger magnitude linear velocity
-    on a locaton affixed to the body the farther that location is from the body's center).
+    on a location affixed to the body the farther that location is from the body's center).
 
 Example Usage
 -------------

--- a/doc/source/math/scalar.rst
+++ b/doc/source/math/scalar.rst
@@ -77,7 +77,7 @@ The following basic arithmetic operators are defined when both ``a`` and
     * - ``-a``
       - negative of ``a``
     * - ``a * b`` ``a / b``
-      - muiltiply or divide two numbers
+      - multiply or divide two numbers
     * - ``a + b`` ``a - b``
       - add or subtract two numbers
 

--- a/doc/source/structures/celestial_bodies/atmosphere.rst
+++ b/doc/source/structures/celestial_bodies/atmosphere.rst
@@ -52,7 +52,7 @@ can't change the value of a body's atmosphere.
           - pressure at sea level
         * - :meth:`ALTITUDEPRESSURE(altitude)`
           - :struct:`Scalar` (atm)
-          - pressure at the givel altitude
+          - pressure at the given altitude
         * - :attr:`HEIGHT`
           - :struct:`Scalar` (m)
           - advertised atmospheric height

--- a/doc/source/structures/collections/lexicon.rst
+++ b/doc/source/structures/collections/lexicon.rst
@@ -374,7 +374,7 @@ Structure
     attribute that shows a list of all the suffixes on the structure,
     but for Lexicons the SUFFIXNAMES attribute has been altered so
     that it will additionally include any keys of the suffix that could
-    be callled using the :ref:`lexicon suffix syntax <lexicon_suffix>`.
+    be called using the :ref:`lexicon suffix syntax <lexicon_suffix>`.
 
 Access to Individual Elements
 -----------------------------
@@ -387,7 +387,7 @@ Access to Individual Elements
 Implicit ADD when using index brackets with new key values
 ----------------------------------------------------------
 
-**(a.k.a. The difference between GETTING and SETTING with nonexistant keys)**
+**(a.k.a. The difference between GETTING and SETTING with nonexistent keys)**
 
 If you attempt to use a key that does not exist in the lexicon, to
 GET a value, as follows::

--- a/doc/source/structures/collections/list.rst
+++ b/doc/source/structures/collections/list.rst
@@ -20,7 +20,7 @@ into it to pre-populate the list with an initial list of items:
     set mylist to list(10,20,30).
     // Make a list with 3 strings in it:
     set mylist to list("10","20","30").
-    // Make a two dimensional 2x3 list with heterogenious contents
+    // Make a two dimensional 2x3 list with heterogeneous contents
     // mixing strings and numbers:
     set mylist to list( list("a","b","c"), list(1,2,3) ).
 
@@ -151,7 +151,7 @@ Structure
     :return: :struct:`Scalar`
 
     This is the same as :meth:`FIND(item)`, except that it searches
-    backward instead of forward through the list.  It finds the lastmost
+    backward instead of forward through the list.  It finds the last
     element that is equal to the item.
 
 .. method:: List:LASTINDEXOF(item)
@@ -170,7 +170,7 @@ All list indexes start counting at zero. (The list elements are numbered from 0 
 ``ITERATOR``
     An alternate means of iterating over a list. See :struct:`Iterator`.
 ``list#x`` *(deprecated)*
-    operator: access the element at postion x. Works for get or set. X must be a hardcoded number or a variable name. This is here for backward compatibility. The syntax in the next bullet point is preferred over this.
+    operator: access the element at position x. Works for get or set. X must be a hardcoded number or a variable name. This is here for backward compatibility. The syntax in the next bullet point is preferred over this.
 
 Examples::
 

--- a/doc/source/structures/communication/connection.rst
+++ b/doc/source/structures/communication/connection.rst
@@ -58,7 +58,7 @@ Structure
           as the current CPU, and will be false otherwise.
     - For Vessel connections:
         - If you are using Stock KSP and chose the PermitAll connectivity
-          manager, then this will aways return true.
+          manager, then this will always return true.
         - If you are using Stock KSP and chose the CommNet connectivity
           manager, then this will obey the rules of the stock CommNet system
           for whether a connection path exists between the source and
@@ -103,7 +103,7 @@ Structure
     - For vessel connections:
 	- If you are using the PermitAll Connectivity Manager, then this
 	  will always be zero, as messages arrive instantly.
-	- If you are using the stock CommNet Connectivirty Manager, then this
+	- If you are using the stock CommNet Connectivity Manager, then this
 	  will always be zero, as stock CommNet does not impose any delay
 	  from radio signals.
 	- If you are using the RemoteTech Connectivity Manager, then this

--- a/doc/source/structures/communication/message.rst
+++ b/doc/source/structures/communication/message.rst
@@ -86,7 +86,7 @@ Structure
     :type: :struct:`Boolean`
 
     Because there can be a delay between when the message was sent and
-    when it was processed by the receiving script, it's possibile that
+    when it was processed by the receiving script, it's possible that
     the vessel that sent the message might not exist anymore.  It could
     have either exploded, or been recovered, or been merged into another
     vessel via docking.  You can check the value of the ``:HASSENDER``

--- a/doc/source/structures/gui.rst
+++ b/doc/source/structures/gui.rst
@@ -36,7 +36,7 @@ by your program changing a value) are a type of trigger, and thus run at a
 "higher priority" than normal code.  You don't need to think too hard about
 this right now, but the effect of it is that by default one gui callback
 cannot trigger while another one is running.  There are ways to change this
-but they require a more in-depth discusion of how the kOS CPU works with
+but they require a more in-depth discussion of how the kOS CPU works with
 triggers, and are thus :ref:`described elsewhere on the
 general CPU hardware description page<drop_priority>`.
 

--- a/doc/source/structures/gui_widgets/button.rst
+++ b/doc/source/structures/gui_widgets/button.rst
@@ -142,7 +142,7 @@ Button
         you to use the :ref:`callback technique <gui_callback_technique>` of widget
         interaction.
 
-        The ``ONTOGGLE`` delegate you assign will get called whenver kOS notices
+        The ``ONTOGGLE`` delegate you assign will get called whenever kOS notices
         that this button has changed from false to true or from true to false.
 
         To use ``ONTOGGLE``, your function must be written to expect a single boolean parameter,

--- a/doc/source/structures/gui_widgets/gui.rst
+++ b/doc/source/structures/gui_widgets/gui.rst
@@ -41,7 +41,7 @@ GUI structure
 
         You can alter this value to move the window.
 
-        If you use a negative value for the coordinate, then the coordiante will be
+        If you use a negative value for the coordinate, then the coordinate will be
         measured in the reverse direction, from the right edge of the screen.  (i.e.
         setting it to -200 means 200 pixels away from the right edge of the screen.)
 
@@ -54,7 +54,7 @@ GUI structure
 
         You can alter this value to move the window.
 
-        If you use a negative value for the coordinate, then the coordiante will be
+        If you use a negative value for the coordinate, then the coordinate will be
         measured in the reverse direction, from the bottom edge of the screen.  (i.e.
         setting it to -200 means 200 pixels away from the bottom edge of the screen.)
 
@@ -81,7 +81,7 @@ GUI structure
         your GUI will work under a signal delay you can use this suffix to
         force a simulated additional signal delay even if you are not using
         RemoteTech.  (Or when you are using RemoteTech but are testing your GUI in
-        situations where there isn't a noticable signal delay, like in Kerbin
+        situations where there isn't a noticeable signal delay, like in Kerbin
         low orbit).
 
     .. attribute:: SKIN

--- a/doc/source/structures/gui_widgets/label.rst
+++ b/doc/source/structures/gui_widgets/label.rst
@@ -98,7 +98,7 @@ supported.  The list of supported tags is shown below:
 - **<color=name>string</color>** - Selects a color, which can be expressed
   by name, and is assumed to be opaque.
 - **<color=#nnnnnnnn>string</color>** - Selects a color, expressed using
-  8 hexidecimal digits in pairs representing red, green, blue, and alpha.
+  8 hexadecimal digits in pairs representing red, green, blue, and alpha.
   (For example, all red, fully opaque would be ``#ff0000ff``, while all-red
   half-transparent would be ``#ff000080``.)
 

--- a/doc/source/structures/gui_widgets/scrollbox.rst
+++ b/doc/source/structures/gui_widgets/scrollbox.rst
@@ -7,7 +7,7 @@ Scrollbox
 
     ``ScrollBox`` objects are created by using :meth:`BOX:ADDSCROLLBOX`.
 
-    A scollbox is a box who's contents can be bigger than it is, accessable
+    A scollbox is a box who's contents can be bigger than it is, accessible
     via scrollbars.
 
     To constrain the actual size of the box, you can use the ``:style``

--- a/doc/source/structures/gui_widgets/slider.rst
+++ b/doc/source/structures/gui_widgets/slider.rst
@@ -38,13 +38,13 @@ Slider
         :type: :struct:`KOSDelegate`
         :access: Get/Set
 
-        This :struct:`KOSDelegate` takes one parmaeter, the value, and returns nothing.
+        This :struct:`KOSDelegate` takes one parameter, the value, and returns nothing.
 
         This allows you to set a callback delegate to be called
         whenever the user has moved the slider to a new
         value.  Note that as the user moves the slider
         to a new position, this will get called several
-        times along the way, giving sevearl intermediate
+        times along the way, giving several intermediate
         values on the way to the final value the user leaves
         the slider at.
 
@@ -89,7 +89,7 @@ Slider
         
         Note that despite the name, :attr:`MIN` doesn't have to be smaller
         than :attr:`MAX`.  If :attr:`MIN` is larger than :attr:`MAX`, then
-        that causes the slider to swapr their meaning, and reverse its direction.
+        that causes the slider to swap their meaning, and reverse its direction.
         (i.e. where numbers normally get larger when you slide to the right,
         inverting MIN and MAX causes the numbers to get larger when you
         slide to the left.)

--- a/doc/source/structures/gui_widgets/spacing.rst
+++ b/doc/source/structures/gui_widgets/spacing.rst
@@ -25,5 +25,5 @@ Spacing
         :access: Get/Set
 
         The number of pixels for this spacing to take up.  Whether this
-        is horizontal or vertial space depends on whether this is being
+        is horizontal or vertical space depends on whether this is being
         added to a horizontal-layout box or a vertical-layout box.

--- a/doc/source/structures/gui_widgets/tipdisplay.rst
+++ b/doc/source/structures/gui_widgets/tipdisplay.rst
@@ -26,11 +26,11 @@ TipDisplay
     suffixes that :struct:`Label` has.  The only special thing it does
     is that it:
 
-    - Has its own style, called "tipDisplay", which can get seperate style
+    - Has its own style, called "tipDisplay", which can get separate style
       settings.
     - Has its :attr:`TEXT` value automatically populated by the Tooltips
       of the other widgets you hover over, within limits.  If no such hover
-      text is avaiable, or the mouse isn't over a supported widget type,
+      text is available, or the mouse isn't over a supported widget type,
       then the :attr:`TEXT` field will be an empty string (``""``).
 
     Please be aware that Unity3d's IMGUI system does not support Tooltips

--- a/doc/source/structures/gui_widgets/widget.rst
+++ b/doc/source/structures/gui_widgets/widget.rst
@@ -72,7 +72,7 @@ Widget
 
         Note that the showing of a widget requires the showing of all widgets
         it's contained inside of.  Hiding a widget will hide all widgets inside
-        it, regardless of their infividual visibility settings.  This is what
+        it, regardless of their individual visibility settings.  This is what
         is happening when you make a :struct:`GUI` Box with a call to :func:`GUI`,
         fill it with widgets, and then show it.  The widgets inside it were already
         set to "visible", but their visibility was suppressed by the fact that
@@ -84,7 +84,7 @@ Widget
 
         (no parameters, no return value)
 
-        Call ``Widget:DISPOSE()`` to permanenly make this widget go away.
+        Call ``Widget:DISPOSE()`` to permanently make this widget go away.
         Not only will it make it invisible, but it will make it impossible
         to set it to visible again later.
 
@@ -128,7 +128,7 @@ Widget
 	:type: :struct:`GUI`
 	:access: Get-only
 
-	To be useful, all widgets (buttons, labels, textfields, etc) must
+	To be useful, all widgets (buttons, labels, text fields, etc) must
 	either be contained inside a :struct:`GUI` widget directly, or be
 	contained inside another :struct:`Widget` which in turn is also
 	contained inside a :struct:`GUI` widget.  (Or contained inside

--- a/doc/source/structures/misc/config.rst
+++ b/doc/source/structures/misc/config.rst
@@ -128,7 +128,7 @@ Configuration of kOS
 
     Configures the ``InstructionsPerUpdate`` setting.
 
-    This is the number of kRISC psuedo-machine-language instructions that each kOS CPU will attempt to execute from the main program per :ref:`physics update tick <cpu hardware>`.
+    This is the number of kRISC pseudo-machine-language instructions that each kOS CPU will attempt to execute from the main program per :ref:`physics update tick <cpu hardware>`.
 
     This value is constrained to stay within the range [50..2000]. If you set it to a value outside that range, it will reset itself to remain in that range.
 
@@ -200,7 +200,7 @@ Configuration of kOS
     :type: :struct:`Boolean`
 
     Setting this config option to TRUE will allow scripts to clobber
-    built-in idenifier names, re-enabling older behavior for backward
+    built-in identifier names, re-enabling older behavior for backward
     compatibility and disabling the compiler enforcement that was
     introduced in kOS v 1.4.0.0 to stop this practice.
 
@@ -215,7 +215,7 @@ Configuration of kOS
     enabled to make the compiler accept them and not throw errors.
 
     Before enabling this to make the error messages go away, first consider
-    going through the offeding script and editing it to rename the variable,
+    going through the offending script and editing it to rename the variable,
     lock, or function that is causing the message.  That would be the better
     solution.  This config option is only being presented as a dirty way
     to make old scripts that are no longer being edited keep working on
@@ -236,7 +236,7 @@ Configuration of kOS
     Configures the ``audibleExceptions`` setting.
 
     If true, then it enables a mode in which errors coming from kOS will
-    generte a sound effect of a short little warning bleep to remind you that
+    generate a sound effect of a short little warning bleep to remind you that
     an exception occurred.  This can be useful when you are flying
     hands-off and need to realize your autopilot script just died so
     

--- a/doc/source/structures/misc/loaddistance.rst
+++ b/doc/source/structures/misc/loaddistance.rst
@@ -105,7 +105,7 @@ Vessel Load Distance
     game to think things have collided together when they haven't.  This
     is the classic "space kraken" that KSP players talk about a lot.  Computer
     floating point numbers get less precise the farther from zero they are.
-    So allowing the game to try to perform microcalculations on tiny time
+    So allowing the game to try to perform micro-calculations on tiny time
     scales using floating point numbers that have imprecision because they are
     large in magnitude (i.e. the positions of parts that are many kilometers
     away from you), can cause phantom collisions, which make the game
@@ -170,7 +170,7 @@ Each of the above
   :struct:`SituationLoadDistance` is what is returned by each of the
   above suffixes mentioned in the LoadDistance suffix list above.
 
-  **Order Matters.** - Becuse of the protections in place to prevent
+  **Order Matters.** - Because of the protections in place to prevent
   you from setting some values bigger than others (see the descriptions
   below), sometimes the order in which you change the values matters
   and you have to be careful to change them in the correct order, or

--- a/doc/source/structures/misc/pidloop.rst
+++ b/doc/source/structures/misc/pidloop.rst
@@ -25,7 +25,7 @@ PID stands for "Proportional, Integral, Derivative".  It tracks
 the thing you are measuring and how it changes over time, and
 uses that to decide how you should set the control.
 
-The kOS documenation has a 
+The kOS documentation has a
 :ref:`tutorial about what PID loops are <pidloops>` that goes over the
 general principles and shows code examples of how to create your
 own PID loop with your own script code.
@@ -39,7 +39,7 @@ read the :ref:`tutorial about what PID loops are <pidloops>` first.
 Constructors
 ------------
 
-The `PIDLoop` constructor function has a number of parametres, and
+The `PIDLoop` constructor function has a number of parameters, and
 they can be left off, leaving optional defaults.
 
 The full version is this::
@@ -86,7 +86,7 @@ Examples
     // minoutput = minimum number value
     SET PID TO PIDLOOP().
 
-    // Create a PIDLoop with a few stated paremeters:
+    // Create a PIDLoop with a few stated parameters:
     SET PID TO PIDLOOP(2.5).
     SET PID TO PIDLOOP(2.0, 0.05, 0.1).
     SET PID TO PIDLOOP(2.0, 0.05, 0.1, -1, 1).
@@ -179,7 +179,7 @@ Version (B)::
   set ctrl to myPid:UPDATE(time:seconds, measurement).
 
 Actually, with kOS's PIDLoop, the second version, Version(B), works a bit better
-and should be preferred.  The reason is that when calcualting the D term,
+and should be preferred.  The reason is that when calculating the D term,
 :struct:`PIDLoop` uses the change in the raw measure, not the error of the
 the measure, to calculate the rate of change of the value.  This becomes
 relevant when your script suddenly changes its mind what the target value is
@@ -336,7 +336,7 @@ Structure
     :type: :struct:`Scalar`
     :access: Get only
 
-    The value representing the time weighted sum of all errrors.  It will be equal to :attr:`ITERM` / :attr:`KI`.  This value is adjusted by the integral windup mitigation logic.
+    The value representing the time weighted sum of all errors.  It will be equal to :attr:`ITERM` / :attr:`KI`.  This value is adjusted by the integral windup mitigation logic.
 
 .. attribute:: PIDLoop:PTERM
 

--- a/doc/source/structures/misc/steeringmanager.rst
+++ b/doc/source/structures/misc/steeringmanager.rst
@@ -36,7 +36,7 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
     :attr:`YAWTS`                        :struct:`Scalar` (s)      Settling time for the yaw torque calculation.
     :attr:`ROLLTS`                       :struct:`Scalar` (s)      Settling time for the roll torque calculation.
     :attr:`TORQUEEPSILONMIN`             :struct:`Scalar` (s)      Torque deadzone when not rotating at max rate
-    :attr:`TORQUEEPSILONMAX`             :struct:`Scalar` (s)      Torquw deadzone when rotating at max roatation rate
+    :attr:`TORQUEEPSILONMAX`             :struct:`Scalar` (s)      Torque deadzone when rotating at max rotation rate
     :attr:`MAXSTOPPINGTIME`              :struct:`Scalar` (s)      The maximum amount of stopping time to limit angular turn rate.
     :attr:`ROLLCONTROLANGLERANGE`        :struct:`Scalar` (deg)    The maximum value of :attr:`ANGLEERROR` for which to control roll.
     :attr:`ANGLEERROR`                   :struct:`Scalar` (deg)    The angle between vessel:facing and target directions
@@ -195,7 +195,7 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
     If you have problems wasting too much RCS propellant because kOS
     "cares too much" about getting the rotation rate exactly right and is
     wiggling the controls unnecessarily when rotating toward a new direction,
-    setting thie value a bit higher can help.
+    setting this value a bit higher can help.
 
     You cannot set this value lower than
     :attr:`SteeringManager:TORQUEEPSILONMIN`.
@@ -268,7 +268,7 @@ The SteeringManager is a bound variable, not a suffix to a specific vessel.  Thi
     which kOS will attempt to respond to error along the roll axis.  If this
     is set to 5 (the default value), the facing direction will need to be within
     5 degrees of the target direction before it actually attempts to roll the
-    ship.  Setting the value to 180 will effectivelly allow roll control at any
+    ship.  Setting the value to 180 will effectively allow roll control at any
     error amount.  When :attr:`ANGLEERROR<SteeringManager:ANGLEERROR>` is
     greater than this value, kOS will only attempt to kill all roll angular
     velocity.  The value is clamped between 180 and 1e-16.

--- a/doc/source/structures/misc/string.rst
+++ b/doc/source/structures/misc/string.rst
@@ -42,7 +42,7 @@ as in the example below::
   }
 
 The reason you can use Strings with the FOR loop like this is
-because you can obatain an :struct:`Iterator` of a string with the
+because you can obtain an :struct:`Iterator` of a string with the
 :attr:`ITERATOR` suffix mentioned below.  (Any type that
 implements the ITERATOR suffix can do this.)
 
@@ -89,8 +89,8 @@ Ordering
 Using the ``<``, ``>``, ``<=``, and ``>=`` operators, one
 string is considered to be less than the other if it is alphabetically
 sooner according to the ordering of its Unicode mapping, with the
-exception that capitalization is ingored (``a`` and ``A`` are
-considered the same letter).  Starting from the lefthand side of the
+exception that capitalization is ignored (``a`` and ``A`` are
+considered the same letter).  Starting from the left-hand side of the
 two strings, the characters are compered one at a time until the first
 difference is found, and that first difference decides the ordering.
 If one of the strings is shorter length than the other, and the characters
@@ -124,7 +124,7 @@ CASE SENSITIVIY
 
 NOTE: All string comparisons for equality and ordering, all substring
 matches, all pattern matches, and all string searches, are currently
-case **in** sensive, meaning that for example the letter "A" and the
+case **in** sensitive, meaning that for example the letter "A" and the
 letter "a" are indistinguishable.  There are future plans to add
 mechanisms that will let you choose case-sensitivity when you prefer.
 
@@ -361,7 +361,7 @@ Structure
 .. method:: String:REPLACE(oldString,newString)
 
     :parameter oldString: :struct:`String` to search for
-    :parameter newString: :struct:`String` that all occurances of oldString will be replaced with
+    :parameter newString: :struct:`String` that all occurrences of oldString will be replaced with
     :type: :struct:`String`
 
     Returns a new string out of this string with any occurrences of oldString replaced with newString.

--- a/doc/source/structures/misc/time.rst
+++ b/doc/source/structures/misc/time.rst
@@ -20,7 +20,7 @@ of time, and can show you that time divided up into years, days,
 hours, minutes, and seconds.
 
 **Differences between ``TimeStamp`` and ``TimeSpan``**:
-The diference is that :struct:`TimeStamp` is for storing a single
+The difference is that :struct:`TimeStamp` is for storing a single
 point in time, while :struct:`TimeSpan` is for
 storing an offset, or duration of time.  Where they differ is in
 what it means to call something "year 1" or "day 1".  ``TimeStamp``
@@ -38,7 +38,7 @@ Mixing TimeStamp with TimeSpan
 ------------------------------
 
 There are rules for how you can mix and match :struct:`TimeStamp` and 
-:struct:`TimeSpan` in artithmetic and boolean comparisons.  (For example
+:struct:`TimeSpan` in arithmetic and boolean comparisons.  (For example
 if you add a :struct:`TimeSpan` to a :struct:`TimeStamp` you get a new
 :struct:`TimeStamp`.)  The full rules for these operations are listed
 in the :ref:`Time operators <time_operators>` section further down this page.
@@ -289,7 +289,7 @@ TimeStamp Structure
     :type: :struct:`Scalar`
 
     Year-hand number.  Note that the first year of the game, at "epoch"
-    time is actullay year 1, not year 0.
+    time is actually year 1, not year 0.
 
 .. attribute:: TimeStamp:DAY
 
@@ -466,7 +466,7 @@ TimeSpan Structure
           - :struct:`Scalar`
           - *TOTAL* time in the span expressed in years.
         * - :attr:`DAY`
-          - :struct:`Scalar` (range vaires by universe)
+          - :struct:`Scalar` (range varies by universe)
           - Whole number of days after the last whole year in the span.
         * - :attr:`DAYS`
           - :struct:`Scalar` 
@@ -561,7 +561,7 @@ TimeSpan Structure
     Whole number of days remaining after the lst full year within the span.
     Kerbin has 426 days in a year if using Kerbin's
     6 hour day (one fourth as much if if :attr:`Kuniverse:HOURSPERDAY`
-    is 24 meaning the game is configured to show Earthlike days not
+    is 24 meaning the game is configured to show Earth-like days not
     Kerbin days.
 
     The range of possible values could be different if you have mods
@@ -643,7 +643,7 @@ TimeSpan Structure
     :access: Get only
     :type: :struct:`Scalar` (float)
 
-    *TOTAL* Seconds in the TimeSpan, including fractonal part.  Note
+    *TOTAL* Seconds in the TimeSpan, including fractional part.  Note
     this is NOT the same as :attr:`TimeSpan:SECOND` (singular),
     because this is the total span of time expressed in seconds,
     and not just the leftover seconds in the last minute of the span.
@@ -759,7 +759,7 @@ Example::
   // This sets C to 22 minutes 30 seconds (half of 45 minutes):
   set C to A / 2.
 
-Time Opertators - comparisons
+Time Operators - comparisons
 -----------------------------
 
 You may check if two TimeStamps are equal, greater, or lesser.

--- a/doc/source/structures/misc/timewarp.rst
+++ b/doc/source/structures/misc/timewarp.rst
@@ -156,7 +156,7 @@ Suffixes
 
     Time warp as an integer index.  In the tables listed above for
     :attr:`RAILSRATELIST<TimeWarp:RAILSRATELIST>` and :attr:`PHYSICSRATELIST<TimeWarp:PHYSICSRATELIST>`, this is the number
-    on the lefthand side of those tables.  (i.e. if
+    on the left-hand side of those tables.  (i.e. if
     :attr:`MODE<TimeWarp:MODE>` is "RAILS" and :attr:`RATE<TimeWarp:RATE>` is 50, then that means
     :attr:`WARP<TimeWarp:WARP>` is 3.)
 
@@ -209,7 +209,7 @@ Suffixes
     Note, the game is actually capable of warping at arbitrary rates
     in between these values, and it does so temporarily when transitioning
     to a new warp rate, but it doesn't allow you to hold the rate at those
-    in-between values indefintiely.
+    in-between values indefinitely.
 
 
 .. method:: TimeWarp:WARPTO(timestamp)
@@ -232,7 +232,7 @@ Suffixes
     :access: Method
     :return: None
 
-    Call this method to cancel any active warp.  This will both interupt any
+    Call this method to cancel any active warp.  This will both interrupt any
     current automated warp (such as one using :meth:`WARPTO<TimeWarp:WARPTO>`
     or the "Warp Here" user interface) and a manual warp setting (as if you had
     used the ``SET WARP TO 0.`` command).

--- a/doc/source/structures/misc/vecdraw.rst
+++ b/doc/source/structures/misc/vecdraw.rst
@@ -78,7 +78,7 @@ Drawing Vectors on the Screen
     :attr:`VecDraw:COLORUPDATER`, instead of :attr:`VecDraw:COLOR`.
 
     All the parameters of the ``VECDRAW()`` and ``VECDRAWARGS()`` are
-    optional.  You can leave any of the lastmost parameters off and they
+    optional.  You can leave any of the rightmost parameters off and they
     will be given a default::
 
         Set anArrow TO VECDRAW().
@@ -115,7 +115,7 @@ Drawing Vectors on the Screen
 
         // Makes a red vecdraw at the origin, pointing 5 meters north,
         // with defaults for the un-mentioned
-        // paramters LABEL, SCALE, SHOW, and WIDTH.
+        // parameters LABEL, SCALE, SHOW, and WIDTH.
         SET vd TO VECDRAW(V(0,0,0), 5*north:vector, red).
 
     To make a :struct:`VecDraw` disappear, you can either set its :attr:`VecDraw:SHOW` to false or just :ref:`UNSET <unset>` the variable, or re-assign it. An example using :struct:`VecDraw` can be seen in the documentation for :func:`POSITIONAT()`.
@@ -130,7 +130,7 @@ Drawing Vectors on the Screen
     present anymore to access the variables that hold them.  The system
     does attempt to clear any vecdraws that go "out of scope", however
     the "closures" that keep local variables alive for LOCK statements
-    and for other reasons can keep them from every truely going away
+    and for other reasons can keep them from every truly going away
     in some circumstances.  To make the arrow drawings all go away, just call
     CLEARVECDRAWS() and it will have the same effect as if you had
     done ``SET varname:show to FALSE`` for all vecdraw varnames in the
@@ -280,7 +280,7 @@ Suffixes of Vecdraw
     :access: Get/Set
     :type: :struct:`Scalar`
 
-    Define the width of the drawn line, in meters.  The deafult is 0.2 if
+    Define the width of the drawn line, in meters.  The default is 0.2 if
     left off.  Note, this also causes the font of the label to be enlarged
     to match if set to a value larger than 0.2.
 

--- a/doc/source/structures/orbits/eta.rst
+++ b/doc/source/structures/orbits/eta.rst
@@ -68,10 +68,10 @@ on an Orbit, and can be obtained one of two ways:
 
     Also be aware that in the stock KSP game (things may be different
     if you install a mod like Principia that changes the orbital
-    calculation model) ``ETA:APOAPSIS`` can be decieving when looking at
+    calculation model) ``ETA:APOAPSIS`` can be deceiving when looking at
     some large orbits.  kOS will only return the fake bignum
     ``3.402823E+38`` for those orbits that are mathematically *actual*
-    hyperbolic escape tragectories, not the orbits that are elliptical
+    hyperbolic escape trajectories, not the orbits that are elliptical
     but the game still lets them escape anyway because of the limits of the
     Sphere of Influence model.
 
@@ -98,7 +98,7 @@ on an Orbit, and can be obtained one of two ways:
     :type: :struct:`Scalar` (s)
     :access: Get only
 
-    Seconds until the next manuever node's timestamp.  NOTE this is the
+    Seconds until the next maneuver node's timestamp.  NOTE this is the
     time shown on the navball for the maneuver node, and does not
     take into account the lead time shown on the navball.
     
@@ -116,9 +116,9 @@ on an Orbit, and can be obtained one of two ways:
     :access: Get only
 
     Seconds until the transition from this orbit patch to the next one.
-    This ignores the effect of any intervening manuever nodes it might
+    This ignores the effect of any intervening maneuver nodes it might
     hit before it gets there. (This will be the path you would follow
-    if you never execute any of those manuever nodes.)
+    if you never execute any of those maneuver nodes.)
 
     If there *is* no next transition (you are on a closed loop that
     will not exit the current sphere of influence), this will

--- a/doc/source/structures/orbits/orbit.rst
+++ b/doc/source/structures/orbits/orbit.rst
@@ -28,7 +28,7 @@ either a :struct:`Vessel` or a :struct:`Body`.  This could be useful when
 you want to be able to get information about a hypothetical orbit that
 an object may someday end up in, even when its not in that orbit now.  One
 case where this may be useful is when trying to place a satellite into a
-desired final orbit (say to fufill a contract).  You may wish to see some
+desired final orbit (say to fulfill a contract).  You may wish to see some
 information about that destination orbit even though no particular objects
 are in that orbit at the moment.  To do this you can create an :struct`Orbit`
 object using the ``CREATEORBIT()`` function described below.  You pass in
@@ -219,7 +219,7 @@ Structure
     :type: :struct:`Scalar` (deg)
     :access: Get only
 
-    The Longitude of the ascening node is the "celestial longitude" where
+    The Longitude of the ascending node is the "celestial longitude" where
     the orbit crosses the body's equator from its southern hemisphere to
     its northern hemisphere
 
@@ -412,7 +412,7 @@ Structure
 .. _true anomaly: http://en.wikipedia.org/wiki/True_anomaly
 .. _mean anomaly: http://en.wikipedia.org/wiki/Mean_anomaly
 
-Both :attr:`NEXTPATCH <Orbit:NEXTPATCH>` and :attr:`HASNEXTPATCH <Orbit:HASNEXTPATCH>` both only operate on the **current** momentum of the object, and do **not** take into account any potential changes planned with maneuver nodes. To see the possible new path you would have if a maneuver node gets executed exactly as planned, you need to first get the orbit that follows the manuever node, by looking at the maneuver node's :attr:`:ORBIT <ManeuverNode:ORBIT>` suffix, and then look at **its** :attr:`:NEXTPATCH <Orbit:NEXTPATCH>` and :attr:`:HASNEXTPATCH <Orbit:HASNEXTPATCH>`.
+Both :attr:`NEXTPATCH <Orbit:NEXTPATCH>` and :attr:`HASNEXTPATCH <Orbit:HASNEXTPATCH>` both only operate on the **current** momentum of the object, and do **not** take into account any potential changes planned with maneuver nodes. To see the possible new path you would have if a maneuver node gets executed exactly as planned, you need to first get the orbit that follows the maneuver node, by looking at the maneuver node's :attr:`:ORBIT <ManeuverNode:ORBIT>` suffix, and then look at **its** :attr:`:NEXTPATCH <Orbit:NEXTPATCH>` and :attr:`:HASNEXTPATCH <Orbit:HASNEXTPATCH>`.
 
 Deprecated Suffix
 -----------------
@@ -446,4 +446,4 @@ ESCAPE
     Means that this orbit will enter a new SOI of another orbital body that is larger in scope and is "outside" the current one. (example: currently in Kerbin orbit, will enter Sun Orbit.)
 
 MANEUVER
-    Means that this orbit will end due to a manuever node that starts a new orbit?
+    Means that this orbit will end due to a maneuver node that starts a new orbit?

--- a/doc/source/structures/orbits/orbitablevelocity.rst
+++ b/doc/source/structures/orbits/orbitablevelocity.rst
@@ -3,7 +3,7 @@
 OrbitableVelocity
 =================
 
-When any :struct:`Orbitable` object returns its :attr:`VELOCITY <Orbitable:VELOCITY>` suffix, it returns it as a structure containing a pair of both its orbit-frame velocity and its surface-frame velocity at the same instant of time. To obtain its velocity as a vector you must pick whether you want the oribtal or surface velocities by giving a further suffix:
+When any :struct:`Orbitable` object returns its :attr:`VELOCITY <Orbitable:VELOCITY>` suffix, it returns it as a structure containing a pair of both its orbit-frame velocity and its surface-frame velocity at the same instant of time. To obtain its velocity as a vector you must pick whether you want the orbital or surface velocities by giving a further suffix:
 
 .. structure:: OrbitableVelocity::
 

--- a/doc/source/structures/reflection.rst
+++ b/doc/source/structures/reflection.rst
@@ -3,7 +3,7 @@
 Reflection
 ==========
 
-"Reflection" refers to the act of a program being self-referrential
+"Reflection" refers to the act of a program being self-referential
 by examining information about itself.  Kerboscript does not provide
 the full reflection characteristics of some languages, but it does
 allow a few reflection-like abilities via its generic Structure type.

--- a/doc/source/structures/reflection/structure.rst
+++ b/doc/source/structures/reflection/structure.rst
@@ -182,7 +182,7 @@ or ``42`` or ``"abc"``.  For example, you can do::
         print x:typename
         Body
 
-    The kOS types described in these documentaion pages correspond
+    The kOS types described in these documentation pages correspond
     one-to-one with underlying types in the C# code the implements
     them.  However they don't have the same name as the underlying 
     C# names.  This returns an abstraction of the C# name.  There

--- a/doc/source/structures/vessels/bounds.rst
+++ b/doc/source/structures/vessels/bounds.rst
@@ -98,7 +98,7 @@ visually on screen:
 
 :ref:`Click here for an example program that displays bounds <display_bounds>`
 
-Trying that first (without necessarily understaand it right away)
+Trying that first (without necessarily understand it right away)
 will help give you a visual guide to what is happening here.
 
 A Part:BOUNDS or Vessel:BOUNDS will move and rotate with the object
@@ -178,9 +178,9 @@ it keeps re-correcting itself to that objects orientation for you
 every time you use it.
 
 The expense of calling ``Part:BOUNDS`` isn't that bad and calling it
-repeatedly probably won't really make your script suffer noticably.
+repeatedly probably won't really make your script suffer noticeably.
 But when you do it for the whole vessel, calling ``Vessel:BOUNDS``
-repeatedly, that can definitely result in noticable unnecessary
+repeatedly, that can definitely result in noticeable unnecessary
 computations being done by your computer.
 
 For a more in-depth explanation of why it's expensive to re-call
@@ -226,11 +226,11 @@ A list of events that can make a ``Bounds`` become incorrect:
   inside the vessel needs to be recalculated (see above list).
   In addition, the items on the following list will require a
   Vessel's Bounds (but not individual parts' bounds) to be
-  recaculated:
+  recalculated:
 
     * Anything that adds/removes parts obviously alters the
       bounding box of the vessel.  These are examples but not an
-      exhuastive list:
+      exhaustive list:
 
 	* Docking and Undocking
 	* Decoupling stages
@@ -310,7 +310,7 @@ for completeness.
 Obviously, a bounds box you make manually yourself this way does not
 have the "magic" linkage to a vessel or part that the ones kOS makes have,
 and therefore its position is more fixed in space unless your script
-manually re-assignes its properties.
+manually re-assigns its properties.
 
 Diagram
 -------
@@ -641,7 +641,7 @@ illustrate what is being talked about:
 
     Note that the vector in the inverse direction of this one (that you'd
     get by multiplying it by -1), points from the center to
-    the oppposite corner, the :attr:`Bounds:RELMIN`.
+    the opposite corner, the :attr:`Bounds:RELMIN`.
 
 .. attribute:: Bounds:SIZE
 
@@ -658,7 +658,7 @@ illustrate what is being talked about:
 .. method:: Bounds:FURTHESTCORNER(ray)
 
     :parameter ray: The "that-a-way" :struct:`Vector` in absolute (ship-raw) reference frame.
-    :return: :struct:`Vector` in absolute (ship-raw) referece frame.
+    :return: :struct:`Vector` in absolute (ship-raw) reference frame.
 
     Returns the position (in absolute (ship-raw) reference frame) of
     whichever of the 8 corners of this bounding box is "furthest" in
@@ -687,7 +687,7 @@ illustrate what is being talked about:
         local my_left is -ship:facing:starvector.
         local leftmost is ves_box:furthestcorner(my_left).
         print "In order to go around the other vessel, to the left, ".
-        pritn "I would need to shift myself this far to my left:".
+        print "I would need to shift myself this far to my left:".
         print vdot(-ship:facing:starvector, leftmost).
     
 .. attribute:: Bounds:BOTTOMALT
@@ -703,7 +703,7 @@ illustrate what is being talked about:
     body to decide which body is the one that defines the bounding
     box's "downward" direction for picking its bottom-most corner,
     and it uses that same body to decide what counts as "altitude",
-    regardless of wether the bounds box is a bounds box of the current
+    regardless of whether the bounds box is a bounds box of the current
     CPU vessel or something else.
 
     To put it another way: You can't "read" what the altitude of a
@@ -739,7 +739,7 @@ Side topic - what is a bounding box and how does kOS know about it?
 -------------------------------------------------------------------
 
 A bounding box is a rectangular box around an item that represents the
-smallest space that contains all verteces of the item yet is still
+smallest space that contains all vertices of the item yet is still
 shaped like a box.  It is common in graphics and video games for the
 GPU and/or game engine to maintain information about the bounding boxes
 of items in the game.  Knowing this information is part of what they
@@ -764,7 +764,7 @@ frame.  This is vital for the game engine's needs, as the speedy quick
 bounding box intersection tests work by doing simple greater-than
 and less-than tests of the coordinates.  This means the box will also be
 "too big" if the item is rotated from the world's XYZ axes, as the
-world-aligned box has to accomodate the item's "diagonal" corners pushing
+world-aligned box has to accommodate the item's "diagonal" corners pushing
 the box bigger.  For the purposes of a graphics engine, that's fine, since
 erring on the side of a too-big bounding box is okay, since it's nothing
 more than a time savings to short-circuit work, and not the final say-so

--- a/doc/source/structures/vessels/core.rst
+++ b/doc/source/structures/vessels/core.rst
@@ -77,4 +77,4 @@ Core represents your ability to identify and interact directly with the running 
     :type: :struct:`MessageQueue`
     :access: Get only
 
-    Returns this processsor's message queue.
+    Returns this processor's message queue.

--- a/doc/source/structures/vessels/deltav.rst
+++ b/doc/source/structures/vessels/deltav.rst
@@ -7,7 +7,7 @@ A :struct:`DeltaV` contains information about the delta-V
 numbers the stock KSP game calculates for you in the
 user interface (in the staging list display).  There are in
 fact two different kinds of DeltaV structures in kOS - one
-that refers to the whole veseel, or one that refers to just
+that refers to the whole vessel, or one that refers to just
 one stage of the vessel.
 
 You can obtain a DeltaV about the sum of the whole vessel
@@ -66,7 +66,7 @@ DeltaV Structure
         * - :attr:`CURRENT`
           - :struct:`Scalar`
           - Get only
-          - How much DeltaV (meters/second) at curent atmospheric conditions?
+          - How much DeltaV (meters/second) at current atmospheric conditions?
         * - :attr:`ASL`
           - :struct:`Scalar`
           - Get only
@@ -156,7 +156,7 @@ DeltaV Structure
 
     After calling FORCECALC(), the deltaV values you see will be quite
     wrong for a few update ticks, while the game calculates the new values.
-    Unfortunately, there isn't a good way for a kerobscript to find out
+    Unfortunately, there isn't a good way for a kerboscript to find out
     when the answer is final and the recalculation is over.  (Sorry, we
     tried, but couldn't find the API call in KSP that would tell us this.)
 

--- a/doc/source/structures/vessels/element.rst
+++ b/doc/source/structures/vessels/element.rst
@@ -17,7 +17,7 @@ Each item of that list is one of the elements.  The rest of this page describes 
 elements and what they do.
 
 .. note::
-        Element boundries are not formed between two docking ports that were launched coupled. a craft with such an arrangement will appear as one element until you uncoupled the nodes and redocked
+        Element boundaries are not formed between two docking ports that were launched coupled. a craft with such an arrangement will appear as one element until you uncoupled the nodes and redocked
 
 .. structure:: Element
 
@@ -29,7 +29,7 @@ elements and what they do.
     :attr:`PARTS`                         :struct:`List`            all :struct:`Parts <Part>`
     :attr:`DOCKINGPORTS`                  :struct:`List`            all :struct:`DockingPorts <DockingPort>`
     :attr:`VESSEL`                        :struct:`Vessel`          the parent :struct:`Vessel`
-    :attr:`RESOURCES`                     :struct:`List`            all :struct:`AggrgateResources <AggregateResource>`
+    :attr:`RESOURCES`                     :struct:`List`            all :struct:`AggregateResources <AggregateResource>`
     ===================================== ========================= =============
 
 .. attribute:: Element:UID

--- a/doc/source/structures/vessels/engine.rst
+++ b/doc/source/structures/vessels/engine.rst
@@ -79,7 +79,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
           - Synonym for VACUUMISP
         * - :attr:`SEALEVELISP`
           - :struct:`Scalar`
-          - `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_ at Kerbin sealevel
+          - `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_ at Kerbin sea level
         * - :attr:`SLISP`
           - :struct:`Scalar`
           - Synonym for SEALEVELISP
@@ -177,7 +177,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
     widget that pops up when you right-click the engine will automatically
     round it to the nearest 0.5 whenever you open the panel.  So if you
     do something like ``set ship:part[20]:thrustlimit to 10.5123.`` in
-    your script, then look at the rightclick menu for the engine, the very
+    your script, then look at the right-click menu for the engine, the very
     act of just looking at the menu will cause it to become 10.5 instead 
     of 10.5123.  There isn't much that kOS can do to change this.  It's a
     user interface decision baked into the stock game.
@@ -198,7 +198,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
     :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
     :type: :struct:`Scalar` (kN)
 
-    How much thrust would this engine give if both the throttle and thrust limtier was max at the current velocity, and at the given atmospheric pressure.  Use a pressure of 0.0 for vacuum, and 1.0 for sea level (on Kerbin) (or more than 1 for thicker atmospheres like on Eve). Note that this will read zero if the engine is currently disabled.
+    How much thrust would this engine give if both the throttle and thrust limiter was max at the current velocity, and at the given atmospheric pressure.  Use a pressure of 0.0 for vacuum, and 1.0 for sea level (on Kerbin) (or more than 1 for thicker atmospheres like on Eve). Note that this will read zero if the engine is currently disabled.
     (Pressure must be greater than or equal to zero.  If you pass in a
     negative value, it will be treated as if you had given a zero instead.)
 
@@ -314,7 +314,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
     :access: Get only
     :type: :struct:`Scalar`
 
-    `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_ at Kerbin sealevel.
+    `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_ at Kerbin sea level.
 
 .. attribute:: Engine:SLISP
 
@@ -377,25 +377,25 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
     :access: Get only
     :type: :struct:`String`
 
-    Name of the current mode. Only assessible for multi-mode engines.
+    Name of the current mode. Only accessible for multi-mode engines.
 
 .. method:: Engine:TOGGLEMODE
 
-    Call to switch to another mode. Only assessible for multi-mode engines.  
+    Call to switch to another mode. Only accessible for multi-mode engines.
 
 .. attribute:: Engine:PRIMARYMODE
 
     :access: Get/Set
     :type: :struct:`Boolean`
 
-    True for primary mode, false for secondary. Setting to other value equals toggling the mode. Only assessible for multi-mode engines. 
+    True for primary mode, false for secondary. Setting to other value equals toggling the mode. Only accessible for multi-mode engines.
 
 .. attribute:: Engine:AUTOSWITCH
 
     :access: Get/Set
     :type: :struct:`Boolean`
 
-    Is automatic switching enabled? Can set to switch between manual and automatic switching. Only assessible for multi-mode engines. 
+    Is automatic switching enabled? Can set to switch between manual and automatic switching. Only accessible for multi-mode engines.
 
 .. attribute:: Engine:HASGIMBAL
 
@@ -424,7 +424,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type E
     :access: Get only
     :type: :struct:`Scalar`
     
-    If RealFuels is installed, returns the fuel stability of this engine as a value between 0 and 1 (where 1 is fullly stable), otherwise returns 1.
+    If RealFuels is installed, returns the fuel stability of this engine as a value between 0 and 1 (where 1 is fully stable), otherwise returns 1.
     Engines that don't require ullage will always return 1, unless they are pressure fed and the feed pressure is too low.
 
 .. attribute:: Engine:PRESSUREFED

--- a/doc/source/structures/vessels/gimbal.rst
+++ b/doc/source/structures/vessels/gimbal.rst
@@ -64,7 +64,7 @@ Many engines in KSP have thrust vectoring gimbals which are handled by their own
 .. note::
 
     :struct:`Gimbal` is a type of :struct:`PartModule`, and therefore can use all the suffixes of :struct:`PartModule`. Shown below are only the suffixes that are unique to :struct:`Gimbal`.
-    :struct:`Gimbal` can be accessed as :attr:`Engine:GIMBAL` atribute of  :struct:`Engine`.
+    :struct:`Gimbal` can be accessed as :attr:`Engine:GIMBAL` attribute of  :struct:`Engine`.
 
 .. attribute:: Gimbal:LOCK
 

--- a/doc/source/structures/vessels/node.rst
+++ b/doc/source/structures/vessels/node.rst
@@ -44,7 +44,7 @@ Creation
 
     You can make a maneuver node in a variable using the :func:`NODE` function.
     The radial, normal, and prograde parameters represent the 3 axes you can
-    adjust on the manuever node.  The time parameter represents when the node
+    adjust on the maneuver node.  The time parameter represents when the node
     is along a vessel's path.  The time parameter has two different possible
     meanings depending on what kind of value you pass in for it.  It's either
     an absolute time since the game started, or it's a relative time (ETA)
@@ -161,7 +161,7 @@ Structure
 
         PRINT X:PROGRADE. // prints 100.
         PRINT X:ETA.      // prints seconds till maneuver
-        PRINT X:TIME.     // prints exact UT time of manuever
+        PRINT X:TIME.     // prints exact UT time of maneuver
         PRINT X:DELTAV    // prints delta-v vector
 
         REMOVE X.         // remove node from flight plan

--- a/doc/source/structures/vessels/part.rst
+++ b/doc/source/structures/vessels/part.rst
@@ -542,7 +542,7 @@ These are the generic properties every PART has. You can obtain a list of values
 
 .. method:: Part:PARTSTITLEDPATTERN(titlePattern)
 
-    :parameter titlePattern: (:struct:`String`) Patern of the title of the parts
+    :parameter titlePattern: (:struct:`String`) Pattern of the title of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
     Same as :meth:`Vessel:PARTSTITLEDPATTERN(titlePattern)` except that this version

--- a/doc/source/structures/vessels/partmodule.rst
+++ b/doc/source/structures/vessels/partmodule.rst
@@ -130,13 +130,13 @@ Once you have a :struct:`PartModule`, you can use it to invoke the behaviors tha
     :parameter name: (:struct:`String`) Name of the field
     :return: varies
 
-    Get the value of one of the fields that this PartModule has placed onto the rightclick menu for the part. Note the Security comments below.
+    Get the value of one of the fields that this PartModule has placed onto the right-click menu for the part. Note the Security comments below.
 
 .. method:: PartModule:SETFIELD(name,value)
 
     :parameter name: (:struct:`String`) Name of the field
 
-    Set the value of one of the fields that this PartModule has placed onto the rightclick menu for the part. Note the Security comments below.
+    Set the value of one of the fields that this PartModule has placed onto the right-click menu for the part. Note the Security comments below.
 
     WARNING: This suffix is only settable for parts attached to the :ref:`CPU Vessel <cpu vessel>`
 
@@ -157,7 +157,7 @@ Once you have a :struct:`PartModule`, you can use it to invoke the behaviors tha
 
     :parameter name: (:struct:`String`) Name of the event
 
-    Trigger an "event button" that is on the rightclick part menu at the moment. Note the Security comments below.
+    Trigger an "event button" that is on the right-click part menu at the moment. Note the Security comments below.
 
     WARNING: This suffix is only callable for parts attached to the :ref:`CPU Vessel <cpu vessel>`
 
@@ -196,7 +196,7 @@ Once you have a :struct:`PartModule`, you can use it to invoke the behaviors tha
 Notes
 -----
 
-In all the above cases where there is a name being passed in to :GETFIELD, :SETFIELD, :DOEVENT, or :DOACTION, the name is meant to be the name that is seen by you, the user, in the GUI screen, and NOT necessarily the actual name of the variable that the programmer of that PartModule chose to call the value behind the scenes. This is so that you can view the GUI rightclick menu to see what to call things in your script.
+In all the above cases where there is a name being passed in to :GETFIELD, :SETFIELD, :DOEVENT, or :DOACTION, the name is meant to be the name that is seen by you, the user, in the GUI screen, and NOT necessarily the actual name of the variable that the programmer of that PartModule chose to call the value behind the scenes. This is so that you can view the GUI right-click menu to see what to call things in your script.
 
 .. note::
 
@@ -239,10 +239,10 @@ Is this an action that the KSP user would have been allowed to set as part of an
 
     **If a KSPField, KSPEvent, or KSPAction has been disallowed, often in kOS it won't even appear to be a field of the PartModule at all.**
 
-    This is necessary because for some modules, the number of fields you can use are far outnumberd by the number of fields that exist but are normally hidden from view. It would become unworkable if all of the unusable ones were exposed to kOS scripts to see as fields.
+    This is necessary because for some modules, the number of fields you can use are far outnumbered by the number of fields that exist but are normally hidden from view. It would become unworkable if all of the unusable ones were exposed to kOS scripts to see as fields.
 
 .. note::
 
     **Which KSPFields, KSPEvents, and KSPActions exist on a PartModule can change during runtime!**
 
-    A PartModule is allowed to change the look and feel of its rightclick menu fields on the fly as the game runs. Therefore a field that didn't exist the last time you looked might now exist, and might not exist again next time. The list of what fields exist is context dependant. For example, a docking port may have an event button on it called "Undock Node", that only exists when that port is connected to another port. If it's not connected, the button may be gone. Similarly, a PartModule might toggle something by using a pair of two events that swap in and out depending on the current state. For example, many of the stock lights in the game have a "Turn on" button that after it's been clicked, gets replaced with a "Turn off" button until it's clicked again. A boolean toggle with a KSPFIeld would be simpler, but until "tweakables" existed in the main game, that wasn't an option so a lot of older Partmodules still do things the old way with two KSPEvents that swap in and out.
+    A PartModule is allowed to change the look and feel of its right-click menu fields on the fly as the game runs. Therefore a field that didn't exist the last time you looked might now exist, and might not exist again next time. The list of what fields exist is context dependant. For example, a docking port may have an event button on it called "Undock Node", that only exists when that port is connected to another port. If it's not connected, the button may be gone. Similarly, a PartModule might toggle something by using a pair of two events that swap in and out depending on the current state. For example, many of the stock lights in the game have a "Turn on" button that after it's been clicked, gets replaced with a "Turn off" button until it's clicked again. A boolean toggle with a KSPField would be simpler, but until "tweakables" existed in the main game, that wasn't an option so a lot of older Partmodules still do things the old way with two KSPEvents that swap in and out.

--- a/doc/source/structures/vessels/rcs.rst
+++ b/doc/source/structures/vessels/rcs.rst
@@ -90,7 +90,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type R
           - Synonym for VACUUMISP
         * - :attr:`SEALEVELISP`
           - :struct:`Scalar`
-          - `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_ at Kerbin sealevel
+          - `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_ at Kerbin sea level
         * - :attr:`SLISP`
           - :struct:`Scalar`
           - Synonym for SEALEVELISP
@@ -190,7 +190,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type R
     widget that pops up when you right-click the rcs will automatically
     round it to the nearest 0.5 whenever you open the panel.  So if you
     do something like ``set ship:part[20]:thrustlimit to 10.5123.`` in
-    your script, then look at the rightclick menu for the rcs, the very
+    your script, then look at the right-click menu for the rcs, the very
     act of just looking at the menu will cause it to become 10.5 instead
     of 10.5123.  There isn't much that kOS can do to change this.  It's a
     user interface decision baked into the stock game.
@@ -267,7 +267,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type R
     :access: Get only
     :type: :struct:`Scalar` (kN)
 
-    How much thrust would this rcs thruster give at its current atmospheric pressure if one of the control axes that activates it (yaw, pitch, roll, fore, aft, or top) was maxxed, and the thrust limiter was max at 100%.  Note this might not be the thruster's actual max thrust it could have under other air pressure conditions.  Some thrusters have a very different value for MAXTHRUST in vacuum as opposed to at sea level pressure.
+    How much thrust would this rcs thruster give at its current atmospheric pressure if one of the control axes that activates it (yaw, pitch, roll, fore, aft, or top) was maxed, and the thrust limiter was max at 100%.  Note this might not be the thruster's actual max thrust it could have under other air pressure conditions.  Some thrusters have a very different value for MAXTHRUST in vacuum as opposed to at sea level pressure.
 
 .. _rcs_MAXTHRUSTAT:
 
@@ -276,7 +276,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type R
     :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
     :type: :struct:`Scalar` (kN)
 
-    How much thrust would this rcs thruster give if one of the control axes that activated it (yaw, pitch, roll, fore, aft, or top) was maxxed and thrust limiter was max at the given atmospheric pressure.  Use a pressure of 0.0 for vacuum, and 1.0 for sea level (on Kerbin) (or more than 1 for thicker atmospheres like on Eve).
+    How much thrust would this rcs thruster give if one of the control axes that activated it (yaw, pitch, roll, fore, aft, or top) was maxed and thrust limiter was max at the given atmospheric pressure.  Use a pressure of 0.0 for vacuum, and 1.0 for sea level (on Kerbin) (or more than 1 for thicker atmospheres like on Eve).
     (Pressure must be greater than or equal to zero.  If you pass in a
     negative value, it will be treated as if you had given a zero instead.)
 
@@ -294,7 +294,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type R
     :access: Get only
     :type: :struct:`Scalar` (kN)
 
-    Taking into account the thrust limiter tweakable setting, how much thrust would this rcs thruster give at its current thrust limit setting and atmospheric pressure conditions, if one of the control axes that activated it (yaw, pitch, roll, fore, aft, or top) was maxxed .
+    Taking into account the thrust limiter tweakable setting, how much thrust would this rcs thruster give at its current thrust limit setting and atmospheric pressure conditions, if one of the control axes that activated it (yaw, pitch, roll, fore, aft, or top) was maxed .
 
 .. _rcs_AVAILABLETHRUSTAT:
 
@@ -303,7 +303,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type R
     :parameter pressure: atmospheric pressure (in standard Kerbin atmospheres)
     :type: :struct:`Scalar` (kN)
 
-    Taking into account the thrust limiter tweakable setting, how much thrust at the given atmospheric pressure would this rcs thruster give at its current thrust limit setting if one of the control axes that activated it (yaw, pitch, roll, fore, aft, or top) was maxxed.   The pressure is measured in ATMs, meaning 0.0 is a vacuum, 1.0 is sea level at Kerbin.
+    Taking into account the thrust limiter tweakable setting, how much thrust at the given atmospheric pressure would this rcs thruster give at its current thrust limit setting if one of the control axes that activated it (yaw, pitch, roll, fore, aft, or top) was maxed.   The pressure is measured in ATMs, meaning 0.0 is a vacuum, 1.0 is sea level at Kerbin.
     (Pressure must be greater than or equal to zero.  If you pass in a
     negative value, it will be treated as if you had given a zero instead.)
 
@@ -312,14 +312,14 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type R
     :access: Get only
     :type: :struct:`Scalar` (units/s)
 
-    How much fuel volume would this rcs thruster consume at standard pressure and velocity if one of the control axes that activated it (yaw, pitch, roll, fore, aft, or top) was maxxed, and the thrust limiter was max at 100%.  Note this might not be the engine's actual max fuel flow it could have under other air pressure conditions.
+    How much fuel volume would this rcs thruster consume at standard pressure and velocity if one of the control axes that activated it (yaw, pitch, roll, fore, aft, or top) was maxed, and the thrust limiter was max at 100%.  Note this might not be the engine's actual max fuel flow it could have under other air pressure conditions.
 
 .. attribute:: RCS:MAXMASSFLOW
 
     :access: Get only
     :type: :struct:`Scalar` (Mg/s)
 
-    How much fuel mass would this rcs thruster consume at standard pressure and velocity if one of the control axes that activated it (yaw, pitch, roll, fore, aft, or top) was maxxed, and the thrust limiter was max at 100%.  Note this might not be the engine's actual max fuel flow it could have under other air pressure conditions.
+    How much fuel mass would this rcs thruster consume at standard pressure and velocity if one of the control axes that activated it (yaw, pitch, roll, fore, aft, or top) was maxed, and the thrust limiter was max at 100%.  Note this might not be the engine's actual max fuel flow it could have under other air pressure conditions.
 
 .. attribute:: RCS:ISP
 
@@ -356,7 +356,7 @@ Some of the Parts returned by :ref:`LIST PARTS <list command>` will be of type R
     :access: Get only
     :type: :struct:`Scalar`
 
-    `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_ at Kerbin sealevel.
+    `Specific impulse <http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse>`_ at Kerbin sea level.
 
 .. attribute:: RCS:SLISP
 

--- a/doc/source/structures/vessels/scienceexperiment.rst
+++ b/doc/source/structures/vessels/scienceexperiment.rst
@@ -12,7 +12,7 @@ example possible to deploy a science experiment::
     SET M TO P:GETMODULE("ModuleScienceExperiment").
     M:DOEVENT("observe mystery goo").
 
-Hovewer, this results in a dialog being shown to the user. Only from that dialog it is possible
+However, this results in a dialog being shown to the user. Only from that dialog it is possible
 to reset the experiment or transmit the experiment results back to Kerbin.
 :struct:`ScienceExperimentModule` structure introduces a few suffixes that allow the player
 to perform all science-related tasks without any manual intervention::

--- a/doc/source/structures/vessels/sensor.rst
+++ b/doc/source/structures/vessels/sensor.rst
@@ -69,7 +69,7 @@ The type of structures returned by :ref:`LIST SENSORS IN SOMEVARIABLE <list comm
     :access: Get only
     :type: :struct:`String`
 
-    The value of the sensor's readout, usualy including the units.
+    The value of the sensor's readout, usually including the units.
 
 .. attribute:: Sensor:POWERCONSUMPTION
 

--- a/doc/source/structures/vessels/vessel.rst
+++ b/doc/source/structures/vessels/vessel.rst
@@ -70,7 +70,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
     :attr:`RCS`                              :struct:`List`                  all :struct:`RCS <RCS>`
     :attr:`DOCKINGPORTS`                     :struct:`List`                  all :struct:`DockingPorts <DockingPort>`
     :attr:`ELEMENTS`                         :struct:`List`                  all :struct:`Elements <Element>`
-    :attr:`RESOURCES`                        :struct:`List`                  all :struct:`AggrgateResources <AggregateResource>`
+    :attr:`RESOURCES`                        :struct:`List`                  all :struct:`AggregateResources <AggregateResource>`
     :meth:`PARTSNAMED(name)`                 :struct:`List`                  :struct:`Parts <Part>` by :attr:`NAME <Part:NAME>`
     :meth:`PARTSNAMEDPATTERN(namePattern)`   :struct:`List`                  :struct:`Parts <Part>` by :attr:`NAME <Part:NAME>` regex pattern
     :meth:`PARTSTITLED(title)`               :struct:`List`                  :struct:`Parts <Part>` by :attr:`TITLE <Part:TITLE>`
@@ -302,7 +302,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
     :return: :struct:`DeltaV`
     
     One stage's Delta-V info.  Pass in the stage number for which stage.  The
-    curent stage can be found with ``:STAGENUM``, and they count down from
+    current stage can be found with ``:STAGENUM``, and they count down from
     there to stage 0 at the "top" of the staging list.
 
     If you pass in a number that is less than zero, it will return the info about
@@ -344,7 +344,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
     .. note::
         This does not change the value returned by :attr:`Vessel:TYPE`.  KSP
         internally manages the "discovery information" for vessels, including
-        assteroids, in a different system. As a result, the value kOS reads for
+        asteroids, in a different system. As a result, the value kOS reads for
         ``TYPE`` may be different from that displayed on the map.
 
 .. method:: Vessel:STOPTRACKING
@@ -561,7 +561,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
 
 .. method:: Vessel:PARTSTITLEDPATTERN(titlePattern)
 
-    :parameter titlePattern: (:struct:`String`) Patern of the title of the parts
+    :parameter titlePattern: (:struct:`String`) Pattern of the title of the parts
     :return: :struct:`List` of :struct:`Part` objects
 
     Returns a list of all the parts that have this Regex pattern in their
@@ -658,7 +658,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
     :return: :struct:`Scalar`
 
     The total delta-v of this vessel in its current situation, using the stock
-    calulations the KSP game shows in the staging list.  Note that this is only
+    calculations the KSP game shows in the staging list.  Note that this is only
     as accurate as the stock KSP game's numbers are.
 
 .. attribute:: Vessel:DELTAVASL
@@ -666,7 +666,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
     :return: :struct:`Scalar`
 
     The total delta-v of this vessel if it were at sea level, using the stock
-    calulations the KSP game shows in the staging list.  Note that this is only
+    calculations the KSP game shows in the staging list.  Note that this is only
     as accurate as the stock KSP game's numbers are.
 
 .. attribute:: Vessel:DELTAVVACUUM
@@ -674,7 +674,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
     :return: :struct:`Scalar`
 
     The total delta-v of this vessel if it were at sea vacuum, using the stock
-    calulations the KSP game shows in the staging list.  Note that this is only
+    calculations the KSP game shows in the staging list.  Note that this is only
     as accurate as the stock KSP game's numbers are.
 
 .. attribute:: Vessel:BURNTIME
@@ -682,7 +682,7 @@ Vessels are also :ref:`Orbitable<orbitable>`, and as such have all the associate
     :return: :struct:`Scalar`
 
     The total burn time, in seconds, of this vessel (or 5 if the vessel has 0 delta/v). Burn time is not affected by atmosphere.  This is using the stock
-    calulations the KSP game shows in the staging list.  Note that this is only
+    calculations the KSP game shows in the staging list.  Note that this is only
     as accurate as the stock KSP game's numbers are.
 
 

--- a/doc/source/structures/vessels/vesselsensors.rst
+++ b/doc/source/structures/vessels/vesselsensors.rst
@@ -40,7 +40,7 @@ If you store this in a variable and wait, the numbers are frozen in time and won
     :access: Get only
     :type: :struct:`Vector`
 
-    Accelleration the vessel is undergoing. A combination of both the gravitational pull and the engine thrust.
+    Acceleration the vessel is undergoing. A combination of both the gravitational pull and the engine thrust.
 
 .. attribute:: VesselSensors:PRES
 

--- a/doc/source/structures/volumes_and_files/volumedirectory.rst
+++ b/doc/source/structures/volumes_and_files/volumedirectory.rst
@@ -39,7 +39,7 @@ Instances of this class are enumerable, every step of iteration will provide a :
     :return: :struct:`Lexicon` of :struct:`VolumeFile` or :struct:`VolumeDirectory`
 
     Returns a Lexicon of all files and directories in this directory,
-    with each pair in the Lexcion having the string name of the file or directory
+    with each pair in the Lexicon having the string name of the file or directory
     as the key, and the :struct:`VolumeFile` or :struct:`VolumeDirectory` itself
     as the value.
 

--- a/doc/source/structures/waypoint.rst
+++ b/doc/source/structures/waypoint.rst
@@ -14,7 +14,7 @@ Waypoints are the location markers you can see on the map view showing you where
     :parameter name: (:struct:`String`) Name of the waypoint as it appears on the map or in the contract description
     :return: :struct:`Waypoint`
 
-    This creates a new Waypoint from a name of a waypoint you read from the contract paramters.  Note that this only works on contracts you've accpted.  Waypoints for proposed contracts haven't accepted yet  do not actually work in kOS.
+    This creates a new Waypoint from a name of a waypoint you read from the contract parameters.  Note that this only works on contracts you've accepted.  Waypoints for proposed contracts haven't accepted yet  do not actually work in kOS.
 
     SET spot TO WAYPOINT("herman's folly beta").
 
@@ -93,7 +93,7 @@ Waypoints are the location markers you can see on the map view showing you where
     :type: :struct:`Scalar`
     :access: Get only
 
-    Altitude of waypoint **above "sea" level**.  Warning, this a point somewhere in the midst of the contract altitude range, not the edge of the altitude range.  It corresponds towhere the marker tip hovers on the map, which is not actually at the very edge of the contract condition's range.  It represents a typical midling location inside the contract's altitude range.
+    Altitude of waypoint **above "sea" level**.  Warning, this a point somewhere in the midst of the contract altitude range, not the edge of the altitude range.  It corresponds to where the marker tip hovers on the map, which is not actually at the very edge of the contract condition's range.  It represents a typical middling location inside the contract's altitude range.
 
 
 .. attribute:: Waypoint:AGL
@@ -101,7 +101,7 @@ Waypoints are the location markers you can see on the map view showing you where
     :type: :struct:`Scalar`
     :access: Get only
 
-    Altitude of waypoint **above ground**.  Warning, this a point somewhere in the midst of the contract altitude range, not the edge of the altitude range.  It corresponds to where the marker tip hovers on the map, which is not actually at the very edge of the contract condition's range.  It represents a typical midling location inside the contract's altitude range.
+    Altitude of waypoint **above ground**.  Warning, this a point somewhere in the midst of the contract altitude range, not the edge of the altitude range.  It corresponds to where the marker tip hovers on the map, which is not actually at the very edge of the contract condition's range.  It represents a typical middling location inside the contract's altitude range.
 
 
 .. attribute:: Waypoint:NEARSURFACE

--- a/doc/source/tutorials.rst
+++ b/doc/source/tutorials.rst
@@ -35,7 +35,7 @@ Intermediate
     Starts with a basic proportional feedback loop and develops, in stages, a complete PID-loop to control the throttle of a simple rocket design.
 
 :doc:`Execute Node script <tutorials/exenode>`
-    ZiwKerman describes a generic "execute manuever node" script to be a one-size-fits-all solution to many situations in KSP.  If you can make a manuever node for something, exenode will execute it.
+    ZiwKerman describes a generic "execute maneuver node" script to be a one-size-fits-all solution to many situations in KSP.  If you can make a maneuver node for something, exenode will execute it.
 
 :doc:`Display Bounds script <tutorials/display_bounds>`
     An example program showing how to read vessel and part bounding

--- a/doc/source/tutorials/basictutorial.rst
+++ b/doc/source/tutorials/basictutorial.rst
@@ -34,7 +34,7 @@ typing the following will create a file called 'hello', to enter the command pre
 
 
 you can now edit the file and make your script for the processor to execute, the other tutorials will show how you can make a
-working script. Keep in mind that files made in game dissapear after the vessel is gone. This happens because you locally made a file on the ship's processor.
+working script. Keep in mind that files made in game disappear after the vessel is gone. This happens because you locally made a file on the ship's processor.
 
 To run the file, type:
 
@@ -333,14 +333,14 @@ It would print ``60``. You can also set the current in-game time as a variable: 
 
   set CurrentTime to time:seconds.
 
-The variable ``CurrentTime`` will stay 60 seconds. Eventhough the in-game time changes: ::
+The variable ``CurrentTime`` will stay 60 seconds. Even though the in-game time changes: ::
 
   set CurrentTime to time:seconds.
   print CurrentTime. // shows: 60
   wait 10.
   print CurrentTime. // shows: 60
 
-As you can see, eventhough the in-game time has changed the variable ``CurrentTime`` is still 60. The ``set`` command does **NOT** constantly update the variable. If you want a constantly updating variable you have to use the ``lock`` command.
+As you can see, even though the in-game time has changed the variable ``CurrentTime`` is still 60. The ``set`` command does **NOT** constantly update the variable. If you want a constantly updating variable you have to use the ``lock`` command.
 Here's an example of what the ``lock`` command can do: ::
 
   lock TimeSecondsPlusTen to time:seconds + 10.

--- a/doc/source/tutorials/gui.rst
+++ b/doc/source/tutorials/gui.rst
@@ -184,7 +184,7 @@ can be added.::
                 SET tab:TOGGLE TO true.
                 SET tab:EXCLUSIVE TO true.
 
-                // If this is the first tab, make it start already shown (make the tab presssed)
+                // If this is the first tab, make it start already shown (make the tab pressed)
                 // Otherwise, we hide it (even though the STACK will only show the first anyway,
                 // but by keeping everything "correct", we can be a little more efficient later.
                 IF panels:WIDGETS:LENGTH = 1 {


### PR DESCRIPTION
I've updated the docs to fix some spelling mistakes. I've also changed the word "lastmost" into "last" or "rightmost" depending on context.

Can I get away with filing a PR with the changes, or should I file a generic "i've found some spelling mistakes" issue?