### PR TITLE
Added docs for missing GREY/GRAY color

### DIFF
--- a/doc/source/structures/misc/colors.rst
+++ b/doc/source/structures/misc/colors.rst
@@ -21,6 +21,12 @@ Method 1: Use one of these pre-arranged named colors:
 
         (Alias of :global:`MAGENTA`)
 
+- .. global:: GREY
+
+    - .. global:: GRAY
+
+        (Alias of :global:`GREY`)
+
 - .. global:: WHITE
 - .. global:: BLACK
 


### PR DESCRIPTION
I've made a huge assumption here; that GREY is the primary one, and GRAY is the alias. I based this on the order of the names in https://github.com/KSP-KOS/KOS/blob/727d345679fe992077fa5604c27b43c34a80fbe7/src/kOS/Binding/ColorBinding.cs#L24