### PR TITLE
Fix RemoteTech API call for connection to unloaded vessels

### DIFF
--- a/src/kOS/AddOns/RemoteTech/RemoteTechConnectivityManager.cs
+++ b/src/kOS/AddOns/RemoteTech/RemoteTechConnectivityManager.cs
@@ -1,6 +1,7 @@
-using System;
 using kOS.Communication;
 using kOS.Module;
+using kOS.Safe.Utilities;
+using System;
 
 namespace kOS.AddOns.RemoteTech
 {
@@ -44,7 +45,8 @@ namespace kOS.AddOns.RemoteTech
             double delay = RemoteTechHook.Instance.GetSignalDelayToSatellite(vessel1.id, vessel2.id);
             if (Double.IsPositiveInfinity(delay) || delay < 0)
             {
-                delay = RemoteTechHook.Instance.GetShortestSignalDelay(vessel2.id);
+                delay = Math.Max(RemoteTechHook.Instance.GetShortestSignalDelay(vessel1.id), 
+                                RemoteTechHook.Instance.GetShortestSignalDelay(vessel2.id));
             }
             return Double.IsPositiveInfinity(delay) ? -1 : delay;
         }

--- a/src/kOS/AddOns/RemoteTech/RemoteTechConnectivityManager.cs
+++ b/src/kOS/AddOns/RemoteTech/RemoteTechConnectivityManager.cs
@@ -1,7 +1,7 @@
+using System;
 using kOS.Communication;
 using kOS.Module;
-using kOS.Safe.Utilities;
-using System;
+
 
 namespace kOS.AddOns.RemoteTech
 {

--- a/src/kOS/AddOns/RemoteTech/RemoteTechConnectivityManager.cs
+++ b/src/kOS/AddOns/RemoteTech/RemoteTechConnectivityManager.cs
@@ -2,7 +2,6 @@ using System;
 using kOS.Communication;
 using kOS.Module;
 
-
 namespace kOS.AddOns.RemoteTech
 {
     /// <summary>

--- a/src/kOS/AddOns/RemoteTech/RemoteTechConnectivityManager.cs
+++ b/src/kOS/AddOns/RemoteTech/RemoteTechConnectivityManager.cs
@@ -42,6 +42,10 @@ namespace kOS.AddOns.RemoteTech
             if (!(RemoteTechHook.IsAvailable()))
                 return -1; // default to no connection if RT itself isn't available.
             double delay = RemoteTechHook.Instance.GetSignalDelayToSatellite(vessel1.id, vessel2.id);
+            if (Double.IsPositiveInfinity(delay) || delay < 0)
+            {
+                delay = RemoteTechHook.Instance.GetShortestSignalDelay(vessel2.id);
+            }
             return Double.IsPositiveInfinity(delay) ? -1 : delay;
         }
 


### PR DESCRIPTION
https://discord.com/channels/210513998876114944/210521126634389505/1403468719732166718

If the `GetSignalDelayToSatellite` API function call does not return a valid value for delay, try `GetShortestSignalDelay`.  
This preserves any existing calls to the `GetDelay()` function in RemoteTechConnectivityManager that may still need 2 vessels as arguments.  But will fix [this bug](https://github.com/KSP-KOS/KOS/issues/3142) which is caused by the `IsConnected` boolean that is determined from the Delay being > 0.   