### PR TITLE
Add pointer and indirect access opcodes

### DIFF
--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -88,6 +88,12 @@ namespace kOS.Safe.Compilation
         TESTARGBOTTOM  = 0x61,
         TESTCANCELLED  = 0x62,
         JUMPSTACK      = 0x63,
+        PEEK           = 0x64,
+        POKE           = 0x65,
+        STORENAME      = 0x66,
+        ALLOCATE       = 0x67,
+        INSTPTR        = 0x68,
+        STACKPTR       = 0x69,
 
         // Augmented bogus placeholder versions of the normal
         // opcodes: These only exist in the program temporarily
@@ -695,6 +701,39 @@ namespace kOS.Safe.Compilation
     }
 
     /// <summary>
+    /// <para>
+    /// Consumes the identifier atop the stack and
+    /// stores the value beneath the identifier into that
+    /// variable name <br/>
+    /// Note that the ident atop the stack must be formatted like a variable
+    /// name (i.e. have the leading '$').
+    /// </para>
+    /// <para></para>
+    /// <para>storename</para>
+    /// <para>... value ident -- ...</para>
+    /// <para></para>
+    /// </summary>
+    public class OpcodeStoreName : Opcode
+    {
+        protected override string Name { get { return "storename"; } }
+        public override ByteCode Code { get { return ByteCode.STORENAME; } }
+
+        public OpcodeStoreName()
+        {
+        }
+
+        public override void Execute(ICpu cpu)
+        {
+            string ident = Convert.ToString(cpu.PopArgumentStack());
+            Structure value = PopStructureAssertEncapsulated(cpu);
+            if (ident != null)
+            {
+                cpu.SetValue(ident, value);
+            }
+        }
+    }
+
+    /// <summary>
     /// Consumes the topmost value of the stack as an identifier, unsetting
     /// the variable referenced by this identifier. This will remove the
     /// variable referenced by this identifier in the innermost scope that
@@ -714,7 +753,7 @@ namespace kOS.Safe.Compilation
             }
             else
             {
-                throw new KOSObsoletionException("0.17","UNSET ALL", "<not supported anymore now that we have nested scoping>", "");
+                throw new KOSObsoletionException("0.17", "UNSET ALL", "<not supported anymore now that we have nested scoping>", "");
             }
         }
     }
@@ -2278,12 +2317,12 @@ namespace kOS.Safe.Compilation
         protected override string Name { get { return "eval"; } }
         public override ByteCode Code { get { return ByteCode.EVAL; } }
         private bool barewordOkay;
-        
+
         public OpcodeEval()
         {
             barewordOkay = false;
         }
-        
+
         /// <summary>
         /// Eval top thing on the stack and replace it with its dereferenced
         /// value.  If you want to allow bare words like filenames then set argument bareOkay to true
@@ -2302,6 +2341,151 @@ namespace kOS.Safe.Compilation
     }
 
     /// <summary>
+    /// <para>
+    /// Pops an index/pointer from the stack and duplicates the value at that stack slot onto the top of the stack.
+    /// Default indexing is top-to-bottom, can be set to bottom-to-tob using the FromBottom MLField.
+    /// </para>
+    /// <para></para>
+    /// <para>peek fromBottom</para>
+    /// <para>... val ... ptr -- ... val ... val</para>
+    /// </summary>
+    public class OpcodePeek : Opcode
+    {
+        protected override string Name { get { return "peek"; } }
+        public override ByteCode Code { get { return ByteCode.PEEK; } }
+
+        [MLField(0, false)]
+        public bool FromBottom { get; set; }
+
+        public OpcodePeek(bool fromBottom)
+        {
+            FromBottom = fromBottom;
+        }
+
+        protected OpcodePeek()
+        {
+        }
+
+        public override void PopulateFromMLFields(List<object> fields)
+        {
+            if (fields == null || fields.Count < 1)
+                throw new Exception("Saved field in ML file for OpcodePeek seems to be missing.  Version mismatch?");
+            FromBottom = (bool)(fields[0]);
+        }
+
+        public override void Execute(ICpu cpu)
+        {
+            int idx = Convert.ToInt32(cpu.PopValueArgument());
+
+            int depth = FromBottom
+                ? cpu.GetArgumentStackSize() - 1 - idx
+                : idx;
+
+            if (depth < 0 || depth >= cpu.GetArgumentStackSize())
+                throw KOSException($"Invalid peek index {idx}");
+
+            object value = cpu.PeekRawArgument(depth, out bool ok);
+            if (!ok)
+                throw new KOSException("Peek failed");
+
+            cpu.PushArgumentStack(value);
+        }
+    }
+
+    /// <summary>
+    /// <para>
+    /// Pops an index/pointer and a value from the stack and pokes the value into that stack slot.
+    /// Default indexing is top-to-bottom, can be set to bottom-to-tob using the FromBottom MLField.
+    /// </para>
+    /// <para></para>
+    /// <para>poke fromBottom</para>
+    /// <para>... val ptr -- ... val ...</para>
+    /// </summary>
+    public class OpcodePoke : Opcode
+    {
+        protected override string Name { get { return "poke"; } }
+        public override ByteCode Code { get { return ByteCode.POKE; } }
+
+        [MLField(0, false)]
+        public bool FromBottom { get; set; }
+
+        public OpcodePoke(bool fromBottom)
+        {
+            FromBottom = fromBottom;
+        }
+
+        protected OpcodePoke()
+        {
+        }
+
+        public override void PopulateFromMLFields(List<object> fields)
+        {
+            if (fields == null || fields.Count < 1)
+                throw new Exception("Saved field in ML file for OpcodePoke seems to be missing.  Version mismatch?");
+            FromBottom = (bool)(fields[0]);
+        }
+
+        public override void Execute(ICpu cpu)
+        {
+            int idx = Convert.ToInt32(cpu.PopValueArgument());
+            object value = cpu.PopArgumentStack();
+
+            int depth = FromBottom
+                ? cpu.GetArgumentStackSize() - 1 - idx
+                : idx;
+
+            if (depth < 0 || depth >= cpu.GetArgumentStackSize())
+                throw KOSException($"Invalid poke index {idx}");
+
+            object value = cpu.PokeArgumentStack(depth, value, out bool ok);
+            if (!ok)
+                throw new KOSException("Poke failed");
+        }
+    }
+
+    /// <summary>
+    /// <para>
+    /// Pushes N nulls onto the stack to use for storage using OpcodePoke
+    /// </para>
+    /// <para></para>
+    /// <para>allocate n</para>
+    /// <para>... -- ... null * N</para>
+    /// </summary>
+    public class OpcodeAllocate : Opcode
+    {
+        protected override string Name { get { return "allocate"; } }
+        public override ByteCode Code { get { return ByteCode.ALLOCATE; } }
+
+        [MLField(0, false)]
+        public Int32 Count { get; set; }
+
+        public OpcodeAllocate(int count)
+        {
+            Count = count;
+        }
+
+        protected OpcodeAllocate()
+        {
+        }
+
+        public override void PopulateFromMLFields(List<object> fields)
+        {
+            if (fields == null || fields.Count < 1)
+                throw Exception("Saved field in ML file for OpcodeAllocate seems to be missing.  Version mismatch?");
+            Count = (Int32)(fields[0]);
+        }
+
+        public override void Execute(ICpu cpu)
+        {
+            object nul = new PseudoNull(); // no modification possible on Null so no possibility of shared state modification
+            for (int i = 0; i < Count; i++)
+            {
+                cpu.PushArgumentStack(nul);
+            }
+        }
+    }
+
+    /// <summary>
     /// Pushes a new variable namespace scope (for example, when a "{" is encountered
     /// in a block-scoping language like C++ or Java or C#.)
     /// From now on any local variables created will be made in this new
@@ -2309,10 +2493,10 @@ namespace kOS.Safe.Compilation
     /// </summary>
     public class OpcodePushScope : Opcode
     {
-        [MLField(1,true)]
-        public Int16 ScopeId {get;set;}
-        [MLField(2,true)]
-        public Int16 ParentScopeId {get;set;}
+        [MLField(1, true)]
+        public Int16 ScopeId { get; set; }
+        [MLField(2, true)]
+        public Int16 ParentScopeId { get; set; }
 
         /// <summary>
         /// Push a scope frame that knows the id of its lexical parent scope.
@@ -2337,25 +2521,25 @@ namespace kOS.Safe.Compilation
         public override void PopulateFromMLFields(List<object> fields)
         {
             // Expect fields in the same order as the [MLField] properties of this class:
-            if (fields == null || fields.Count<2)
+            if (fields == null || fields.Count < 2)
                 throw new Exception("Saved field in ML file for OpcodePushScope seems to be missing.  Version mismatch?");
-            ScopeId = (Int16)( fields[0] );
-            ParentScopeId = (Int16)( fields[1] );
+            ScopeId = (Int16)(fields[0]);
+            ParentScopeId = (Int16)(fields[1]);
         }
 
         protected override string Name { get { return "pushscope"; } }
         public override ByteCode Code { get { return ByteCode.PUSHSCOPE; } }
-        
+
         public override void Execute(ICpu cpu)
         {
-            cpu.PushNewScope(ScopeId,ParentScopeId);
+            cpu.PushNewScope(ScopeId, ParentScopeId);
         }
 
         public override string ToString()
         {
             return String.Format("{0} {1} {2}", Name, ScopeId, ParentScopeId);
         }
-        
+
     }
 
     /// <summary>
@@ -2370,17 +2554,17 @@ namespace kOS.Safe.Compilation
     /// </summary>
     public class OpcodePopScope : Opcode
     {
-        [MLField(1,true)]
-        public Int16 NumLevels {get;set;} // Are we really going to have recursion more than 32767 levels?  Int16 is fine.
+        [MLField(1, true)]
+        public Int16 NumLevels { get; set; } // Are we really going to have recursion more than 32767 levels?  Int16 is fine.
 
         protected override string Name { get { return "popscope"; } }
         public override ByteCode Code { get { return ByteCode.POPSCOPE; } }
-        
+
         public OpcodePopScope(int numLevels)
         {
             NumLevels = (Int16)numLevels;
         }
-        
+
         public OpcodePopScope()
         {
             NumLevels = 1;
@@ -2389,7 +2573,7 @@ namespace kOS.Safe.Compilation
         public override void PopulateFromMLFields(List<object> fields)
         {
             // Expect fields in the same order as the [MLField] properties of this class:
-            if (fields == null || fields.Count<1)
+            if (fields == null || fields.Count < 1)
                 throw new Exception("Saved field in ML file for OpcodePopScope seems to be missing.  Version mismatch?");
             NumLevels = (Int16)(fields[0]); // should throw error if it's not an int.
         }
@@ -2398,7 +2582,7 @@ namespace kOS.Safe.Compilation
         {
             DoPopScope(cpu, NumLevels);
         }
-        
+
         /// <summary>
         /// Do the actual work of the Execute() method.  This was pulled out
         /// to a separate static method so that others can call it without needing
@@ -2417,7 +2601,59 @@ namespace kOS.Safe.Compilation
         {
             return Name + " " + NumLevels;
         }
-        
+
+    }
+
+    /// <summary>
+    /// <para>
+    /// Pushes the value of the stack pointer onto the stack.
+    /// The stack pointer points to value where the next push will go to.
+    /// As result of this, the returned value will point to itself (absolute)
+    /// </para>
+    /// <para></para>
+    /// <para>stackptr</para>
+    /// <para>... -- ... ptr</para>
+    /// </summary>
+    public class OpcodeStackPointer : Opcode
+    {
+        protected override string Name { get { return "stackptr"; } }
+        public override ByteCode Code { get { return ByteCode.STACKPTR; } }
+
+        public OpcodeStackPointer()
+        {
+        }
+
+        public override void Execute(ICpu cpu)
+        {
+            int ptr = cpu.GetArgumentStackSize();
+            cpu.PushArgumentStack(ptr);
+        }
+    }
+
+    /// <summary>
+    /// <para>
+    /// Pushes the value of the instruction pointer onto the stack.
+    /// The instruction pointer points to the current instruction to.
+    /// As result of this, the returned value will point to this instruction (absolute)
+    /// </para>
+    /// <para></para>
+    /// <para>instptr</para>
+    /// <para>... -- ... ptr</para>
+    /// </summary>
+    public class OpcodeInstructionPointer : Opcode
+    {
+        protected override string Name { get { return "instptr"; } }
+        public override ByteCode Code { get { return ByteCode.INSTPTR; } }
+
+        public OpcodeInstructionPointer()
+        {
+        }
+
+        public override void Execute(ICpu cpu)
+        {
+            int ptr = cpu.InstructionPointer;
+            cpu.PushArgumentStack(ptr);
+        }
     }
 
     /// <summary>
@@ -2430,9 +2666,9 @@ namespace kOS.Safe.Compilation
     /// </summary>
     public class OpcodePushDelegate : Opcode
     {
-        [MLField(1,false)]
+        [MLField(1, false)]
         private int EntryPoint { get; set; }
-        [MLField(2,false)]
+        [MLField(2, false)]
         private bool WithClosure { get; set; }
 
         protected override string Name { get { return "pushdelegate"; } }
@@ -2452,7 +2688,7 @@ namespace kOS.Safe.Compilation
         public override void PopulateFromMLFields(List<object> fields)
         {
             // Expect fields in the same order as the [MLField] properties of this class:
-            if (fields == null || fields.Count<2)
+            if (fields == null || fields.Count < 2)
                 throw new Exception("Saved field in ML file for OpcodePushDelegate seems to be missing.  Version mismatch?");
             EntryPoint = Convert.ToInt32(fields[0]);
             WithClosure = Convert.ToBoolean(fields[1]);

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -92,8 +92,9 @@ namespace kOS.Safe.Compilation
         POKE           = 0x65,
         STORENAME      = 0x66,
         ALLOCATE       = 0x67,
-        INSTPTR        = 0x68,
-        STACKPTR       = 0x69,
+        DEALLOCATE     = 0x68,
+        INSTPTR        = 0x69,
+        STACKPTR       = 0x6A,
 
         // Augmented bogus placeholder versions of the normal
         // opcodes: These only exist in the program temporarily
@@ -2480,6 +2481,47 @@ namespace kOS.Safe.Compilation
             for (int i = 0; i < Count; i++)
             {
                 cpu.PushArgumentStack(nul);
+            }
+        }
+    }
+
+    /// <summary>
+    /// <para>
+    /// Pops N entries from the stack, quickly freeing the space that ALLOCATE has created
+    /// </para>
+    /// <para></para>
+    /// <para>deallocate n</para>
+    /// <para>... null * N -- .. </para>
+    /// </summary>
+    public class OpcodeDeallocate : Opcode
+    {
+        protected override string Name { get { return "deallocate"; } }
+        public override ByteCode Code { get { return ByteCode.DEALLOCATE; } }
+
+        [MLField(0, false)]
+        public Int32 Count { get; set; }
+
+        public OpcodeDeallocate(int count)
+        {
+            Count = count;
+        }
+
+        protected OpcodeDeallocate()
+        {
+        }
+
+        public override void PopulateFromMLFields(List<object> fields)
+        {
+            if (fields == null || fields.Count < 1)
+                throw Exception("Saved field in ML file for OpcodeDeallocate seems to be missing.  Version mismatch?");
+            Count = (Int32)(fields[0]);
+        }
+
+        public override void Execute(ICpu cpu)
+        {
+            for (int i = 0; i < Count; i++)
+            {
+                cpu.PopArgumentStack();
             }
         }
     }

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -8,7 +8,6 @@ using kOS.Safe.Execution;
 using kOS.Safe.Exceptions;
 using kOS.Safe.Utilities;
 using kOS.Safe.Persistence;
-using kOS.Safe.Compilation.KS;
 
 namespace kOS.Safe.Compilation
 {

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -8,6 +8,7 @@ using kOS.Safe.Execution;
 using kOS.Safe.Exceptions;
 using kOS.Safe.Utilities;
 using kOS.Safe.Persistence;
+using kOS.Safe.Compilation.KS;
 
 namespace kOS.Safe.Compilation
 {
@@ -88,11 +89,11 @@ namespace kOS.Safe.Compilation
         TESTARGBOTTOM  = 0x61,
         TESTCANCELLED  = 0x62,
         JUMPSTACK      = 0x63,
-        PEEK           = 0x64,
-        POKE           = 0x65,
-        STORENAME      = 0x66,
+        CREATEPTR      = 0x64,
+        GETPTR         = 0x65,
+        SETPTR         = 0x66,
         ALLOCATE       = 0x67,
-        DEALLOCATE     = 0x68,
+        FREE           = 0x68,
         INSTPTR        = 0x69,
         STACKPTR       = 0x6A,
 
@@ -532,7 +533,6 @@ namespace kOS.Safe.Compilation
 
     #region General
 
-
     /// <summary>
     /// Consumes the topmost value of the stack, storing it into
     /// a variable named by the Identifier MLField of this opcode.<br/>
@@ -698,38 +698,6 @@ namespace kOS.Safe.Compilation
         {
             Structure value = PopStructureAssertEncapsulated(cpu);
             cpu.SetGlobal(Identifier, value);
-        }
-    }
-
-    /// <summary>
-    /// <para>
-    /// Consumes a value and identifier and stores the value
-    /// into that a local variable under that identifier<br/>
-    /// Note that the ident atop the stack must be formatted like a variable
-    /// name (i.e. have the leading '$').
-    /// </para>
-    /// <para></para>
-    /// <para>storename</para>
-    /// <para>... ident value -- ...</para>
-    /// <para></para>
-    /// </summary>
-    public class OpcodeStoreName : Opcode
-    {
-        protected override string Name { get { return "storename"; } }
-        public override ByteCode Code { get { return ByteCode.STORENAME; } }
-
-        public OpcodeStoreName()
-        {
-        }
-
-        public override void Execute(ICpu cpu)
-        {
-            Structure value = PopStructureAssertEncapsulated(cpu);
-            string ident = Convert.ToString(cpu.PopArgumentStack());
-            if (ident != null)
-            {
-                cpu.SetNewLocal(ident, value);
-            }
         }
     }
 
@@ -2342,109 +2310,6 @@ namespace kOS.Safe.Compilation
 
     /// <summary>
     /// <para>
-    /// Pops an index/pointer from the stack and duplicates the value at that stack slot onto the top of the stack.
-    /// Default indexing is top-to-bottom, can be set to bottom-to-tob using the FromBottom MLField.
-    /// </para>
-    /// <para></para>
-    /// <para>peek fromBottom</para>
-    /// <para>... val ... ptr -- ... val ... val</para>
-    /// </summary>
-    public class OpcodePeek : Opcode
-    {
-        protected override string Name { get { return "peek"; } }
-        public override ByteCode Code { get { return ByteCode.PEEK; } }
-
-        [MLField(0, false)]
-        public bool FromBottom { get; set; }
-
-        public OpcodePeek(bool fromBottom)
-        {
-            FromBottom = fromBottom;
-        }
-
-        protected OpcodePeek()
-        {
-        }
-
-        public override void PopulateFromMLFields(List<object> fields)
-        {
-            if (fields == null || fields.Count < 1)
-                throw new Exception("Saved field in ML file for OpcodePeek seems to be missing.  Version mismatch?");
-            FromBottom = (bool)(fields[0]);
-        }
-
-        public override void Execute(ICpu cpu)
-        {
-            int idx = Convert.ToInt32(cpu.PopValueArgument());
-
-            int depth = FromBottom
-                ? cpu.GetArgumentStackSize() - 1 - idx
-                : idx;
-
-            if (depth < 0 || depth >= cpu.GetArgumentStackSize())
-                throw KOSException($"Invalid peek index {idx}");
-
-            object value = cpu.PeekRawArgument(depth, out bool ok);
-            if (!ok)
-                throw new KOSException("Peek failed");
-
-            cpu.PushArgumentStack(value);
-        }
-    }
-
-    /// <summary>
-    /// <para>
-    /// Pops a value and an index/pointer from the stack and pokes the value into that stack slot.
-    /// Default indexing is top-to-bottom, can be set to bottom-to-tob using the FromBottom MLField.
-    /// </para>
-    /// <para></para>
-    /// <para>poke fromBottom</para>
-    /// <para>... ptr val -- ... val ...</para>
-    /// </summary>
-    public class OpcodePoke : Opcode
-    {
-        protected override string Name { get { return "poke"; } }
-        public override ByteCode Code { get { return ByteCode.POKE; } }
-
-        [MLField(0, false)]
-        public bool FromBottom { get; set; }
-
-        public OpcodePoke(bool fromBottom)
-        {
-            FromBottom = fromBottom;
-        }
-
-        protected OpcodePoke()
-        {
-        }
-
-        public override void PopulateFromMLFields(List<object> fields)
-        {
-            if (fields == null || fields.Count < 1)
-                throw new Exception("Saved field in ML file for OpcodePoke seems to be missing.  Version mismatch?");
-            FromBottom = (bool)(fields[0]);
-        }
-
-        public override void Execute(ICpu cpu)
-        {
-            object value = cpu.PopArgumentStack();
-            int idx = Convert.ToInt32(cpu.PopValueArgument());
-
-            int depth = FromBottom
-                ? cpu.GetArgumentStackSize() - 1 - idx
-                : idx;
-
-            if (depth < 0 || depth >= cpu.GetArgumentStackSize())
-                throw KOSException($"Invalid poke index {idx}");
-
-            object value = cpu.PokeArgumentStack(depth, value, out bool ok);
-            if (!ok)
-                throw new KOSException("Poke failed");
-        }
-    }
-
-    /// <summary>
-    /// <para>
     /// Pushes N nulls onto the stack to use for storage using OpcodePoke
     /// </para>
     /// <para></para>
@@ -2471,7 +2336,7 @@ namespace kOS.Safe.Compilation
         public override void PopulateFromMLFields(List<object> fields)
         {
             if (fields == null || fields.Count < 1)
-                throw Exception("Saved field in ML file for OpcodeAllocate seems to be missing.  Version mismatch?");
+                throw new Exception("Saved field in ML file for OpcodeAllocate seems to be missing.  Version mismatch?");
             Count = (Int32)(fields[0]);
         }
 
@@ -2490,30 +2355,30 @@ namespace kOS.Safe.Compilation
     /// Pops N entries from the stack, quickly freeing the space that ALLOCATE has created
     /// </para>
     /// <para></para>
-    /// <para>deallocate n</para>
+    /// <para>free n</para>
     /// <para>... null * N -- .. </para>
     /// </summary>
-    public class OpcodeDeallocate : Opcode
+    public class OpcodeFree : Opcode
     {
-        protected override string Name { get { return "deallocate"; } }
-        public override ByteCode Code { get { return ByteCode.DEALLOCATE; } }
+        protected override string Name { get { return "free"; } }
+        public override ByteCode Code { get { return ByteCode.FREE; } }
 
         [MLField(0, false)]
         public Int32 Count { get; set; }
 
-        public OpcodeDeallocate(int count)
+        public OpcodeFree(int count)
         {
             Count = count;
         }
 
-        protected OpcodeDeallocate()
+        protected OpcodeFree()
         {
         }
 
         public override void PopulateFromMLFields(List<object> fields)
         {
             if (fields == null || fields.Count < 1)
-                throw Exception("Saved field in ML file for OpcodeDeallocate seems to be missing.  Version mismatch?");
+                throw new Exception("Saved field in ML file for OpcodeFree seems to be missing.  Version mismatch?");
             Count = (Int32)(fields[0]);
         }
 
@@ -2780,6 +2645,211 @@ namespace kOS.Safe.Compilation
         }
     }
     
+    #endregion
+
+    #region Pointers
+
+    /// <summary>
+    /// <para>
+    /// Consumes N elements from the stack and returns a PointerValue
+    /// </para>
+    /// <para></para>
+    /// <para>createptr n</para>
+    /// <para>... seg1 seg2 -- ... ptr</para>
+    /// </summary>
+    public class OpcodeCreatePointer : Opcode
+    {
+        [MLField(0, false)]
+        private Int32 Count { get; set; }
+
+        protected override string Name { get { return "createptr"; } }
+        public override ByteCode Code { get { return ByteCode.CREATEPTR; } }
+
+        protected OpcodeCreatePointer() {  }
+
+        public OpcodeCreatePointer(int count)
+        {
+            Count = count;
+        }
+
+        public override void PopulateFromMLFields(List<object> fields)
+        {
+            if (fields == null || fields.Count < 1)
+                throw new Exception("Saved field in ML file for OpcodeCreatePointer seems to be missing.  Version mismatch?");
+            Count = (Int32)(fields[0]);
+            if (Count < 1)
+                throw new Exception("CREATEPTR requires at least one segment.");
+        }
+
+        public override void Execute(ICpu cpu)
+        {
+            if (cpu.GetArgumentStackSize() < Count)
+                throw new KOSException($"CREATEPTR {Count} requires {Count} stack values but only {cpu.GetArgumentStackSize()} present.");
+            
+            List<Structure> segments = new List<Structure>(Count);
+
+            for (int i = 0; i < Count; i++)
+            {
+                segments.Add(cpu.PopStructureEncapsulatedArgument());
+            }
+
+            segments.Reverse();
+
+            // validate
+            if (!(segments[0] is ScalarIntValue) &&
+                !(segments[0] is StringValue str && str.StartsWith("$")))
+            {
+                throw new KOSException("Invalid pointer root: must be int (stack index) or variable name ('$' prefixed string).");
+            }
+
+            cpu.PushArgumentStack(new PointerValue(segments));
+        }
+    }
+
+    /// <summary>
+    /// <para>
+    /// Pops a PointerValue from the stack and pushes its resolution
+    /// </para>
+    /// <para></para>
+    /// <para>getptr</para>
+    /// <para>... ptr -- ... value</para>
+    /// </summary>
+    public class OpcodeGetPointer : Opcode
+    {
+        protected override string Name { get { return "getptr"; } }
+        public override ByteCode Code { get { return ByteCode.GETPTR; } }
+
+        public OpcodeGetPointer() {  }
+
+        public override void Execute(ICpu cpu)
+        {
+            Structure ptrStruct = cpu.PopStructureEncapsulatedArgument();
+            if (!(ptrStruct is PointerValue ptr))
+                throw new KOSException("GETPTR expects a PointerValue on the stack.");
+
+            // validate
+            if (ptr.Segments.Count < 1)
+                throw new KOSException("GETPTR: PointerValue must have at least one segment.");
+
+            // Resolve first segment
+            Structure current;
+            Structure firstSeg = ptr.Segments[0];
+            if (firstSeg is ScalarIntValue idx)
+            {
+                int absIndex = idx.GetIntValue();
+                if (absIndex < 0 || absIndex >= cpu.GetArgumentStackSize())
+                    throw new KOSException($"GETPTR: stack index {absIndex} out of range.");
+                current = Structure.FromPrimitiveWithAssert(cpu.PeekRawArgument(cpu.GetArgumentStackSize() - 1 - absIndex, out bool ok));
+                if (!ok)
+                    throw new KOSException("GETPTR: stack indexing failed");
+            }
+            else if (firstSeg is StringValue varName && varName.StartsWith("$"))
+            {
+                current = Structure.FromPrimitiveWithAssert(cpu.GetValue(varName.ToString()));
+            }
+            else
+            {
+                throw new KOSException("GETPTR: first segment must be a stack index or variable name.");
+            }
+
+            // Traverse remaining segments
+            for (int i = 1; i < ptr.Segments.Count; i++)
+            {
+                Structure seg = ptr.Segments[i];
+
+                if (!(current is IIndexable indexable))
+                    throw new KOSException($"GETPTR: segment {i} encountered non-indexable value.");
+                
+                current = indexable.GetIndex(seg);
+            }
+
+            cpu.PushArgumentStack(current);
+        }
+    }
+
+    /// <summary>
+    /// <para>
+    /// Pops a Value and a PointerValue from the stack and writes the value into the pointer's resolution
+    /// </para>
+    /// <para></para>
+    /// <para>setptr</para>
+    /// <para>... ptr value -- ...</para>
+    /// </summary>
+    public class OpcodeSetPointer : Opcode
+    {
+        protected override string Name { get { return "setptr"; } }
+        public override ByteCode Code { get { return ByteCode.SETPTR; } }
+
+        public OpcodeSetPointer() {  }
+
+        public override void Execute(ICpu cpu)
+        {
+            Structure value = cpu.PopStructureEncapsulatedArgument();
+            Structure ptrStruct = cpu.PopStructureEncapsulatedArgument();
+            if (!(ptrStruct is PointerValue ptr))
+                throw new KOSException("SETPTR expects a PointerValue on the stack.");
+
+            // validate
+            if (ptr.Segments.Count < 1)
+                throw new KOSException("SETPTR: PointerValue must have at least one segment.");
+
+            // Resolve first segment
+            Structure current;
+            Structure firstSeg = ptr.Segments[0];
+            if (firstSeg is ScalarIntValue idx)
+            {
+                int absIndex = idx.GetIntValue();
+                if (absIndex < 0 || absIndex >= cpu.GetArgumentStackSize())
+                    throw new KOSException($"SETPTR: stack index {absIndex} out of range.");
+                
+                int depth = cpu.GetArgumentStackSize() - 1 - absIndex;
+
+                if (ptr.Segments.Count == 1)
+                {
+                    cpu.PokeArgumentStack(depth, value, out bool ok);
+                    if (!ok)
+                        throw new KOSException("SETPTR: stack indexing failed");
+                    return;
+                }
+
+                current = Structure.FromPrimitiveWithAssert(cpu.PeekRawArgument(depth, out bool ok));
+                if (!ok)
+                    throw new KOSException("SETPTR: stack indexing failed");
+            }
+            else if (firstSeg is StringValue varName && varName.StartsWith("$"))
+            {
+                if (ptr.Segments.Count == 1)
+                {
+                    cpu.SetValueExists(varName.ToString(), value);
+                    return;
+                }
+                current = Structure.FromPrimitiveWithAssert(cpu.GetValue(varName.ToString()));
+            }
+            else
+            {
+                throw new KOSException("SETPTR: first segment must be a stack index or variable name.");
+            }
+
+            // Traverse remaining segments
+            for (int i = 1; i < ptr.Segments.Count - 1; i++)
+            {
+                Structure seg = ptr.Segments[i];
+
+                if (!(current is IIndexable indexable))
+                    throw new KOSException($"SETPTR: segment {i} encountered non-indexable value.");
+                
+                current = indexable.GetIndex(seg);
+            }
+
+            // set last segment
+            Structure lastSeg = ptr.Segments[^1];
+            if (!(current is IIndexable lastIndexable))
+                throw new KOSException("SETPTR: final target is not indexable.");
+
+            lastIndexable.SetIndex(lastSeg, value);
+        }
+    }
+
     #endregion
 
     #region Wait / Trigger

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -728,7 +728,7 @@ namespace kOS.Safe.Compilation
             Structure value = PopStructureAssertEncapsulated(cpu);
             if (ident != null)
             {
-                cpu.SetValue(ident, value);
+                cpu.SetNewLocal(ident, value);
             }
         }
     }

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -702,15 +702,14 @@ namespace kOS.Safe.Compilation
 
     /// <summary>
     /// <para>
-    /// Consumes the identifier atop the stack and
-    /// stores the value beneath the identifier into that
-    /// variable name <br/>
+    /// Consumes a value and identifier and stores the value
+    /// into that a local variable under that identifier<br/>
     /// Note that the ident atop the stack must be formatted like a variable
     /// name (i.e. have the leading '$').
     /// </para>
     /// <para></para>
     /// <para>storename</para>
-    /// <para>... value ident -- ...</para>
+    /// <para>... ident value -- ...</para>
     /// <para></para>
     /// </summary>
     public class OpcodeStoreName : Opcode
@@ -724,8 +723,8 @@ namespace kOS.Safe.Compilation
 
         public override void Execute(ICpu cpu)
         {
-            string ident = Convert.ToString(cpu.PopArgumentStack());
             Structure value = PopStructureAssertEncapsulated(cpu);
+            string ident = Convert.ToString(cpu.PopArgumentStack());
             if (ident != null)
             {
                 cpu.SetNewLocal(ident, value);
@@ -2394,12 +2393,12 @@ namespace kOS.Safe.Compilation
 
     /// <summary>
     /// <para>
-    /// Pops an index/pointer and a value from the stack and pokes the value into that stack slot.
+    /// Pops a value and an index/pointer from the stack and pokes the value into that stack slot.
     /// Default indexing is top-to-bottom, can be set to bottom-to-tob using the FromBottom MLField.
     /// </para>
     /// <para></para>
     /// <para>poke fromBottom</para>
-    /// <para>... val ptr -- ... val ...</para>
+    /// <para>... ptr val -- ... val ...</para>
     /// </summary>
     public class OpcodePoke : Opcode
     {
@@ -2427,8 +2426,8 @@ namespace kOS.Safe.Compilation
 
         public override void Execute(ICpu cpu)
         {
-            int idx = Convert.ToInt32(cpu.PopValueArgument());
             object value = cpu.PopArgumentStack();
+            int idx = Convert.ToInt32(cpu.PopValueArgument());
 
             int depth = FromBottom
                 ? cpu.GetArgumentStackSize() - 1 - idx

--- a/src/kOS.Safe/Encapsulation/PointerValue.cs
+++ b/src/kOS.Safe/Encapsulation/PointerValue.cs
@@ -1,0 +1,23 @@
+
+namespace kOS.Safe.Encapsulation
+{
+    /// <summary>
+    /// A Pointer class that stores a "path" to a value using keys and indecies.<br/>
+    /// Used by the Pointer instructions "CREATEPTR", "GETPTR", "SETPTR". <br/>
+    /// </summary>
+    [kOS.Safe.Utilities.KOSNomenclature("Pointer")]
+    public class PointerValue : Structure
+    {
+        public readonly List<Structure> Segments;
+
+        public PointerValue(IEnumerable<Structure> segments)
+        {
+            Segments = new List<Structure>(segments);
+        }
+
+        public override string ToString()
+        {
+            return "<Pointer>";
+        }
+    }
+}

--- a/src/kOS.Safe/Execution/CPU.cs
+++ b/src/kOS.Safe/Execution/CPU.cs
@@ -914,8 +914,7 @@ namespace kOS.Safe.Execution
 
         /// <summary>
         /// Try to make a new local variable at the localmost scoping level and
-        /// give it a starting value.  It errors out of there is already one there
-        /// by the same name.<br/>
+        /// give it a starting value.<br/>
         /// <br/>
         /// This does NOT scan up the scoping stack like SetValue() does.
         /// It operates at the local level only.<br/>

--- a/src/kOS.Safe/Execution/CPU.cs
+++ b/src/kOS.Safe/Execution/CPU.cs
@@ -1143,6 +1143,17 @@ namespace kOS.Safe.Execution
         }
 
         /// <summary>
+        /// Poke a value into the argument stack without evaluating it to get the variable's value.
+        /// </summary>
+        /// <param name="digDepth">Poke the element this far down the stack (0 means top, 1 means just under the top, etc)</param>
+        /// <param name="item">The object to write to that depth</param>
+        /// <param name="checkOkay">Tells you whether or not the stack was exhausted.  If it's false, then the poke went too deep.</param>
+        public void PokeArgumentStack(int digDepth, object item, out bool checkOkay)
+        {
+            checkOkay = stack.PokeCheckArgument(digDepth, item);
+        }
+
+        /// <summary>
         /// Peek at a value atop the scope stack without popping it.
         /// </summary>
         /// <param name="digDepth">Peek at the element this far down the stack (0 means top, 1 means just under the top, etc)</param>

--- a/src/kOS.Safe/Execution/ICpu.cs
+++ b/src/kOS.Safe/Execution/ICpu.cs
@@ -19,6 +19,7 @@ namespace kOS.Safe.Execution
         object PopValueArgument(bool barewordOkay = false);
         object PeekValueArgument(int digDepth, bool barewordOkay = false);
         object PeekRawArgument(int digDepth, out bool checkOkay);
+        void PokeArgumentStack(int digDepth, object item, out bool checkOkay);
         object PeekRawScope(int digDepth, out bool checkOkay);
         object PopValueEncapsulatedArgument(bool barewordOkay = false);
         object PeekValueEncapsulatedArgument(int digDepth, bool barewordOkay = false);

--- a/src/kOS.Safe/Execution/IStack.cs
+++ b/src/kOS.Safe/Execution/IStack.cs
@@ -9,6 +9,7 @@ namespace kOS.Safe.Execution
         object PopArgument();
         object PeekArgument(int digDepth);
         bool PeekCheckArgument(int digDepth, out object item);
+        bool PokeCheckArgument(int digDepth, object item);
         object PeekScope(int digDepth);
         bool PeekCheckScope(int digDepth, out object item);
         void PushScope(object item);

--- a/src/kOS.Safe/Execution/Stack.cs
+++ b/src/kOS.Safe/Execution/Stack.cs
@@ -233,6 +233,42 @@ namespace kOS.Safe.Execution
         }
 
         /// <summary>
+        /// Pokes a value into the argument stack.
+        /// Slightly "cheats" and breaks out of the 'stack' model by allowing you to replace the contents of
+        /// somewhere on the stack that is underneath the topmost thing.  You can only replace, but not pop
+        /// values this way.  It a boolean for whether or not your poke attempt went out of bounds of the stack.
+        /// </summary>
+        /// <param name="digDepth">How far underneath the top to look.  Zero means poke at the top,
+        /// 1 means replace the item just under the top, 2 means replace the item just under that, and
+        /// so on.</param>
+        /// <param name="item">The object to write to that depth</param>
+        /// <returns>Returns true if your poke was within the bounds of the stack, or false if you tried
+        /// to poke too far and went past the top or bottom of the stack.</returns>
+        public bool PokeCheckArgument(int digDepth, object item)
+        {
+            ThrowIfInvalid(item);
+
+            if (digDepth < 0)
+            {
+                return false;
+            }
+
+            int index = argumentCount - digDepth - 1; // 0 means top
+            if (index < 0)
+            {
+                return false;
+            }
+
+            object prev = argumentStack[index];
+            AdjustTriggerCountIfNeeded(prev, -1);
+
+            argumentStack[index] = ProcessItem(item);
+            AdjustTriggerCountIfNeeded(item, +1);
+
+            return true;
+        }
+
+        /// <summary>
         /// Peeks at a value in the scope stack.
         /// Slightly "cheats" and breaks out of the 'stack' model by allowing you to view the contents of
         /// somewhere on the stack that is underneath the topmost thing.  You can only peek, but not pop


### PR DESCRIPTION
Closes: #3154 
This pull request adds seven new opcodes to the kOS virtual machine.
They introduce pointer-like and indirect access functionality for low-level Kerboscript bytecode writers and compiler backends.
All new instructions are fully backward-compatible and have no effect on existing programs unless explicitly used.
### New opcodes
| Opcode         | Stack input     | Stack output | Description |
|:---------------|:----------------|:------------:|:------------|
| `PEEK <abs>` | `ptr` | `value` | Pushes the value from the stack index referenced by `ptr` |
| `POKE <abs>` | `value`<br>`ptr` | | Write `value` to the stack index referenced by `ptr` |
| `STORENAME` | `value`<br>`name*` | | Stores `value` into a local variable dynamically by name. Complements exisitng 'EVAL' instruction |
| `ALLOCATE <N>` | | `0`<br>`...`<br>`0` | Pushes `N` nulls onto the stack, effectively reserving stack space. |
| `DEALLOCATE<N>` | `0`<br>`...`<br>`0` | | Pops `N` entries from the stack, effectively undoing the reservation of `ALLOCATE <N>` |
| `STACKPTR` | | `sp` | Pushes the current stack pointer (stack length). |
| `INSTPTR` | | `ip` | Pushes the current instruction pointer. Useful for introspection or indirect calls. |

*like with all other variables, this name should be a string prefixed with `$`

The `<abs>` machine-language field is a boolean flag that toggles between top-relative indexing and absolute bottom-up indexing (`false` = relative, `true` = absolute). The origin for relative indexing is the top of the stack after popping all arguments.

These instructions are designed to be simple extensions that do **not** alter existing behavior or affect normal Kerboscript execution.

### Compatibility
- No changes to existing opcodes.
- No behavioral impact on existing scripts.
- Only affects programs explicitly using the new instructions.