### PR TITLE
Add `assertrange <min> <max>` instruction

### DIFF
--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -88,6 +88,7 @@ namespace kOS.Safe.Compilation
         TESTARGBOTTOM  = 0x61,
         TESTCANCELLED  = 0x62,
         JUMPSTACK      = 0x63,
+        ASSERTRANGE    = 0x64,
 
         // Augmented bogus placeholder versions of the normal
         // opcodes: These only exist in the program temporarily
@@ -944,6 +945,58 @@ namespace kOS.Safe.Compilation
                 throw new KOSException(string.Format("Can't set indexed elements on an object of type {0}", list.GetType()));
             }
             indexable.SetIndex(index, value);
+        }
+    }
+
+    /// <summary>
+    /// <para>
+    /// Asserts that the top value of the stack is a value ranging between MinValue and MaxValue
+    /// </para>
+    /// <para></para>
+    /// <para>assertrange min max</para>
+    /// <para>... val -- ... val</para>
+    /// </summary>
+    public class OpcodeAssertRange : Opcode
+    {
+        protected override string Name { get { return "assertrange"; } }
+        public override ByteCode Code { get { return ByteCode.ASSERTRANGE; } }
+
+        [MLField(0, false)]
+        public double MinValue { get; set; }
+        [MLField(1, false)]
+        public double MaxValue { get; set; }
+
+        protected OpcodeAssertRange()
+        {
+        }
+
+        public OpcodeAssertRange(int min, int max)
+        {
+            MinValue = min;
+            MaxValue = max;
+        }
+
+        public override void PopulateFromMLFields(List<object> fields)
+        {
+            if (fields == null || fields.Count < 2)
+                throw new Exception(String.Format("Saved field in ML file for OpcodeAssertRange seems to be missing.  Version mismatch?"));
+            MinValue = Convert.ToDouble(fields[0]);
+            MaxValue = Convert.ToDouble(fields[1]);
+        }
+
+        public override void Execute(ICpu cpu)
+        {
+            object value = cpu.PeekRawArgument(0, out bool ok);
+            if (!ok)
+                throw new KOSException("Failed to assert range: failed to load stack argument");
+
+            if (value is not ScalarValue scalar)
+                throw new KOSException("Failed to assert range: cannot assert range for non scalar");
+            
+            double actual = scalar.GetDoubleValue();
+
+            if (actual < MinValue || actual > MaxValue)
+                throw new KOSException("Value ({0}) out of range ({1}..{2})", actual, MinValue, MaxValue);
         }
     }
 

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -970,7 +970,7 @@ namespace kOS.Safe.Compilation
         {
         }
 
-        public OpcodeAssertRange(int min, int max)
+        public OpcodeAssertRange(double min, double max)
         {
             MinValue = min;
             MaxValue = max;

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -962,9 +962,9 @@ namespace kOS.Safe.Compilation
         public override ByteCode Code { get { return ByteCode.ASSERTRANGE; } }
 
         [MLField(0, false)]
-        public double MinValue { get; set; }
+        public double? MinValue { get; set; }
         [MLField(1, false)]
-        public double MaxValue { get; set; }
+        public double? MaxValue { get; set; }
 
         protected OpcodeAssertRange()
         {
@@ -980,8 +980,8 @@ namespace kOS.Safe.Compilation
         {
             if (fields == null || fields.Count < 2)
                 throw new Exception(String.Format("Saved field in ML file for OpcodeAssertRange seems to be missing.  Version mismatch?"));
-            MinValue = Convert.ToDouble(fields[0]);
-            MaxValue = Convert.ToDouble(fields[1]);
+            MinValue = !(fields[0] is PseudoNull) ? Convert.ToDouble(fields[0]) : (double?)null;
+            MaxValue = !(fields[1] is PseudoNull) ? Convert.ToDouble(fields[1]) : (double?)null;
         }
 
         public override void Execute(ICpu cpu)
@@ -995,8 +995,14 @@ namespace kOS.Safe.Compilation
             
             double actual = scalar.GetDoubleValue();
 
-            if (actual < MinValue || actual > MaxValue)
-                throw new KOSException("Value ({0}) out of range ({1}..{2})", actual, MinValue, MaxValue);
+            if ((MinValue.HasValue && actual < MinValue.Value) ||
+                (MaxValue.HasValue && actual > MaxValue.Value))
+            {
+                throw new KOSException(
+                    $"assertrange failed: value {value} not in range " +
+                    $"[{MinValue?.ToString() ?? "-infinity"}, {MaxValue?.ToString() ?? "infinity"}]"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Closes #3158
This PR implements the `assertrange <min> <max>` opcode as proposed in the linked issue.
It validates that the value on top of the stack is within the specified range without consuming it.
It throws an exception if it is called with an empty stack, the value isn't a Scalar, or the value lies outside of the specified range (inclusive on both sides).

The `min` and `max` fields can be any two doubles.
A coercion using `Convert.ToDouble(..)` is made to allow for integer inputs.
if `PseudoNull` is used as an argument, the range will be open.
It does not validate that `min` is smaller than `max`.

The kerboscript compiler hasn't been altered and this feature is only accessible through manual / external compilation.
This addition is backward compatible and changes no underlying behavior.

~**This PR does not yet implement the optional open range behavior.**~
| `min` | `max` | allowed |
|-------|-------|---------|
|   0   |   10  | 0.0, ..., 10.0 |
|  -1   |    0  | -1.0, ..., 0.0 |
|  5.5  |  6.0  | 5.5, ..., 6.0 |
| `PseudoNull` | 0 | -∞, ..., 0.0 |
| 0 | `PseudoNull` | 0.0, ..., ∞ |
| `PseudoNull` | `PseudoNull` | -∞, ..., ∞ |