### PR TITLE
Make ACTUATION suffix available in release

### DIFF
--- a/src/kOS/Control/SteeringManager.cs
+++ b/src/kOS/Control/SteeringManager.cs
@@ -368,9 +368,9 @@ namespace kOS.Control
             AddSuffix("ROLLTORQUEFACTOR", new SetSuffix<ScalarValue>(() => RollTorqueFactor, value => RollTorqueFactor = value));
             AddSuffix("AVERAGEDURATION", new Suffix<ScalarValue>(() => AverageDuration.Mean));
             AddSuffix("ROLLCONTROLANGLERANGE", new SetSuffix<ScalarValue>(() => RollControlAngleRange, value => RollControlAngleRange = value));
+            AddSuffix("ACTUATION", new Suffix<Vector>(() => new Vector(accPitch, accRoll, accYaw)));
 #if DEBUG
             AddSuffix("MOI", new Suffix<Vector>(() => new Vector(momentOfInertia)));
-            AddSuffix("ACTUATION", new Suffix<Vector>(() => new Vector(accPitch, accRoll, accYaw)));
             AddSuffix("CONTROLTORQUE", new Suffix<Vector>(() => new Vector(controlTorque)));
             AddSuffix("MEASUREDTORQUE", new Suffix<Vector>(() => new Vector(measuredTorque)));
             AddSuffix("RAWTORQUE", new Suffix<Vector>(GetRawTorque));


### PR DESCRIPTION
Addresses https://github.com/KSP-KOS/KOS/issues/2823

In addition to the linked issue, multiple commenters on Reddit over the years, and my own current project, would like access to the output of the SteeringManager. This is already available under the ACTUATION suffix of SteeringManager, but only in DEBUG builds. This makes it available in release builds as well.

See: https://www.reddit.com/r/Kos/comments/lx5nb6/get_steering_output_values/ and https://www.reddit.com/r/Kos/comments/a4qer7/getting_yawpitchroll_control_deflections_when/