### PR TITLE
Remove redundant OpCode in UNTIL loop

### DIFF
--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -2386,8 +2386,7 @@ namespace kOS.Safe.Compilation.KS
             string conditionLabel = GetNextLabel(false);
             PushBreakList(braceNestLevel);
             VisitNode(node.Nodes[1]);
-            AddOpcode(new OpcodeLogicNot());
-            Opcode branch = AddOpcode(new OpcodeBranchIfFalse());
+            Opcode branch = AddOpcode(new OpcodeBranchIfTrue());
             AddToBreakList(branch);
             VisitNode(node.Nodes[2]);
             Opcode jump = AddOpcode(new OpcodeBranchJump());

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -1058,9 +1058,15 @@ namespace kOS.Safe.Compilation
 
         public override void Execute(ICpu cpu)
         {
-            bool condition = Convert.ToBoolean(cpu.PopValueArgument());
-
-            DeltaInstructionPointer = !condition ? Distance : 1;
+            try
+            {
+                bool condition = Convert.ToBoolean(cpu.PopValueArgument());
+                DeltaInstructionPointer = !condition ? Distance : 1;
+            }
+            catch
+            {
+                throw new KOSCastException(value.GetType(), typeof(BooleanValue)); 
+            }
         }
     }
 
@@ -1079,8 +1085,15 @@ namespace kOS.Safe.Compilation
 
         public override void Execute(ICpu cpu)
         {
-            bool condition = Convert.ToBoolean(cpu.PopValueArgument());
-            DeltaInstructionPointer = condition ? Distance : 1;
+            try
+            {
+                bool condition = Convert.ToBoolean(cpu.PopValueArgument());
+                DeltaInstructionPointer = condition ? Distance : 1;
+            }
+            catch
+            {
+                throw new KOSCastException(value.GetType(), typeof(BooleanValue)); 
+            }
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/KSP-KOS/KOS/issues/3094

Added try-catch block to OpcodeBranchIfTrue and OpcodeBranchIfFalse to capture the protection that was presumably the root cause of the not -> branchIfFalse logic. Then removed the redundant Not opcode in favor of the equivalent logic using OpcodeBranchIfTrue.