### PR TITLE
Fix telnet server failing to connect on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bug Fixes
 
+- Fixed telnet server failing to accept connections on Windows when loopback interface is intercepted by third-party software (e.g. Npcap/Wireshark) (#3171)
 - Fixed numeric formatting patters (thanks @sisve) [commit](https://github.com/KSP-KOS/KOS/commit/5780b75ff90e238c441ab71d366391b051e8bd14)
 - Fixed many documentation issues (thanks @sisve) [commit1](https://github.com/KSP-KOS/KOS/commit/727d345679fe992077fa5604c27b43c34a80fbe7) [commit2](https://github.com/KSP-KOS/KOS/commit/afabb19e860adc67ad63f939a3d624e9344ad7b8) [commit3](https://github.com/KSP-KOS/KOS/commit/110b209ad89225bf447caa079334c434df0e9746)
 - Fixed `GetSignalDelayToSatellite` for RemoteTech (thanks @KerbalOne) [commit](https://github.com/KSP-KOS/KOS/commit/b76759f24ba43e7cb2d82437c2251caf7d3a582f)

--- a/src/kOS/UserIO/TelnetMainServer.cs
+++ b/src/kOS/UserIO/TelnetMainServer.cs
@@ -245,9 +245,16 @@ namespace kOS.UserIO
             // refresh the port information, don't need to refresh address because it's refreshed every Update
             port = SafeHouse.Config.TelnetPort; 
 
-            server = new TcpListener(bindAddr, port);
+            // Bind to IPAddress.Any instead of the specific bindAddr when using loopback.
+            // On Windows, Npcap (installed by Wireshark/Nmap) installs a "Npcap Loopback Adapter"
+            // that intercepts traffic bound specifically to the loopback interface (127.0.0.1),
+            // causing TCP connections to time out with no SYN-ACK. Binding to IPAddress.Any
+            // routes through the normal network stack and avoids this issue.
+            // Non-loopback addresses are used as-is since users explicitly chose them.
+            var listenAddr = IPAddress.IsLoopback(bindAddr) ? IPAddress.Any : bindAddr;
+            server = new TcpListener(listenAddr, port);
             server.Start();
-            SafeHouse.Logger.Log(string.Format("{2} TelnetMainServer started listening on {0} {1}", bindAddr, port, KSPLogger.LOGGER_PREFIX));
+            SafeHouse.Logger.Log(string.Format("{2} TelnetMainServer started listening on {0} (requested {1}) port {3}", listenAddr, bindAddr, KSPLogger.LOGGER_PREFIX, port));
             isListening = true;
         }
 
@@ -333,10 +340,24 @@ namespace kOS.UserIO
                 return;
 
             TcpClient incomingClient = server.AcceptTcpClient();
-            
+
             string remoteIdent = ((IPEndPoint)(incomingClient.Client.RemoteEndPoint)).Address.ToString();
             SafeHouse.Logger.Log(string.Format("{0} telnet server got an incoming connection from {1}", KSPLogger.LOGGER_PREFIX, remoteIdent));
-            
+
+            // When the user configured loopback mode, reject connections from non-loopback addresses.
+            // We bind to IPAddress.Any to work around Npcap intercepting the loopback interface,
+            // but we still enforce the user's intent to only allow local connections.
+            if (IPAddress.IsLoopback(bindAddr))
+            {
+                var remoteAddr = ((IPEndPoint)(incomingClient.Client.RemoteEndPoint)).Address;
+                if (!IPAddress.IsLoopback(remoteAddr))
+                {
+                    SafeHouse.Logger.Log(string.Format("{0} Rejected non-loopback connection from {1} (server is in loopback mode)", KSPLogger.LOGGER_PREFIX, remoteIdent));
+                    incomingClient.Close();
+                    return;
+                }
+            }
+
             TelnetSingletonServer newServer = new TelnetSingletonServer(this, incomingClient, ++howManySpawned);
             telnets.Add(newServer);
             newServer.StartListening();


### PR DESCRIPTION
Fixes #3171

## The Problem

On some Windows systems, the kOS telnet server listens successfully but clients can never connect — the connection hangs at "Trying 127.0.0.1..." indefinitely. No error, no rejection, just silence.

The root cause: when `TcpListener` binds specifically to `IPAddress.Loopback` (127.0.0.1), certain software that hooks the Windows loopback network interface can intercept the traffic before it reaches the application. The most common culprit is **Npcap** (bundled with Wireshark and Nmap), which installs its own "Npcap Loopback Adapter" — but firewalls and other network drivers can cause the same issue.

This has likely been the cause behind reports like #2937, where users saw the server listening but could never connect.

## The Fix

Two changes to `TelnetMainServer.cs`:

1. **Bind to `IPAddress.Any` instead of `IPAddress.Loopback`** when the user has configured loopback mode. This routes connections through the general network stack instead of the dedicated loopback interface, bypassing whatever is intercepting it.

2. **Reject non-loopback connections** when in loopback mode. Since binding to `0.0.0.0` also listens on LAN interfaces, we explicitly check the remote address and reject anything that isn't loopback. This preserves the user's security intent.

The fix is transparent on unaffected systems — `IPAddress.Any` accepts loopback connections identically to `IPAddress.Loopback`.

## Testing

- Tested on Windows 11 with Npcap installed (via Wireshark)
- Confirmed telnet fails with the old code, works with the fix
- Confirmed non-loopback connections are rejected in loopback mode
- Confirmed no change in behavior for non-loopback configurations

## Checklist

- [x] Related issue: #3171
- [x] CHANGELOG.md updated
- [x] No API changes (no documentation needed)
- [x] No changes to .sln or .csproj
- [x] No files added to Resources