### PR TITLE
Fix RemoteTech API call for connection to unloaded vessels

### DIFF
--- a/src/kOS/AddOns/RemoteTech/RemoteTechConnectivityManager.cs
+++ b/src/kOS/AddOns/RemoteTech/RemoteTechConnectivityManager.cs
@@ -42,6 +42,11 @@ namespace kOS.AddOns.RemoteTech
             if (!(RemoteTechHook.IsAvailable()))
                 return -1; // default to no connection if RT itself isn't available.
             double delay = RemoteTechHook.Instance.GetSignalDelayToSatellite(vessel1.id, vessel2.id);
+            if (Double.IsPositiveInfinity(delay) || delay < 0)
+            {
+                delay = Math.Max(RemoteTechHook.Instance.GetShortestSignalDelay(vessel1.id),
+                                RemoteTechHook.Instance.GetShortestSignalDelay(vessel2.id));
+            }
             return Double.IsPositiveInfinity(delay) ? -1 : delay;
         }
 


### PR DESCRIPTION
Bugfix for unloaded vessels not establishing a kOS connection when RT signal delay is enabled.

* Delay GetSignalDelayToSatellite broken, should return higher of GetShortestSignalDelay for each vessel

