### PR TITLE
Fix NRE in GetHashCode for unloaded vessels

### DIFF
--- a/src/kOS/Suffixed/VesselTarget.cs
+++ b/src/kOS/Suffixed/VesselTarget.cs
@@ -550,7 +550,7 @@ namespace kOS.Suffixed
 
         public override int GetHashCode()
         {
-            return Vessel.rootPart.flightID.GetHashCode();
+            return Vessel.id.GetHashCode();
         }
 
         public static bool operator ==(VesselTarget left, VesselTarget right)


### PR DESCRIPTION
Can be triggered by using an unloaded vessel as a key in lexicons and uniquesets